### PR TITLE
Issue #56 - Added an Amazon S3 resolver

### DIFF
--- a/Command/S3UploadCommand.php
+++ b/Command/S3UploadCommand.php
@@ -1,0 +1,70 @@
+<?
+
+namespace Liip\ImagineBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class S3UploadCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('liip:s3upload')
+            ->setDescription('Cron script to upload queued images to s3')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+    	// Get the full path where cached images are stored
+    	$cachePath = $this->getContainer()->getParameter('liip_imagine.web_root') . $this->getContainer()->getParameter('liip_imagine.cache_prefix') . '/';
+    	
+    	$em = $this->getContainer()->get('doctrine')->getEntityManager();
+
+    	$repository = $this->getContainer()->get('doctrine')->getRepository('LiipImagineBundle:LiipS3Image');
+
+    	// Get a list of queued images that have not been uploaded to s3
+    	$result = $repository->findBy(array('url' => NULL));
+
+    	foreach( $result as $s3Image )
+		{
+			try
+			{
+				$filename = $s3Image->getFilename();
+
+				$fs = $this->getContainer()->get('liip_imagine.s3.fs');
+
+				$fs->write($filename, $s3Image->getData(), FALSE, array(
+					'content-type' => $s3Image->getMimetype()
+				));
+
+				// Set the newly uploaded file's ACL to public
+				$s3 = $this->getContainer()->get('liip_imagine.s3');
+				$s3->set_object_acl($this->getContainer()->getParameter('liip_imagine.s3.bucket_name'), $filename, \AmazonS3::ACL_PUBLIC);
+
+				// Set the image's live url, // prefix for http/https
+				$s3Image->setUrl('//' . 's3.amazonaws.com/' . $this->getContainer()->getParameter('liip_imagine.s3.bucket_name') . '/' . $filename);
+				
+				// Set the data to blank to preserve disk space
+				$s3Image->setData(NULL);
+				$em->persist($s3Image);
+				
+				unlink($cachePath . $filename);
+			}
+			catch( \Exception $e )
+			{
+				$logger = $this->getContainer()->get('logger');
+				$logger->err($e);
+			}
+    	}
+
+		$em->flush();
+
+        $output->writeln(sprintf('Completed - uploaded %d images.', count($result)));
+    }
+
+}

--- a/Entity/LiipS3Image.php
+++ b/Entity/LiipS3Image.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Liip\ImagineBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Liip\ImagineBundle\Entity\LiipS3Image
+ */
+class LiipS3Image
+{
+    /**
+     * @var integer $id
+     */
+    private $id;
+    
+    /**
+     * @var text $data
+     */
+    private $data;
+    
+    /**
+     * @var string $url
+     */
+    private $url;
+    
+    /**
+     * @var string $mimetype
+     */
+    private $mimetype;
+    
+    /**
+     * @var string $filename
+     */
+    private $filename;
+
+    /**
+     * Get id
+     *
+     * @return integer 
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set data
+     *
+     * @param text $data
+     * @return Image
+     */
+    public function setData($data)
+    {
+        $this->data = base64_encode($data);
+        return $this;
+    }
+
+    /**
+     * Get data
+     *
+     * @return text 
+     */
+    public function getData()
+    {
+        return base64_decode($this->data);
+    }
+
+    /**
+     * Set url
+     *
+     * @param string $url
+     * @return LiipS3Image
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+        return $this;
+    }
+
+    /**
+     * Get url
+     *
+     * @return string 
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * Set mimetype
+     *
+     * @param string $mimetype
+     * @return LiipS3Image
+     */
+    public function setMimetype($mimetype)
+    {
+        $this->mimetype = $mimetype;
+        return $this;
+    }
+
+    /**
+     * Get mimetype
+     *
+     * @return string 
+     */
+    public function getMimetype()
+    {
+        return $this->mimetype;
+    }
+
+    /**
+     * Set filename
+     *
+     * @param string $filename
+     * @return LiipS3Image
+     */
+    public function setFilename($filename)
+    {
+        $this->filename = $filename;
+        return $this;
+    }
+
+    /**
+     * Get filename
+     *
+     * @return string 
+     */
+    public function getFilename()
+    {
+        return $this->filename;
+    }
+}

