### PR TITLE
Fix for last version of symfony

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,7 +41,6 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->fixXmlConfig('filter', 'filters')
-                        ->useAttributeAsKey('name')
                         ->children()
                             ->scalarNode('path')->end()
                             ->scalarNode('quality')->defaultValue(100)->end()


### PR DESCRIPTION
when i update symfony this bundle doesn't work anymore.

[Symfony\Component\Config\Definition\Exception\InvalidDefinitionException]

Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition::useAttributeAsKey() is not applicable to concrete nodes.
