### PR TITLE
Add image form type

### DIFF
--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -55,5 +55,9 @@ class LiipImagineExtension extends Extension
         }
 
         $container->setParameter('liip_imagine.cache.resolver.base_path', $config['cache_base_path']);
+
+        $resources = $container->hasParameter('twig.form.resources') ? $container->getParameter('twig.form.resources') : array();
+        $resources[] = 'LiipImagineBundle:Form:form_div_layout.html.twig';
+        $container->setParameter('twig.form.resources', $resources);
     }
 }

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Liip\ImagineBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * ImageType
+ *
+ * @author Emmanuel Vella <vella.emmanuel@gmail.com>
+ */
+class ImageType extends AbstractType
+{
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['image_path']   = $options['image_path'];
+        $view->vars['image_filter'] = $options['image_filter'];
+        $view->vars['image_attr']   = $options['image_attr'];
+        $view->vars['link_url']     = $options['link_url'];
+        $view->vars['link_attr']    = $options['link_attr'];
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setRequired(array(
+            'image_path',
+            'image_filter',
+        ));
+
+        $resolver->setDefaults(array(
+            'image_attr' => array(),
+            'link_url' => null,
+            'link_attr' => array(),
+        ));
+    }
+
+    public function getParent()
+    {
+        return 'file';
+    }
+
+    public function getName()
+    {
+        return 'liip_imagine_image';
+    }
+}

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -48,6 +48,10 @@
         <parameter key="liip_imagine.cache.resolver.web_path.class">Liip\ImagineBundle\Imagine\Cache\Resolver\WebPathResolver</parameter>
         <parameter key="liip_imagine.cache.resolver.no_cache.class">Liip\ImagineBundle\Imagine\Cache\Resolver\NoCacheResolver</parameter>
 
+        <!-- Form types -->
+
+        <parameter key="liip_imagine.form.type.image.class">Liip\ImagineBundle\Form\Type\ImageType</parameter>
+
     </parameters>
 
     <services>
@@ -153,6 +157,12 @@
         <service id="liip_imagine.cache.resolver.no_cache" class="%liip_imagine.cache.resolver.no_cache.class%">
             <tag name="liip_imagine.cache.resolver" resolver="no_cache" />
             <argument type="service" id="filesystem" />
+        </service>
+
+        <!-- Form types -->
+
+        <service id="liip_imagine.form.type.image" class="%liip_imagine.form.type.image.class%">
+            <tag name="form.type" alias="liip_imagine_image" />
         </service>
 
     </services>

--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -1,0 +1,19 @@
+{% block liip_imagine_image_widget %}
+    {% spaceless %}
+        {% if image_path %}
+            <div>
+                {% if link_url %}
+                    <a href="{{ link_url }}" {% for attrname, attrvalue in link_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}>
+                {% endif %}
+
+                <img src="{{ image_path|imagine_filter(image_filter) }}" {% for attrname, attrvalue in image_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %} />
+
+                {% if link_url %}
+                    </a>
+                {% endif %}
+            </div>
+        {% endif %}
+
+        {{ block('form_widget_simple') }}
+    {% endspaceless %}
+{% endblock %}


### PR DESCRIPTION
Displays a file input with an imagine thumbnail. Only `image_path` and `image_filter` options are mandatory.

```
 ->add('image', 'liip_imagine_image', array(
    'image_path' => '/uploads/my-image.jpg',
    'image_filter' => 'my_thumb',
    'image_attr' => array('class' => 'thumbnail'),
    'link_url' => '/uploads/my-image.jpg'
    'link_attr' => array('class' => 'link')
))
```

I often need this and I  think it would be nice to make it available in the bundle.
