### PR TITLE
made the phpcr loader search for the requested path with or without a file extension

### DIFF
--- a/Imagine/Data/Loader/DoctrinePHPCRLoader.php
+++ b/Imagine/Data/Loader/DoctrinePHPCRLoader.php
@@ -2,38 +2,75 @@
 
 namespace Liip\ImagineBundle\Imagine\Data\Loader;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Imagine\Image\ImagineInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class DoctrinePHPCRLoader extends AbstractDoctrineLoader
+class DoctrinePHPCRLoader extends FileSystemLoader
 {
+    /**
+     * @var DocumentManager
+     */
+    protected $manager;
+
     /**
      * @var string
      */
-    protected $rootPath;
+    protected $class;
 
     /**
      * Constructor.
      *
-     * @param ImagineInterface $imagine
-     * @param ObjectManager $manager
-     * @param string $class
-     * @param string $rootPath
+     * @param ImagineInterface  $imagine
+     * @param array             $formats
+     * @param string            $rootPath
+     * @param DocumentManager   $manager
+     * @param string            $class
      */
-    public function __construct(ImagineInterface $imagine, ObjectManager $manager, $class = null, $rootPath = '')
+    public function __construct(ImagineInterface $imagine, array $formats, $rootPath, DocumentManager $manager, $class = null)
     {
-        parent::__construct($imagine, $manager, $class);
+        parent::__construct($imagine, $formats, $rootPath);
 
+        $this->manager = $manager;
+        $this->class = $class;
         $this->rootPath = $rootPath;
-    }
-
-    protected function mapPathToId($path)
-    {
-        return $this->rootPath.'/'.ltrim($path, '/');
     }
 
     protected function getStreamFromImage($image)
     {
         return $image->getContent();
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return \Imagine\Image\ImageInterface
+     */
+    public function find($path)
+    {
+        $file = $this->rootPath.'/'.ltrim($path, '/');
+        $info = $this->getFileInfo($file);
+        $name = $info['dirname'].'/'.$info['filename'];
+
+        // consider full path as provided (with or without an extension)
+        $paths = array($file);
+        foreach ($this->formats as $format) {
+            // consider all possible alternative extensions
+            if (empty($info['extension']) || $info['extension'] !== $format) {
+                $paths[] = $name.'.'.$format;
+            }
+        }
+
+        // if the full path contained an extension, also consider the full path without an extension
+        if ($file !== $name) {
+            $paths[] = $name;
+        }
+
+        $images = $this->manager->findMany($this->class, $paths);
+        if (!$images->count()) {
+            throw new NotFoundHttpException(sprintf('Source image not found with id "%s"', $path));
+        }
+
+        return $this->imagine->load(stream_get_contents($this->getStreamFromImage($images->first())));
     }
 }

--- a/Resources/doc/data-loader/doctrine-phpcr.md
+++ b/Resources/doc/data-loader/doctrine-phpcr.md
@@ -7,15 +7,16 @@ service definition:
 
 ``` xml
 <service id="liip_imagine.data.loader.phpcr" class="Liip\ImagineBundle\Imagine\Data\Loader\DoctrinePHPCRLoader">
-    <tag name="liip_imagine.data.loader" loader="phpcr" />
+    <tag name="liip_imagine.data.loader" loader="doctrine_phpcr" />
     <argument type="service" id="liip_imagine" />
+    <argument>%liip_imagine.formats%</argument>
+    <argument>%symfony_cmf_create.static_basepath%</argument>
     <argument type="service" id="doctrine_phpcr.odm.document_manager" />
     <argument>%symfony_cmf_create.image.model_class%</argument>
-    <argument>%symfony_cmf_create.static_basepath%</argument>
 </service>
 ```
 
-Note this loader extends from AbstractDoctrineLoader. It is quite easy to extend this abstract class
+Note there is an AbstractDoctrineLoader. It is quite easy to extend this abstract class
 to create a new Doctrine loader for the ORM or another ODM.
 
 - [Back to data loaders](../data-loaders.md)


### PR DESCRIPTION
this makes it possible to simply pass a filename with a file extension even if the path inside PHPCR does not include a file extension.

fixes #167
