### PR TITLE
fix doc of CacheManager::resolve to not lie

### DIFF
--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -162,7 +162,10 @@ class CacheManager
      * @param string $path
      * @param string $filter
      *
-     * @return string target path
+     * @return string|boolean|Response target path or false if filter has no
+     *      resolver or a Response object from the resolver
+     *
+     * @throws NotFoundHttpException if the path can not be resolved
      */
     public function resolve(Request $request, $path, $filter)
     {


### PR DESCRIPTION
the method does return Response in some cases, if i convert this to string for all cases, we get all kind of errors elsewhere.
