### PR TITLE
Adds a new loader for pdf preview

### DIFF
--- a/Imagine/Data/Loader/FileSystemLoader.php
+++ b/Imagine/Data/Loader/FileSystemLoader.php
@@ -38,6 +38,19 @@ class FileSystemLoader implements LoaderInterface
     }
 
     /**
+     * Get the file info for the given path
+     *
+     * This can optionally be used to generate the given file
+     *
+     * @param $absolutePath
+     * @return array
+     */
+    protected function getFileInfo($absolutePath)
+    {
+        return pathinfo($absolutePath);
+    }
+
+    /**
      * @param string $path
      *
      * @return Imagine\Image\ImageInterface
@@ -48,9 +61,8 @@ class FileSystemLoader implements LoaderInterface
             throw new NotFoundHttpException(sprintf("Source image was searched with '%s' out side of the defined root path", $path));
         }
 
-        $absolutePath = $this->rootPath.'/'.ltrim($path, '/');
-
-        $info = pathinfo($absolutePath);
+        $info = $this->getFileInfo($this->rootPath.'/'.ltrim($path, '/'));
+        $absolutePath = $info['dirname'].'/'.$info['basename'];
 
         $name = $info['dirname'].'/'.$info['filename'];
         $targetFormat = empty($this->formats) || in_array($info['extension'], $this->formats)

--- a/Imagine/Data/Loader/PdfPreviewLoader.php
+++ b/Imagine/Data/Loader/PdfPreviewLoader.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Liip\ImagineBundle\Imagine\Data\Loader;
+
+class PdfPreviewLoader extends FileSystemLoader
+{
+  
+    /**
+     * Overrides FileSystemLoader's getFileInfo and creates,
+     * if it doesn't exists, an image of the first page of
+     * the pdf document
+     *
+     * @param $absolutePath
+     * @return array
+     */
+    protected function getFileInfo($absolutePath)
+    {
+        $info = pathinfo($absolutePath);
+        if (isset($info['extension']) && strpos(strtolower($info['extension']), 'pdf') !== false ) {
+            //If it doesn't exists, extract first page of the PDF to png
+            if (!file_exists("$absolutePath.png")) {
+                $img = new \Imagick ( $absolutePath.'[0]' );
+                $img->setImageFormat( "png" );
+                $img->writeImages($absolutePath.'.png', true);
+            }
+            //finally update $absolutePath
+            $absolutePath .= '.png';
+        }
+        return pathinfo($absolutePath);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -370,6 +370,27 @@ liip_imagine:
 For an example of a data loader implementation, refer to
 `Liip\ImagineBundle\Imagine\Data\Loader\FileSystemLoader`.
 
+Thanks to the `getFileInfo` method, `Liip\ImagineBundle\Imagine\Data\Loader\FileSystemLoader`
+can be extended to manage different files type. You can see an example in
+`Liip\ImagineBundle\Imagine\Data\Loader\PdfPreviewLoader`. If you use the ``PdfPreviewLoader``
+loader, when the required file has a `pdf` extension, `getFileInfo` extracts and returns
+an image, in `png` format, of the first page of the document.
+``PdfPreviewLoader`` requires the php native extension Imagick.
+In order to work, you'll have to "force" the outputted image format:
+
+``` yaml
+liip_imagine:
+    filter_sets:
+        my_pdf_preview:
+            data_loader: pdfpreview
+            format: png
+            filters:
+                my_custom_filter: { }
+```
+
+Extending `Liip\ImagineBundle\Imagine\Data\Loader\FileSystemLoader` makes it possible
+to create previews for virtually any file type.
+
 ## Custom cache resolver
 
 The ImagineBundle allows you to add your custom cache resolver classes. The only

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -40,7 +40,8 @@
         <!-- Data loaders' classes -->
 
         <parameter key="liip_imagine.data.loader.filesystem.class">Liip\ImagineBundle\Imagine\Data\Loader\FileSystemLoader</parameter>
-
+        <parameter key="liip_imagine.data.loader.pdfpreview.class">Liip\ImagineBundle\Imagine\Data\Loader\PdfPreviewLoader</parameter>
+        
         <!-- Cache resolvers' classes -->
 
         <parameter key="liip_imagine.cache.resolver.web_path.class">Liip\ImagineBundle\Imagine\Cache\Resolver\WebPathResolver</parameter>
@@ -128,6 +129,13 @@
 
         <service id="liip_imagine.data.loader.filesystem" class="%liip_imagine.data.loader.filesystem.class%">
             <tag name="liip_imagine.data.loader" loader="filesystem" />
+            <argument type="service" id="liip_imagine" />
+            <argument>%liip_imagine.formats%</argument>
+            <argument>%liip_imagine.data_root%</argument>
+        </service>
+        
+        <service id="liip_imagine.data.loader.pdfpreview" class="%liip_imagine.data.loader.pdfpreview.class%">
+            <tag name="liip_imagine.data.loader" loader="pdfpreview" />
             <argument type="service" id="liip_imagine" />
             <argument>%liip_imagine.formats%</argument>
             <argument>%liip_imagine.data_root%</argument>


### PR DESCRIPTION
PdfPreviewLoader is an example of how, with a loader, it is
possible to preview virtually any file system type.
Extending `FileSystemLoader`, thanks to Lukas's code, PdfPreviewLoader
generate a png image of the first page of the pdf document and
updates the infos of the file to be rendered.

I think that it would be better to pass from config the number of the page to be extracted and the image format to use but... I'm not sure how this could be done...