--- a/Imagine/Cache/Resolver/AmazonS3Resolver.php
+++ b/Imagine/Cache/Resolver/AmazonS3Resolver.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
+
+use Symfony\Component\HttpFoundation\Request,
+	Symfony\Component\HttpFoundation\Response,
+    Symfony\Component\HttpFoundation\RedirectResponse,
+    Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use Liip\ImagineBundle\Imagine\Cache\CacheManagerAwareInterface,
+    Liip\ImagineBundle\Imagine\Cache\CacheManager;
+
+class AmazonS3Resolver extends WebPathResolver implements CacheManagerAwareInterface
+{
+	/**
+	 * @var Doctrine\Bundle\DoctrineBundle\Registry
+	 */
+	protected $doctrine = NULL;
+	
+	/**
+     * Constructs cache web path resolver
+     *
+     * @param Filesystem  $filesystem
+     */
+    public function __construct($filesystem, $doctrine)
+    {
+    	$this->doctrine = $doctrine;
+
+    	// Construct the web path resolver
+    	parent::__construct($filesystem);
+    }	
+    
+	/**
+     * @throws \RuntimeException
+     * @param Response $response
+     * @param string $targetPath
+     * @param string $filter
+     *
+     * @return Response
+     */
+    public function store(Response $response, $targetPath, $filter)
+    {
+    	// Construct a filename to store on s3, prefixed by the filter as the folder.
+    	$filename = $filter . '/' . pathinfo($targetPath, PATHINFO_BASENAME);
+    	
+    	// Check if the image is already queued
+    	$existingImage = $this->doctrine->getRepository('LiipImagineBundle:LiipS3Image')->findOneByFilename($filename);
+    	
+    	// If the image isn't already queued, store it inside the db
+    	if( is_null($existingImage) )
+    	{    	
+	    	// Create the entity object
+	    	$image = new \Liip\ImagineBundle\Entity\LiipS3Image();
+	    	$image->setFilename($filename);
+	    	$image->setData($response->getContent());
+	    	$image->setMimetype($response->headers->get('Content-Type'));
+	    	
+	    	// Save the record to the db
+	    	$em = $this->doctrine->getEntityManager();
+	    	$em->persist($image);
+	    	$em->flush();
+    	}
+    	
+    	// Store the image on the file system as well, using the WebPathResolver's store method
+    	return parent::store($response, $targetPath, $filter);
+    }
+	
+    /**
+     * Resolves filtered path for rendering in the browser
+     *
+     * @param Request $request
+     * @param string $path
+     * @param string $filter
+     *
+     * @return string target path
+     */
+    public function resolve(Request $request, $path, $filter)
+    {
+    	// Find the image inside the s3 queue
+    	$image = $this->doctrine->getRepository('LiipImagineBundle:LiipS3Image')->findOneByFilename($filter . '/' . $path);
+    	
+    	// If the image is not inside the queue, or it has no URL (ie. has not been uploaded to s3) then resolve to the web path
+    	if( is_null($image) or is_null($image->getUrl()) )
+    	{
+    		return parent::resolve($request, $path, $filter);
+    	}
+    	else
+    	{
+    		// Return a 302 redirect to the image on s3,  so the browser can remember the destination
+    		return new RedirectResponse($image->getUrl());
+    	}    
+    }
+}

--- a/Resources/config/doctrine/LiipS3Image.orm.yml
+++ b/Resources/config/doctrine/LiipS3Image.orm.yml
@@ -1,0 +1,23 @@
+Liip\ImagineBundle\Entity\LiipS3Image:
+    type: entity
+    table: liip_s3image
+    fields:
+        id:
+            type: integer
+            id: true
+            generator:
+                strategy: AUTO
+        data:
+            type: text             
+        url:
+            type: string
+            length: 255
+            nullable: true
+        mimetype:
+            type: string
+            length: 255           
+        filename:
+            type: string
+            length: 255
+            unique: true
+    lifecycleCallbacks: {}

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -139,6 +139,30 @@
             <tag name="liip_imagine.cache.resolver" resolver="web_path" />
             <argument type="service" id="filesystem" />
         </service>
