### PR TITLE
Added check for the existence of extension info

### DIFF
--- a/Imagine/Data/Loader/FileSystemLoader.php
+++ b/Imagine/Data/Loader/FileSystemLoader.php
@@ -64,8 +64,13 @@ class FileSystemLoader implements LoaderInterface
         $absolutePath = $info['dirname'].'/'.$info['basename'];
 
         $name = $info['dirname'].'/'.$info['filename'];
-        $targetFormat = empty($this->formats) || in_array($info['extension'], $this->formats)
-            ? $info['extension'] : null;
+
+        $targetFormat = null;
+        // set a format if an extension is found and is allowed
+        if (isset($info['extension']) &&
+            (empty($this->formats) || in_array($info['extension'], $this->formats))) {
+            $targetFormat = $info['extension'];
+        }
 
         if (empty($targetFormat) || !file_exists($absolutePath)) {
             // attempt to determine path and format

--- a/Tests/Imagine/Data/Loader/FileSystemLoaderTest.php
+++ b/Tests/Imagine/Data/Loader/FileSystemLoaderTest.php
@@ -45,6 +45,15 @@ class FileSystemLoaderTest extends AbstractTest
         $loader->find('/invalid.jpeg');
     }
 
+    public function testFindWithNoExtensionDoesNotThrowNotice()
+    {
+        $loader = new FileSystemLoader($this->imagine, array(), $this->tempDir);
+
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+
+        $loader->find('/invalid');
+    }
+
     public function testFindRetrievesImage()
     {
         $image = $this->getMockImage();


### PR DESCRIPTION
Fixes a notice issue occurring when passing a filename with no extension:

Notice: Undefined index: extension in vendor/liip/imagine-bundle/Liip/ImagineBundle/Imagine/Data/Loader/FileSystemLoader.php line 69 
