### PR TITLE
improve phpcr loader doc

### DIFF
--- a/Resources/doc/data-loader/doctrine-phpcr.md
+++ b/Resources/doc/data-loader/doctrine-phpcr.md
@@ -10,11 +10,17 @@ service definition:
     <tag name="liip_imagine.data.loader" loader="doctrine_phpcr" />
     <argument type="service" id="liip_imagine" />
     <argument>%liip_imagine.formats%</argument>
-    <argument>%symfony_cmf_create.static_basepath%</argument>
+    <argument>%my_content_basepath%</argument>
     <argument type="service" id="doctrine_phpcr.odm.document_manager" />
     <argument>%symfony_cmf_create.image.model_class%</argument>
 </service>
 ```
+
+Instead of liip_imagine.formats you can of course also provide a custom set of
+image formats to support.
+``my_content_basepath`` is used to limit what parts of your repository are
+exposed by imagine. This must be a path without trailing slash. For example
+``"/cms/content`` or if you want to expose everything, ``""`` (but *not* ``"/"``).
 
 Note there is an AbstractDoctrineLoader. It is quite easy to extend this abstract class
 to create a new Doctrine loader for the ORM or another ODM.


### PR DESCRIPTION
had a hard time figuring out that things where not working anymore because the signature of the phpcr loader changed...

is there a reason why this bundle does not allow to configure the phpcr loader service but recommends defining your own service?

see also https://github.com/symfony-cmf/MediaBundle/issues/3 - i expect somebody will soon attempt to improve the phpcr loader support.
