### PR TITLE
Allow storage object responses of 301 to be accepted as OK in AmazonS3Resolver

### DIFF
--- a/Imagine/Cache/Resolver/AmazonS3Resolver.php
+++ b/Imagine/Cache/Resolver/AmazonS3Resolver.php
@@ -106,7 +106,7 @@ class AmazonS3Resolver implements ResolverInterface, CacheManagerAwareInterface
             'acl' => $this->acl,
         ));
 
-        if ($storageResponse->isOK()) {
+        if ($storageResponse->isOK(array(200, 201, 204, 206, 301))) {
             $response->setStatusCode(301);
             $response->headers->set('Location', $this->getObjectUrl($targetPath));
         } else {


### PR DESCRIPTION
When pushing an image to S3 using `AmazonS3Resolver` I get a response back that looks as follows (I've removed lots of unnecessary bits of data):

```
object(CFResponse)[266]
  public 'header' => 
    array (size=13)
      …
  public 'body' => 
    object(CFSimpleXML)[292]
      public 'Code' => string 'PermanentRedirect' (length=17)
      public 'Message' => string 'The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.' (length=137)
      public 'RequestId' => string '…' (length=16)
      public 'Bucket' => string '…' (length=31)
      public 'HostId' => string '…' (length=64)
      public 'Endpoint' => string '…' (length=48)
  public 'status' => int 301
```

This is then checked to see if the response was valid. However, 301 responses were being classed as invalid and the user wasn't being redirected to the asset on S3.
