### PR TITLE
add basePath injection to filesystem resolver

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('data_root')->defaultValue('%liip_imagine.web_root%')->end()
                 ->scalarNode('cache_prefix')->defaultValue('/media/cache')->end()
                 ->scalarNode('cache')->defaultValue('web_path')->end()
+                ->scalarNode('cache_base_path')->defaultValue('')->end()
                 ->scalarNode('data_loader')->defaultValue('filesystem')->end()
                 ->scalarNode('controller_action')->defaultValue('liip_imagine.controller:filterAction')->end()
                 ->arrayNode('formats')

--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -48,5 +48,7 @@ class LiipImagineExtension extends Extension
         if ('2' == Kernel::MAJOR_VERSION && '0' == Kernel::MINOR_VERSION) {
             $container->removeDefinition('liip_imagine.cache.clearer');
         }
+
+        $container->setParameter('liip_imagine.cache.resolver.base_path', $config['cache_base_path']);
     }
 }

--- a/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
+++ b/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
@@ -14,6 +14,11 @@ abstract class AbstractFilesystemResolver implements ResolverInterface
     protected $filesystem;
 
     /**
+     * @var string
+     */
+    protected $basePath = '';
+
+    /**
      * Constructs a filesystem based cache resolver.
      *
      * @param Filesystem $filesystem
@@ -21,6 +26,16 @@ abstract class AbstractFilesystemResolver implements ResolverInterface
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem   = $filesystem;
+    }
+
+    /**
+     * Set the base path to
+     *
+     * @param $basePath
+     */
+    public function setBasePath($basePath)
+    {
+        $this->basePath = $basePath;
     }
 
     /**
@@ -74,9 +89,8 @@ abstract class AbstractFilesystemResolver implements ResolverInterface
      *
      * @param string $path The resource path to convert.
      * @param string $filter The name of the imagine filter.
-     * @param string $basePath An optional base path to remove from the path.
      *
      * @return string
      */
-    abstract protected function getFilePath($path, $filter, $basePath = '');
+    abstract protected function getFilePath($path, $filter);
 }

--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -77,7 +77,7 @@ class WebPathResolver extends AbstractFilesystemResolver implements CacheManager
     /**
      * {@inheritDoc}
      */
-    protected function getFilePath($path, $filter, $basePath = '')
+    protected function getFilePath($path, $filter)
     {
         $browserPath = $this->decodeBrowserPath($this->getBrowserPath($path, $filter));
 
@@ -86,8 +86,8 @@ class WebPathResolver extends AbstractFilesystemResolver implements CacheManager
             throw new NotFoundHttpException('Image doesn\'t exist');
         }
 
-        if (!empty($basePath) && 0 === strpos($browserPath, $basePath)) {
-            $browserPath = substr($browserPath, strlen($basePath));
+        if (!empty($this->basePath) && 0 === strpos($browserPath, $this->basePath)) {
+            $browserPath = substr($browserPath, strlen($this->basePath));
         }
 
         return $this->cacheManager->getWebRoot().$browserPath;

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -149,6 +149,9 @@
         <service id="liip_imagine.cache.resolver.web_path" class="%liip_imagine.cache.resolver.web_path.class%">
             <tag name="liip_imagine.cache.resolver" resolver="web_path" />
             <argument type="service" id="filesystem" />
+            <call method="setBasePath">
+                <argument type="string">%liip_imagine.cache.resolver.base_path%</argument>
+            </call>
         </service>
 
         <service id="liip_imagine.cache.resolver.no_cache" class="%liip_imagine.cache.resolver.no_cache.class%">


### PR DESCRIPTION
This fixes #74.

A new option `cache_base_path` is added, to define the injected base path for default services. Any foreign service may inject it by its own need.
