### PR TITLE
Updates PdfTransformer so that imagick is injected

### DIFF
--- a/Imagine/Data/Transformer/PdfTransformer.php
+++ b/Imagine/Data/Transformer/PdfTransformer.php
@@ -4,21 +4,28 @@ namespace Liip\ImagineBundle\Imagine\Data\Transformer;
 
 class PdfTransformer
 {
+    /**
+     *
+     * @var \Imagick
+     */
+    private $imagick;
+    
+    public function __construct(\Imagick $imagick)
+    {
+        $this->imagick = $imagick;
+    }
+    
     public function applyTransform($absolutePath)
     {
         $info = pathinfo($absolutePath);
         if (isset($info['extension']) && strpos(strtolower($info['extension']), 'pdf') !== false) {
-            //Check if Imagick extension is loaded
-            if (!extension_loaded('Imagick'))
-                throw new \RuntimeException ("PHP Imagick extension is not loaded but required by the PdfTransformer");
-            
-            //If it doesn't exists extract the first page of the PDF
+            //If it doesn't exists, extract the first page of the PDF
             if (!file_exists("$absolutePath.png")) {
-                $img = new \Imagick($absolutePath.'[0]');
-                $img->setImageFormat('png');
-                $img->writeImages($absolutePath.'.png', true);
+                $this->imagick->readImage($absolutePath.'[0]');
+                $this->imagick->setImageFormat('png');
+                $this->imagick->writeImage("$absolutePath.png");
+                $this->imagick->clear();
             }
-            //finally update $absolutePath
             $absolutePath .= '.png';
         }
         return $absolutePath;

--- a/README.md
+++ b/README.md
@@ -406,16 +406,20 @@ to `Liip\ImagineBundle\Imagine\Data\Transformer\PdfTransformer` as an example.
 
 ExtendedFileSystemLoader extends FileSystemLoader and takes, as argument, an array of transformers.
 In the example, when a file with the pdf extension is passed to the data loader,
-PdfTransformer uses php imagick extension to extract the first page of the document
-and returns it to the data loader as a png image.
+PdfTransformer uses a php imagick object (injected via the service container) 
+to extract the first page of the document and returns it to the data loader as a png image.
 
 To tell the bundle about the transformers, you have to register them as services
 with the new loader:
 
 ```yml
 services:
+    imagick_object:
+        class:   Imagick
     acme_custom_transformer:
         class:     Acme\ImagineBundle\Imagine\Data\Transformer\MyCustomTransformer
+        arguments:
+            -    '@imagick_object'
     custom_loader:
         class:     Acme\ImagineBundle\Imagine\Data\Loader\MyCustomDataLoader
         tags:


### PR DESCRIPTION
With this update Imagick is injected in the transformer via
Symfony's Service Container.
The check, relative to imagick extension being loaded, is now up
to the user: the service container will complain about Imagick
not found before injecting it in the transformer.
