### PR TITLE
Fixing typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ liip_imagine:
 ```
 
 
-For an example of a data loader implementation, refer to
+For an example of a cache resolver implementation, refer to
 `Liip\ImagineBundle\Imagine\Cache\Resolver\WebPathResolver`.
 
 ## Dynamic filters


### PR DESCRIPTION
Trying to install LiipImagineBundle I noticed that for creating a custom image loader, you have to get liip_imagine service and not "imagine".
