### PR TITLE
Issue #56 - Added a DbLoader data loader

### DIFF
--- a/Entity/LiipImage.php
+++ b/Entity/LiipImage.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Liip\ImagineBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Liip\ImagineBundle\Entity\LiipImage
+ */
+class LiipImage
+{
+    /**
+     * @var integer $id
+     */
+    private $id;
+    
+    /**
+     * @var text $data
+     */
+    private $data;
+        
+    /**
+     * @var string $uniqueIdentifier
+     */
+    private $uniqueIdentifier;
+    
+    /**
+     * @var string $fileName
+     */
+    private $fileName;
+        
+    /**
+     * @var string $mimetype
+     */
+    private $mimetype;
+    
+	/**
+     * Get id
+     *
+     * @return integer 
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set data
+     *
+     * @param text $data
+     * @return Image
+     */
+    public function setData($data)
+    {
+        $this->data = base64_encode($data);
+        return $this;
+    }
+
+    /**
+     * Get data
+     *
+     * @return text 
+     */
+    public function getData()
+    {
+        return base64_decode($this->data);
+    }
+
+    /**
+     * Set fileName
+     *
+     * @param string $fileName
+     * @return Image
+     */
+    public function setFileName($fileName)
+    {
+        $this->fileName = $fileName;
+        return $this;
+    }
+
+    /**
+     * Get fileName
+     *
+     * @return string 
+     */
+    public function getFileName()
+    {
+        return $this->fileName;
+    }
+
+    /**
+     * Set uniqueIdentifier
+     *
+     * @param string $uniqueIdentifier
+     * @return Image
+     */
+    public function setUniqueIdentifier($uniqueIdentifier)
+    {
+        $this->uniqueIdentifier = $uniqueIdentifier;
+        return $this;
+    }
+    
+    /**
+     * Get uniqueIdentifier
+     *
+     * @return string 
+     */
+    public function getUniqueIdentifier()
+    {
+        return $this->uniqueIdentifier;
+    }
+
+    
+    /**
+     * Set mimetype
+     *
+     * @param string $mimetype
+     * @return Image
+     */
+    public function setMimetype($mimetype)
+    {
+    	$this->mimetype = $mimetype;
+    	return $this;
+    }
+    
+    /**
+     * Get mimetype
+     *
+     * @return string
+     */
+    public function getMimetype()
+    {
+    	return $this->mimetype;
+    }
+    
+    /**
+     * Update the unique identifier
+     */
+    public function updateUniqueIdentifier()
+    {
+    	$this->setUniqueIdentifier(md5(time() . $this->fileName) . '.' . $this->_calculateExtention($this->mimetype));
+    }
+    
+    /**
+     * Calculate the image's mimetype.
+     */
+    private function _calculateExtention()
+    {
+	    $mimeTypes = array(
+	    		'image/jpeg' => 'jpeg',
+	    		'image/jpeg' => 'jpg',
+	    		'image/gif' => 'gif',
+	    		'image/png' => 'png',
+	    		'image/vnd.wap.wbmp' => 'wbmp',
+	    		'image/xbm' => 'xmb',
+	    );
+	    
+	    return $mimeTypes[$this->mimetype];
+    }
+}

