### PR TITLE
Updated the Imagine library to version 0.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 
     "require": {
         "php":                      ">=5.3.2",
-        "imagine/Imagine":          "<=0.3.0",
+        "imagine/Imagine":          "<=0.4.0",
         "symfony/framework-bundle": ">=2.0.14,<2.3-dev"
     },
 


### PR DESCRIPTION
The latest stable release of the Imagine library (v0.4.0) was recently released on packagist.org.
