### PR TITLE
Exclude Tests directory on composer archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
             "homepage": "https://github.com/liip/LiipImagineBundle/contributors"
         }
     ],
-
+    "archive": {
+        "exclude": ["/Tests"]
+    },
     "require": {
         "php":                      ">=5.3.2",
         "imagine/Imagine":          "0.5.*",


### PR DESCRIPTION
Hi,

I got troubles when attempted to install the bundle with `composer install --dev --prefer-dist`.

When archiving sources, it throw this exception due to the cyrilic characters:

``` shell
[BadMethodCallException]
  Entry Tests/Fixtures/assets/АГГЗ.jpeg cannot be created: phar error: invalid path "Tests/Fixtures/assets/АГГЗ.jpeg" contains illegal character
```

To solve it, I [excluded the tests directory](http://getcomposer.org/doc/04-schema.md#archive) on archive creation:

``` json
"archive": {
    "exclude": ["/Tests"]
},
```

Thanks.
