### PR TITLE
[RFC,WIP] add variables to generated routes for dynamic filters 

### DIFF
--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -118,9 +118,9 @@ class CacheManager
      *
      * @return string
      */
-    public function getBrowserPath($path, $filter, $absolute = false)
+    public function getBrowserPath($path, $filter, $absolute = false, $params = array())
     {
-        return $this->getResolver($filter)->getBrowserPath($path, $filter, $absolute);
+        return $this->getResolver($filter)->getBrowserPath($path, $filter, $absolute, $this->getFilterParams($params, $filter));
     }
 
     /**
@@ -133,7 +133,7 @@ class CacheManager
      *
      * @return string
      */
-    public function generateUrl($path, $filter, $absolute = false)
+    public function generateUrl($path, $filter, $absolute = false, $params = array())
     {
         $config = $this->filterConfig->get($filter);
 
@@ -152,7 +152,7 @@ class CacheManager
             }
         }
 
-        $params = array('path' => ltrim($path, '/'));
+        $params = array_merge(array('path' => ltrim($path, '/')), $params);
 
         return str_replace(
             urlencode($params['path']),
@@ -237,5 +237,17 @@ class CacheManager
         foreach ($this->resolvers as $resolver) {
             $resolver->clear($cachePrefix);
         }
+    }
+
+    public function getFilterParams($params, $filter)
+    {
+        $result = array();
+        $config = $this->filterConfig->get($filter);
+        foreach($params as $key => $value) {
+            if (isset($config['route']['variables']) && in_array($key, $config['route']['variables'])) {
+                $result[$key] = $value;
+            }
+        }
+        return $result;
     }
 }

--- a/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
+++ b/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
@@ -136,5 +136,5 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
      *
      * @return string
      */
-    abstract protected function getFilePath($path, $filter);
+    abstract protected function getFilePath($path, $filter, $params = array());
 }

--- a/Imagine/Cache/Resolver/AmazonS3Resolver.php
+++ b/Imagine/Cache/Resolver/AmazonS3Resolver.php
@@ -125,7 +125,7 @@ class AmazonS3Resolver implements ResolverInterface, CacheManagerAwareInterface
     /**
      * {@inheritDoc}
      */
