### PR TITLE
Pathinfo-related notices in generateUrl()

### DIFF
--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -123,9 +123,12 @@ class CacheManager
     public function generateUrl($targetPath, $filter, $absolute = false)
     {
         $config = $this->filterConfig->get($filter);
+
         if (isset($config['format'])) {
             $pathinfo = pathinfo($targetPath);
-            if ($pathinfo['extension'] !== $config['format']) {
+            // the extension should be forced and a directory is detected
+            if ((!isset($pathinfo['extension']) || $pathinfo['extension'] !== $config['format'])
+                && isset($pathinfo['dirname'])) {
                 $targetPath = $pathinfo['dirname'].'/'.$pathinfo['filename'].'.'.$config['format'];
             }
         }


### PR DESCRIPTION
A file path with no extension or `/` will throw notices when pushed to the twig imagine_filter.
`null` or any random alphabetic string like 'test' can be used to test it.
pathinfo() will then return an array with only the basename and filename set.

Php 5.3.10 at least.
