### PR TITLE
make loader work with File document from phpcr-odm

### DIFF
--- a/Imagine/Data/Loader/DoctrinePHPCRLoader.php
+++ b/Imagine/Data/Loader/DoctrinePHPCRLoader.php
@@ -42,7 +42,7 @@ class DoctrinePHPCRLoader extends FileSystemLoader
 
     protected function getStreamFromImage($image)
     {
-        return $image->getContent();
+        return $image->getFileContentAsStream();
     }
 
     /**


### PR DESCRIPTION
if this loader is supposed to work with Doctrine\ODM\PHPCR\Document\File it needs to be getFileContentAsStream not getContent ...
