### PR TITLE
Extracted the abstract class Resolver from WebPathResolver

### DIFF
--- a/Imagine/Cache/Resolver/Resolver.php
+++ b/Imagine/Cache/Resolver/Resolver.php
@@ -2,23 +2,15 @@
 
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
-use Liip\ImagineBundle\Imagine\Cache\CacheManagerAwareInterface,
-    Liip\ImagineBundle\Imagine\Cache\CacheManager;
-
 use Symfony\Component\HttpFoundation\Response,
     Symfony\Component\HttpKernel\Util\Filesystem;
 
-abstract class Resolver implements ResolverInterface, CacheManagerAwareInterface
+abstract class AbstractFilesystemResolver implements ResolverInterface
 {
     /**
      * @var Filesystem
      */
     protected $filesystem;
-
-    /**
-     * @var CacheManager;
-     */
-    protected $cacheManager;
 
     /**
      * Constructs cache web path resolver
@@ -28,14 +20,6 @@ abstract class Resolver implements ResolverInterface, CacheManagerAwareInterface
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem   = $filesystem;
-    }
-
-    /**
-     * @param CacheManager $cacheManager
-     */
-    public function setCacheManager(CacheManager $cacheManager)
-    {
-        $this->cacheManager = $cacheManager;
     }
 
     /**

--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -6,8 +6,24 @@ use Symfony\Component\HttpFoundation\Request,
     Symfony\Component\HttpFoundation\RedirectResponse,
     Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class WebPathResolver extends Resolver
+use Liip\ImagineBundle\Imagine\Cache\CacheManagerAwareInterface,
+    Liip\ImagineBundle\Imagine\Cache\CacheManager;
+
+class WebPathResolver extends AbstractFilesystemResolver implements CacheManagerAwareInterface
 {
+    /**
+     * @var CacheManager;
+     */
+    protected $cacheManager;
+
+    /**
+     * @param CacheManager $cacheManager
+     */
+    public function setCacheManager(CacheManager $cacheManager)
+    {
+        $this->cacheManager = $cacheManager;
+    }
+
     /**
      * Resolves filtered path for rendering in the browser
      *


### PR DESCRIPTION
Storing files in the cache is a feature that will be used by most of the custom cache resolvers.

I extracted the store method as well as the CacheManager injection to an abstract Resolver class so that custom cache resolvers can share the code without extending WebPathResolver.