-    public function getBrowserPath($path, $filter, $absolute = false)
+    public function getBrowserPath($path, $filter, $absolute = false, $params = array())
     {
         $objectPath = $this->getObjectPath($path, $filter);
         if ($this->objectExists($objectPath)) {

--- a/Imagine/Cache/Resolver/AwsS3Resolver.php
+++ b/Imagine/Cache/Resolver/AwsS3Resolver.php
@@ -128,7 +128,7 @@ class AwsS3Resolver implements ResolverInterface, CacheManagerAwareInterface
     /**
      * {@inheritDoc}
      */
-    public function getBrowserPath($path, $filter, $absolute = false)
+    public function getBrowserPath($path, $filter, $absolute = false, $params = array())
     {
         $objectPath = $this->getObjectPath($path, $filter);
         if ($this->objectExists($objectPath)) {

--- a/Imagine/Cache/Resolver/CacheResolver.php
+++ b/Imagine/Cache/Resolver/CacheResolver.php
@@ -90,7 +90,7 @@ class CacheResolver implements ResolverInterface
     /**
      * {@inheritDoc}
      */
-    public function getBrowserPath($path, $filter, $absolute = false)
+    public function getBrowserPath($path, $filter, $absolute = false, $params = array())
     {
         $key = $this->generateCacheKey('getBrowserPath', $path, $filter, array(
             $absolute ? 'absolute' : 'relative',

--- a/Imagine/Cache/Resolver/ResolverInterface.php
+++ b/Imagine/Cache/Resolver/ResolverInterface.php
@@ -42,7 +42,7 @@ interface ResolverInterface
      *
      * @return string
      */
-    function getBrowserPath($path, $filter, $absolute = false);
+    function getBrowserPath($path, $filter, $absolute = false, $params = array());
 
     /**
      * Removes a stored image resource.

--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -13,9 +13,10 @@ class WebPathResolver extends AbstractFilesystemResolver
      */
     public function resolve(Request $request, $path, $filter)
     {
-        $browserPath = $this->decodeBrowserPath($this->getBrowserPath($path, $filter));
+        $params = $this->cacheManager->getFilterParams($request->attributes->all(), $filter);
+        $browserPath = $this->decodeBrowserPath($this->getBrowserPath($path, $filter, false, $params));
         $this->basePath = $request->getBaseUrl();
-        $targetPath = $this->getFilePath($path, $filter);
+        $targetPath = $this->getFilePath($path, $filter, $params);
 
         // if the file has already been cached, we're probably not rewriting
         // correctly, hence make a 301 to proper location, so browser remembers
@@ -35,9 +36,9 @@ class WebPathResolver extends AbstractFilesystemResolver
     /**
      * {@inheritDoc}
      */
-    public function getBrowserPath($targetPath, $filter, $absolute = false)
+    public function getBrowserPath($targetPath, $filter, $absolute = false, $params = array())
     {
-        return $this->cacheManager->generateUrl($targetPath, $filter, $absolute);
+        return $this->cacheManager->generateUrl($targetPath, $filter, $absolute, $params);
     }
 
     /**
@@ -61,9 +62,9 @@ class WebPathResolver extends AbstractFilesystemResolver
     /**
      * {@inheritDoc}
      */
-    protected function getFilePath($path, $filter)
+    protected function getFilePath($path, $filter, $params = array())
     {
-        $browserPath = $this->decodeBrowserPath($this->getBrowserPath($path, $filter));
+        $browserPath = $this->decodeBrowserPath($this->getBrowserPath($path, $filter, false, $params));
 
         if (!empty($this->basePath) && 0 === strpos($browserPath, $this->basePath)) {
             $browserPath = substr($browserPath, strlen($this->basePath));

--- a/Routing/ImagineLoader.php
+++ b/Routing/ImagineLoader.php
@@ -40,6 +40,11 @@ class ImagineLoader extends Loader
                     $pattern .= '/'.$filter;
                 }
 
+                if (isset($config['route']['variables'])) {
+                    foreach ($config['route']['variables'] as $variable) {
+                        $pattern .= '/{'.$variable.'}';
+                    }
+                }
                 $defaults = array(
                     '_controller' => empty($config['controller_action']) ? $this->controllerAction : $config['controller_action'],
                     'filter' => $filter,

--- a/Templating/Helper/ImagineHelper.php
+++ b/Templating/Helper/ImagineHelper.php
@@ -31,9 +31,9 @@ class ImagineHelper extends Helper
      *
      * @return string
      */
-    public function filter($path, $filter, $absolute = false)
+    public function filter($path, $filter, $absolute = false, $params = array())
     {
-        return $this->cacheManager->getBrowserPath($path, $filter, $absolute);
+        return $this->cacheManager->getBrowserPath($path, $filter, $absolute, $params);
     }
 
     /**

--- a/Templating/ImagineExtension.php
+++ b/Templating/ImagineExtension.php
@@ -40,9 +40,9 @@ class ImagineExtension extends \Twig_Extension
      *
      * @return string
      */
-    public function filter($path, $filter, $absolute = false)
+    public function filter($path, $filter, $absolute = false, $params = array())
     {
-        return $this->cacheManager->getBrowserPath($path, $filter, $absolute);
+        return $this->cacheManager->getBrowserPath($path, $filter, $absolute, $params);
     }
 
     /**

--- a/Tests/Imagine/Cache/CacheManagerTest.php
+++ b/Tests/Imagine/Cache/CacheManagerTest.php
@@ -65,7 +65,7 @@ class CacheManagerTest extends AbstractTest
 
         $config = $this->getMockFilterConfiguration();
         $config
-            ->expects($this->once())
+            ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
             ->will($this->returnValue(array(

--- a/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
@@ -4,6 +4,7 @@ namespace Liip\ImagineBundle\Tests\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Imagine\Cache\Resolver\WebPathResolver;
 use Liip\ImagineBundle\Tests\AbstractTest;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -66,6 +67,7 @@ class WebPathResolverTest extends AbstractTest
         ;
 
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->attributes = new ParameterBag();
         $request
             ->expects($this->atLeastOnce())
             ->method('getBaseUrl')
@@ -110,6 +112,7 @@ class WebPathResolverTest extends AbstractTest
         ;
 
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->attributes = new ParameterBag();
         $request
             ->expects($this->atLeastOnce())
             ->method('getBaseUrl')
@@ -142,6 +145,7 @@ class WebPathResolverTest extends AbstractTest
         ;
 
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->attributes = new ParameterBag();
         $request
             ->expects($this->atLeastOnce())
             ->method('getBaseUrl')
@@ -174,6 +178,7 @@ class WebPathResolverTest extends AbstractTest
         ;
 
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->attributes = new ParameterBag();
         $request
             ->expects($this->atLeastOnce())
             ->method('getBaseUrl')
@@ -219,6 +224,7 @@ class WebPathResolverTest extends AbstractTest
         ;
 
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->attributes = new ParameterBag();
         $request
             ->expects($this->atLeastOnce())
             ->method('getBasePath')


### PR DESCRIPTION
This PR adds the possibility to have additional variables in the generated routes to implement dynamic filters.

I had a look at the discussion in https://github.com/liip/LiipImagineBundle/pull/42 and propose this as an alternative.

Currently there are no tests for this feature and this is only implemented in the WebPathResolver not in any of the AWS S3 resolvers.

This is also a BC break since it adds an extra parameter to ResolverInterface::getBrowserPath if you implemented your own resolver.

To use it configure the filter like this

```
    dynamic:
        route:
            variables: [width, height]
            requirements:
                width: '2\d{2}'
                height: '\d{3}' 
```

where your requirements protect you from the DDoS threat. In the template you can pass the parameters to the filter:

```
imagine_filter('dynamic', false, {'width': 240, 'height' : 120} )
```

and then you can do something useful with it in a custom controller:

```
$config = $filterConfig->get($filter);
$config['filters']['thumbnail']['size'] = array($request->get('width'), $request->get('height'));
$filterConfig->set($filter, $config);
```