+        
+		<service id="liip_imagine.cache.resolver.amazons3" class="Liip\ImagineBundle\Imagine\Cache\Resolver\AmazonS3Resolver">
+			<tag name="liip_imagine.cache.resolver" resolver="amazons3" />
+			<argument type="service" id="filesystem" />
+			<argument type="service" id="doctrine" />
+		</service>
+		
+		<!-- S3 setup -->
+		<service id="liip_imagine.s3" class="AmazonS3">
+			<argument type="collection">
+				<argument key="key">%liip_imagine.aws_key%</argument>
+            	<argument key="secret">%liip_imagine.aws_secret_key%</argument>
+			</argument>
+		</service>
+		
+		<service id="liip_imagine.s3.adapter" class="Gaufrette\Adapter\AmazonS3">
+			<argument type="service" id="liip_imagine.s3" />
+            <argument>%liip_imagine.s3.bucket_name%</argument>
+            <argument>true</argument>
+		</service>
+		
+		<service id="liip_imagine.s3.fs" class="Gaufrette\Filesystem">
+			<argument type="service" id="liip_imagine.s3.adapter" />
+		</service>
 
     </services>
 </container>


### PR DESCRIPTION
Reference #56? (I've never done pull requests before so unsure how referencing works)

I've created an Amazon S3 resolver for this bundle.

Usage:.

You will need to update your composer.yml to include KnpLabs's Gaurfrette bundle & amazon sdk

<pre>
"require": {
    "knplabs/gaufrette": "dev-master"
},
"repositories": [
        {
            "type": "pear",
            "url": "http://pear.amazonwebservices.com"
        }
    ],
"recommend": {
    "pear-aws/sdk": ">=1.5.3"
},
</pre>


Add the following to the autoloader, as instructed by https://github.com/KnpLabs/KnpGaufretteBundle - we've had to adjust the path of the file slightly because of composer placing it somewhere else.

<pre>
define("AWS_CERTIFICATE_AUTHORITY", true);

// AWS SDK needs a special autoloader
require_once __DIR__.'/../vendor/pear-aws/sdk/sdk.class.php';
</pre>

Setup your filter inside config.yml, with the amazon resolver:

<pre>
liip_imagine:
    filter_sets:
        my_thumb:
            quality: 75
            filters:
                thumbnail: { size: [120, 90], mode: outbound }
        amazon:
            cache: amazons3
            quality: 75
            filters:
                relative_resize: { widen: 400, mode: outbound }
</pre>


Add 3 new keys to your config.yml:

<pre>
liip_imagine.aws_key: "[key]"
liip_imagine.aws_secret_key: "[secret]"
liip_imagine.s3.bucket_name: "[bucketname]"
</pre>


Once you've done your schema update, you can start using your filter with the amazon s3 resolver.

The resolver will add any images to its upload queue that are requested,  in the period between the image hitting the queue and subsequent requests coming in for that image, it will be served from disk in the same way as the WebPathResolver works.

Once you've got images in the queue table, you can run the console command "liip:s3upload" which will upload the images to S3, and set their live URL on the record.  You'll notice in the cron script that it unlinks the cached file that WebPathResolver creates so the apache -f rewritecond will no longer pick it up.

Once the resolver now sees that the requested image is on S3, it will send out a 302 redirect to the image's S3 location instead, if the image doesn't already exist in the user's browser cache.

Foreseeable issues that need suggestions:
- If the bucket is renamed, the files will still link to the old url and most likely 404 on amazon's end
- I believe gaufrette actually has another class to automatically set the ACL of the images when you ->write them, I just didn't get around to trying it out.  For now I'm directly accessing the amazon sdk and updating the acl.
- Someone recommended using cloudfront custom origins instead of s3,  I'm not too sure whats involved in doing that instead as I've always been using s3.
