### PR TITLE
Fix if want to see site under /app_dev.php

### DIFF
--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -54,11 +54,27 @@ class WebPathResolver extends AbstractFilesystemResolver implements CacheManager
     {
         $params = array('path' => ltrim($targetPath, '/'));
 
-        return str_replace(
+        $uri = str_replace(
             urlencode($params['path']),
             urldecode($params['path']),
             $this->cacheManager->getRouter()->generate('_imagine_'.$filter, $params, $absolute)
         );
+
+        if (strpos($uri, '.php') !== false) {
+            $uriParts = explode('/', $uri);
+            $index = 0;
+            foreach ($uriParts as $uriIndex => $uriPart) {
+                if (strpos($uriPart, '.php') !== false) {
+                    $index = $uriIndex;
+                    break;
+                }
+            }
+
+            unset($uriParts[$index]);
+            $uri = implode('/', $uriParts);
+        }
+
+        return $uri;
     }
 
     /**


### PR DESCRIPTION
If view site through any of entry points without rewrites ( "/" root path instead of "/app_dev.php" ) cache resolver resolves into /app_dev.php/media/cache/whatever.jpg and can not create a direcory.
