### PR TITLE
In AbstractFilesystemResolver::remove(), $targetPath is calculated 2 times

### DIFF
--- a/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
+++ b/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
@@ -60,10 +60,9 @@ abstract class AbstractFilesystemResolver implements ResolverInterface
      */
     public function remove($targetPath, $filter)
     {
-        $filename = $this->getFilePath($targetPath, $filter);
-        $this->filesystem->remove($filename);
+        $this->filesystem->remove($targetPath);
 
-        return file_exists($filename);
+        return file_exists($targetPath);
     }
 
     /**


### PR DESCRIPTION
Filename used in `AbstractFilesystemResolver::remove()` was buggy, resulting in files never been removed from the filesystem.

There's no need to call `AbstractFilesystemResolver::getFilePath()` to get `$filename` as `$targetPath` is already the path to the file.
