### PR TITLE
mkdir() doesn't take care about the umask

### DIFF
--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -170,6 +170,9 @@
             <call method="setBasePath">
                 <argument type="string">%liip_imagine.cache.resolver.base_path%</argument>
             </call>
+            <call method="setFolderPermissions">
+                <argument type="string">%liip_imagine.cache_mkdir_mode%</argument>
+            </call>
         </service>
 
         <service id="liip_imagine.cache.resolver.no_cache" class="%liip_imagine.cache.resolver.no_cache.class%">

--- a/Tests/Imagine/Cache/Resolver/AbstractFilesystemResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/AbstractFilesystemResolverTest.php
@@ -34,6 +34,29 @@ class AbstractFilesystemResolverTest extends AbstractTest
         $this->assertEquals($data, file_get_contents($targetPath));
     }
 
+    public function testMkdirVerifyPermissionOnLastLevel () {
+        if (false !== strpos(strtolower(PHP_OS), 'win')) {
+            $this->markTestSkipped('mkdir mode is ignored on windows');
+        }
+
+        $resolver = $this->getMockAbstractFilesystemResolver(new Filesystem());
+
+
+        $resolver->store(new Response(''), $this->tempDir . '/first-level/second-level/cats.jpeg', 'thumbnail');
+        $this->assertEquals(040777, fileperms($this->tempDir . '/first-level/second-level'));
+    }
+
+    public function testMkdirVerifyPermissionOnFirstLevel () {
+        if (false !== strpos(strtolower(PHP_OS), 'win')) {
+            $this->markTestSkipped('mkdir mode is ignored on windows');
+        }
+
+        $resolver = $this->getMockAbstractFilesystemResolver(new Filesystem());
+
+        $resolver->store(new Response(''), $this->tempDir . '/first-level/second-level/cats.jpeg', 'thumbnail');
+        $this->assertEquals(040777, fileperms($this->tempDir . '/first-level'));
+    }
+
     public function testStoreInvalidDirectory()
     {
         if (false !== strpos(strtolower(PHP_OS), 'win')) {


### PR DESCRIPTION
I use the default setting

```
cache_mkdir_mode: 0777
```

The problem now is, that if a umask is set, the permissions for the created folders aren't `0777`. This break the cache-cleanup. It should also take care, that every recursively created folder should have the same permissions.

Update: While I was looking for a solution I realized, that during storing the created files no permission mask is applied to `mkdir()` at all

https://github.com/liip/LiipImagineBundle/blob/master/Imagine/Cache/Resolver/AbstractFilesystemResolver.php#L75

This means, even if I set something different as `cache_mkdir_mode` it is never applied, is it? Is this intended?
