### PR TITLE
handle image extensions in doctrine loader

### DIFF
--- a/Imagine/Data/Loader/AbstractDoctrineLoader.php
+++ b/Imagine/Data/Loader/AbstractDoctrineLoader.php
@@ -24,17 +24,28 @@ abstract class AbstractDoctrineLoader implements LoaderInterface
     protected $class;
 
     /**
+     * @var array
+     */
+    protected $formats;
+
+    /**
      * Constructor.
      *
      * @param ImagineInterface $imagine
      * @param ObjectManager $manager
      * @param string $class
+     * @param array $formats possible image formats to look up file ids
      */
-    public function __construct(ImagineInterface $imagine, ObjectManager $manager, $class = null)
-    {
+    public function __construct(
+        ImagineInterface $imagine,
+        ObjectManager $manager,
+        $class = null,
+        array $formats = array()
+    ) {
         $this->imagine = $imagine;
         $this->manager = $manager;
         $this->class = $class;
+        $this->formats = $formats;
     }
 
     /**
@@ -63,6 +74,24 @@ abstract class AbstractDoctrineLoader implements LoaderInterface
     public function find($path)
     {
         $image = $this->manager->find($this->class, $this->mapPathToId($path));
+
+        if (!$image) {
+            // try to find the image without extension
+            $info = pathinfo($path);
+            $name = $info['dirname'].'/'.$info['filename'];
+
+            // attempt to determine available format
+            foreach ($this->formats as $format) {
+                if ($image = $this->manager->find($this->class, $this->mapPathToId($name.'.'.$format))) {
+                    break;
+                }
+            }
+
+            // maybe the image has an id without extension
+            if (!$image) {
+                $image = $this->manager->find($this->class, $this->mapPathToId($name));
+            }
+        }
 
         if (!$image) {
             throw new NotFoundHttpException(sprintf('Source image not found with id "%s"', $path));


### PR DESCRIPTION
This is a first step towards #78 - we try to lookup an image also without file extension. this is more of a content negotiation thing than of proper  ids, so @lsmith77 and i feel it belongs here rather than for example https://github.com/symfony-cmf/MediaBundle/blob/master/Doctrine/Phpcr/MediaManager.php#L121

with this change it will become possible to at least build your image urls with a hardcoded format, e.g. use `format: jpg` in the filter definition, or put it into the output like `{{ item.image.id | imagine_filter('header_desktop') }}.jpg` 

/cc @rmsint
