### PR TITLE
'cache_resolver' property name change

### DIFF
--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -90,8 +90,8 @@ class CacheManager
     {
         $config = $this->filterConfig->get($filter);
 
-        $resolverName = empty($config['cache_resolver'])
-            ? $this->defaultResolver : $config['cache_resolver'];
+        $resolverName = empty($config['cache'])
+            ? $this->defaultResolver : $config['cache'];
 
         if (!isset($this->resolvers[$resolverName])) {
             throw new \InvalidArgumentException(sprintf(


### PR DESCRIPTION
TYPO in property name. 'cache_resolver' property does not exist in configuration. 'cache' property should be used instead.
