### PR TITLE
add CacheManagerAwareTrait

### DIFF
--- a/Imagine/Cache/CacheManagerAwareTrait.php
+++ b/Imagine/Cache/CacheManagerAwareTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Liip\ImagineBundle\Imagine\Cache;
+
+trait CacheManagerAwareTrait
+{
+    /**
+     * @var CacheManager
+     */
+    protected $cacheManager;
+
+    public function setCacheManager(CacheManager $cacheManager)
+    {
+        $this->cacheManager = $cacheManager;
+    }
+}


### PR DESCRIPTION
The trait is given, but as the bundle is meant to work on PHP 5.3, this trait is not used by the bundle directly.
It's sole purpose is to have a common trait for applications using this bundle.