--- a/Imagine/Data/Loader/DbLoader.php
+++ b/Imagine/Data/Loader/DbLoader.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Liip\ImagineBundle\Imagine\Data\Loader;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use Imagine\Image\ImagineInterface;
+
+class DbLoader implements LoaderInterface
+{
+    /**
+     * @var Imagine\Image\ImagineInterface
+     */
+    protected $imagine;
+
+    /**
+     * @var Doctrine\Bundle\DoctrineBundle\Registry
+     */
+    protected $doctrine;
+
+    /**
+     * Constructs
+     *
+     * @param ImagineInterface  $imagine
+     * @param array             $formats
+     * @param string            $rootPath
+     */
+    public function __construct(ImagineInterface $imagine, \Doctrine\Bundle\DoctrineBundle\Registry $doctrine)
+    {
+    	$this->imagine = $imagine;
+        $this->doctrine = $doctrine;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return Imagine\Image\ImageInterface
+     */
+    public function find($uniqueIdentifier)
+    {
+    	$image = $this->doctrine->getRepository('LiipImagineBundle:LiipImage')->findOneByUniqueIdentifier($uniqueIdentifier);
+        
+        if( is_null($image) )
+        {
+        	throw new NotFoundHttpException(sprintf('Could not find image by unique identifier "%s"', $uniqueIdentifier));
+        }
+        
+        return $this->imagine->load($image->getData());
+    }
+}

--- a/Resources/config/doctrine/LiipImage.orm.yml
+++ b/Resources/config/doctrine/LiipImage.orm.yml
@@ -1,0 +1,22 @@
+Liip\ImagineBundle\Entity\LiipImage:
+    type: entity
+    table: liip_image
+    fields:
+        id:
+            type: integer
+            id: true
+            generator:
+                strategy: AUTO
+        data:
+            type: text             
+        mimetype:
+            type: string
+            length: 255
+        fileName:
+            type: string
+            length: 255           
+        uniqueIdentifier:
+            type: string
+            length: 255
+            unique: true
+    lifecycleCallbacks: { prePersist: [ updateUniqueIdentifier ] }

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -40,6 +40,7 @@
         <!-- Data loaders' classes -->
 
         <parameter key="liip_imagine.data.loader.filesystem.class">Liip\ImagineBundle\Imagine\Data\Loader\FileSystemLoader</parameter>
+        <parameter key="liip_imagine.data.loader.db.class">Liip\ImagineBundle\Imagine\Data\Loader\DbLoader</parameter>
 
         <!-- Cache resolvers' classes -->
 
@@ -132,6 +133,12 @@
             <argument>%liip_imagine.formats%</argument>
             <argument>%liip_imagine.data_root%</argument>
         </service>
+        
+        <service id="liip_imagine.data.loader.db" class="%liip_imagine.data.loader.db.class%">
+    		<tag name="liip_imagine.data.loader" loader="db" />
+    		<argument type="service" id="liip_imagine" />
+    		<argument type="service" id="doctrine" />
+		</service>
 
         <!-- Cache resolver -->
 


### PR DESCRIPTION
First pull request ever, or open source submission for that matter so go easy.

Reference #56?

I've added a DbLoader data loader, along with YML schema

Usage:

Creating an image, should be moved to a handler method at some point to just pass the filename and it returns an image object.

<pre>
// The image path, can be from /tmp etc if it were from $_FILES
$img = $_SERVER['DOCUMENT_ROOT'] . 'wrx.jpg';
        
$imageInfo = getimagesize($img);
$imageContents = file_get_contents($img);
        
$image = new \Liip\ImagineBundle\Entity\LiipImage();
        
$image->setData($imageContents);
$image->setMimetype($imageInfo['mime']);
$image->setFilename('wrx.jpg');

$em = $this->getDoctrine()->getEntityManager();
$em->persist($image);
$em->flush();
        
echo $image->getId();
</pre>


Now setup another filter inside your config.yml, using the data_loader of "db"

<pre>
liip_imagine:
    filter_sets:
        my_thumb:
            quality: 75
            filters:
                thumbnail: { size: [120, 90], mode: outbound }
        db:
            data_loader: db
            quality: 75
            filters:
                relative_resize: { widen: 400, mode: outbound }
</pre>


From your view or controller you can now call imagine_filter on your image object, ie:

<pre>
$repository = $this->getDoctrine()->getRepository('LiipImagineBundle:LiipImage');
$image = $repository->find([id]);
        
$source = $this->get('liip_imagine.cache.manager')->getBrowserPath($image->getUniqueIdentifier(), 'db');

echo $source;
</pre>


As you can see, every image has a unique identifer (md5 of time(), filename) with the file extention on the end.

If the image cannot be found then the 404 exception will be thrown.
