### PR TITLE
[WIP][1.0][FilterManager] Filter manager drop get method. Add ability to configure at runtime.

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -65,7 +65,10 @@ class ImagineController
         $binary = $this->dataManager->find($filter, $path);
         $image = $this->imagine->load($binary->getContent());
 
-        $response = $this->filterManager->get($request, $filter, $image, $path);
+        $filteredImage = $this->filterManager->applyFilter($image, $filter, array(
+            'format' => $binary->getFormat()
+        ));
+        $response = $this->filterManager->get($request, $filter, $filteredImage, $path);
 
         return $this->cacheManager->store($response, $path, $filter);
     }

--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -140,21 +140,21 @@ class CacheManager
      */
     public function generateUrl($path, $filter, $absolute = false)
     {
-        $config = $this->filterConfig->get($filter);
+        $config = $this->filterConfig->get($filter, array(
+            'format' => pathinfo($path, PATHINFO_EXTENSION),
+        ));
 
-        if (isset($config['format'])) {
-            $pathinfo = pathinfo($path);
+        $pathinfo = pathinfo($path);
 
-            // the extension should be forced and a directory is detected
-            if ((!isset($pathinfo['extension']) || $pathinfo['extension'] !== $config['format'])
-                && isset($pathinfo['dirname'])) {
+        // the extension should be forced and a directory is detected
+        if ((!isset($pathinfo['extension']) || $pathinfo['extension'] !== $config['format'])
+            && isset($pathinfo['dirname'])) {
 
-                if ('\\' === $pathinfo['dirname']) {
-                    $pathinfo['dirname'] = '';
-                }
-
-                $path = $pathinfo['dirname'].'/'.$pathinfo['filename'].'.'.$config['format'];
+            if ('\\' === $pathinfo['dirname']) {
+                $pathinfo['dirname'] = '';
             }
+
+            $path = $pathinfo['dirname'].'/'.$pathinfo['filename'].'.'.$config['format'];
         }
 
         $params = array('path' => ltrim($path, '/'));

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -66,6 +66,7 @@
 
         <service id="liip_imagine.filter.manager" class="%liip_imagine.filter.manager.class%">
             <argument type="service" id="liip_imagine.filter.configuration" />
+            <argument type="service" id="liip_imagine" />
         </service>
 
         <service id="liip_imagine.data.manager" class="%liip_imagine.data.manager.class%">

--- a/Resources/doc/filters.md
+++ b/Resources/doc/filters.md
@@ -183,7 +183,8 @@ public function filterAction(Request $request, $path, $filter)
     $config['filters']['thumbnail']['size'] = array(300, 100);
     $filterConfig->set($filter, $config);
 
-    $response = $this->filterManager->get($request, $filter, $image, $path);
+    $filteredImage = $this->filterManager->applyFilter($image, $filter);
+    $response = $this->filterManager->get($request, $filter, $filteredImage, $path);
 
     $this->cacheManager->store($response, $path, $filter);
 

--- a/Tests/Controller/ImagineControllerTest.php
+++ b/Tests/Controller/ImagineControllerTest.php
@@ -102,7 +102,7 @@ class ImagineControllerTest extends AbstractTest
 
         $filterLoader = new ThumbnailFilterLoader();
 
-        $filterManager = new FilterManager($this->configuration);
+        $filterManager = new FilterManager($this->configuration, $this->imagine);
         $filterManager->addLoader('thumbnail', $filterLoader);
 
         $webPathResolver = new WebPathResolver($this->filesystem);
@@ -146,7 +146,7 @@ class ImagineControllerTest extends AbstractTest
         $extensionGuesser = ExtensionGuesser::getInstance();
 
         $dataManager = $this->getMock('Liip\ImagineBundle\Imagine\Data\DataManager', array(), array($mimeTypeGuesser, $extensionGuesser, $this->configuration));
-        $filterManager = $this->getMock('Liip\ImagineBundle\Imagine\Filter\FilterManager', array(), array($this->configuration));
+        $filterManager = $this->getMock('Liip\ImagineBundle\Imagine\Filter\FilterManager', array(), array($this->configuration, $this->imagine));
 
         $controller = new ImagineController($dataManager, $filterManager, $cacheManager, $this->imagine);
 

--- a/Tests/Imagine/Cache/CacheManagerTest.php
+++ b/Tests/Imagine/Cache/CacheManagerTest.php
@@ -3,6 +3,7 @@
 namespace Liip\ImagineBundle\Tests\Imagine\Cache;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -106,6 +107,7 @@ class CacheManagerTest extends AbstractTest
             ->method('get')
             ->with('thumbnail')
             ->will($this->returnValue(array(
+                'format' => 'png',
                 'size' => array(180, 180),
                 'mode' => 'outbound',
                 'cache' => null,
@@ -242,13 +244,8 @@ class CacheManagerTest extends AbstractTest
      */
     public function testGenerateUrl($filterConfig, $path, $expectedPath)
     {
-        $config = $this->getMockFilterConfiguration();
-        $config
-            ->expects($this->once())
-            ->method('get')
-            ->with('thumbnail')
-            ->will($this->returnValue($filterConfig))
-        ;
+        $config = new FilterConfiguration;
+        $config->set('thumbnail', $filterConfig);
 
         $router = $this->getMockRouter();
         $router

--- a/Tests/Imagine/Filter/FilterConfigurationTest.php
+++ b/Tests/Imagine/Filter/FilterConfigurationTest.php
@@ -10,9 +10,11 @@ use Liip\ImagineBundle\Tests\AbstractTest;
  */
 class FilterConfigurationTest extends AbstractTest
 {
-    public function testSetAndGetFilter()
+    public function testShouldGetSameConfigSetBefore()
     {
         $config = array(
+            'quality' => 85,
+            'format' => 'jpg',
             'filters' => array(
                 'thumbnail' => array(
                     'size' => array(180, 180),
@@ -28,11 +30,107 @@ class FilterConfigurationTest extends AbstractTest
         $this->assertEquals($config, $filterConfiguration->get('profile_photo'));
     }
 
+    public function testShouldSetDefaultFormatIfNotProvidedOnSet()
+    {
+        $filterConfiguration = new FilterConfiguration();
+        $filterConfiguration->set('profile_photo', array());
+
+        $actualConfig = $filterConfiguration->get('profile_photo');
+
+        $this->assertArrayHasKey('format', $actualConfig);
+        $this->assertEquals('png', $actualConfig['format']);
+    }
+
+    public function testShouldSetDefaultQualityIfNotProvidedOnSet()
+    {
+        $filterConfiguration = new FilterConfiguration();
+        $filterConfiguration->set('profile_photo', array());
+
+        $actualConfig = $filterConfiguration->get('profile_photo');
+
+        $this->assertArrayHasKey('quality', $actualConfig);
+        $this->assertEquals(100, $actualConfig['quality']);
+    }
+
+    public function testShouldSetDefaultEmptyFiltersArrayIfNotProvidedOnSet()
+    {
+        $filterConfiguration = new FilterConfiguration();
+        $filterConfiguration->set('profile_photo', array());
+
+        $actualConfig = $filterConfiguration->get('profile_photo');
+
+        $this->assertArrayHasKey('filters', $actualConfig);
+        $this->assertEquals(array(), $actualConfig['filters']);
+    }
+
     public function testGetUndefinedFilter()
     {
         $filterConfiguration = new FilterConfiguration();
 
-        $this->setExpectedException('RuntimeException', 'Filter not defined: thumbnail');
+        $this->setExpectedException('RuntimeException', 'Could not find configuration for a filter: thumbnail');
         $filterConfiguration->get('thumbnail');
+    }
+
+    public function testGetConfigSetViaConstructor()
+    {
+        $filterConfiguration = new FilterConfiguration(array(
+            'profile_photo' => array(),
+            'thumbnail' => array(),
+        ));
+
+        $this->assertInternalType('array', $filterConfiguration->get('profile_photo'));
+        $this->assertInternalType('array', $filterConfiguration->get('thumbnail'));
+    }
+
+    public function testMergeDefaultAndRuntimeConfigOnGet()
+    {
+        $defaultConfig = array(
+            'filters' => array(
+                'thumbnail' => array(
+                    'size' => array(180, 180),
+                    'mode' => 'outbound',
+                ),
+            ),
+            'cache' => 'web_path',
+        );
+
+        $runtimeConfig = array(
+            'quality' => 85,
+            'format' => 'jpg',
+        );
+
+        $expectedConfig = array(
+            'quality' => 85,
+            'format' => 'jpg',
+            'filters' => array(
+                'thumbnail' => array(
+                    'size' => array(180, 180),
+                    'mode' => 'outbound',
+                ),
+            ),
+            'cache' => 'web_path',
+        );
+
+        $filterConfiguration = new FilterConfiguration();
+        $filterConfiguration->set('profile_photo', $defaultConfig);
+
+        $this->assertEquals($expectedConfig, $filterConfiguration->get('profile_photo', $runtimeConfig));
+    }
+
+    public function testShouldNotOverwriteDefaultFormatByRuntimeOneOnGet()
+    {
+        $defaultConfig = array(
+            'format' => 'jpg',
+        );
+
+        $runtimeConfig = array(
+            'format' => 'gif',
+        );
+
+        $filterConfiguration = new FilterConfiguration();
+        $filterConfiguration->set('profile_photo', $defaultConfig);
+
+        $config = $filterConfiguration->get('profile_photo', $runtimeConfig);
+        $this->assertEquals('jpg', $config['format']);
     }
 }

--- a/Tests/Imagine/Filter/FilterManagerTest.php
+++ b/Tests/Imagine/Filter/FilterManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Liip\ImagineBundle\Tests\Filter;
 
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
 use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\HttpFoundation\Request;
@@ -11,213 +12,260 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class FilterManagerTest extends AbstractTest
 {
-    public function testGetWithoutLoader()
+    public function testUseDefaultConfigOnApplyFilter()
     {
-        $config = $this->getMockFilterConfiguration();
-        $config
-            ->expects($this->atLeastOnce())
-            ->method('get')
-            ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
-                    'thumbnail' => array(
-                        'size' => array(180, 180),
-                        'mode' => 'outbound',
-                    ),
-                ),
-            )))
-        ;
-        $filterManager = new FilterManager($config);
-
-        $this->setExpectedException('InvalidArgumentException', 'Could not find filter loader for "thumbnail" filter type');
-        $filterManager->get(new Request(), 'thumbnail', $this->getMockImage(), 'cats.jpeg');
-    }
-
-    public function testGetDefaultBehavior()
-    {
-        $thumbConfig = array(
-            'size' => array(180, 180),
-            'mode' => 'outbound',
-        );
-
-        $config = $this->getMockFilterConfiguration();
-        $config
-            ->expects($this->atLeastOnce())
-            ->method('get')
-            ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
-                    'thumbnail' => $thumbConfig,
-                ),
-            )))
-        ;
+        $config = new FilterConfiguration(array(
+            'thumbnail' => array(
+                'format' => 'png',
+                'quantity' => 100,
+            )
+        ));
 
         $image = $this->getMockImage();
         $image
             ->expects($this->once())
             ->method('get')
-            ->with('jpeg', array('quality' => 100))
-            ->will($this->returnSelf())
+            ->with('png', array('quality' => 100))
+            ->will($this->returnValue('aBinaryContent'))
         ;
 
-        $loader = $this->getMockLoader();
-        $loader
-            ->expects($this->once())
-            ->method('load')
-            ->with($image, $thumbConfig)
-            ->will($this->returnValue($image))
-        ;
+        $filterManager = new FilterManager($config, $this->getMockImagine());
 
-        $filterManager = new FilterManager($config);
-        $filterManager->addLoader('thumbnail', $loader);
-
-        $request = new Request();
-        $response = $filterManager->get($request, 'thumbnail', $image, $this->fixturesDir.'/assets/cats.jpeg');
-
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('image/jpeg', $response->headers->get('Content-Type'));
+        $filterManager->applyFilter($image, 'thumbnail');
     }
 
-    public function testGetConfigAltersFormatAndQuality()
+    public function testUseRuntimeConfigOnApplyFilter()
     {
-        $thumbConfig = array(
-            'size' => array(180, 180),
-            'mode' => 'outbound',
-        );
-
-        $config = $this->getMockFilterConfiguration();
-        $config
-            ->expects($this->atLeastOnce())
-            ->method('get')
-            ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
-                    'thumbnail' => $thumbConfig,
-                ),
-                'format' => 'jpg',
-                'quality' => 80,
-            )))
-        ;
+        $config = new FilterConfiguration(array(
+            'thumbnail' => array()
+        ));
 
         $image = $this->getMockImage();
         $image
             ->expects($this->once())
             ->method('get')
-            ->with('jpg', array('quality' => 80))
-            ->will($this->returnSelf())
+            ->with('jpg', array('quality' => 70))
+            ->will($this->returnValue('aBinaryContent'))
         ;
 
-        $loader = $this->getMockLoader();
-        $loader
-            ->expects($this->once())
-            ->method('load')
-            ->with($image, $thumbConfig)
-            ->will($this->returnValue($image))
-        ;
+        $filterManager = new FilterManager($config, $this->getMockImagine());
 
-        $filterManager = new FilterManager($config);
-        $filterManager->addLoader('thumbnail', $loader);
-
-        $request = new Request();
-        $response = $filterManager->get($request, 'thumbnail', $image, $this->fixturesDir.'/assets/cats.jpeg');
-
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('image/jpg', $response->headers->get('Content-Type'));
+        $filterManager->applyFilter($image, 'thumbnail', array(
+            'format' => 'jpg',
+            'quality' => 70,
+        ));
     }
 
-    public function testGetRequestKnowsContentType()
+    public function testMergeDefaultAndRuntimeConfigOnApplyFilter()
     {
-        $thumbConfig = array(
-            'size' => array(180, 180),
-            'mode' => 'outbound',
-        );
-
-        $config = $this->getMockFilterConfiguration();
-        $config
-            ->expects($this->atLeastOnce())
-            ->method('get')
-            ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
-                    'thumbnail' => $thumbConfig,
-                ),
-                'format' => 'jpg',
-            )))
-        ;
+        $config = new FilterConfiguration(array(
+            'thumbnail' => array(
+                'quality' => 70,
+                'format' => 'gif',
+            )
+        ));
 
         $image = $this->getMockImage();
         $image
             ->expects($this->once())
             ->method('get')
-            ->with('jpg', array('quality' => 100))
-            ->will($this->returnSelf())
+            ->with('gif', array('quality' => 50))
+            ->will($this->returnValue('aBinaryContent'))
         ;
 
-        $loader = $this->getMockLoader();
-        $loader
-            ->expects($this->once())
-            ->method('load')
-            ->with($image, $thumbConfig)
-            ->will($this->returnValue($image))
-        ;
+        $filterManager = new FilterManager($config, $this->getMockImagine());
 
-        $filterManager = new FilterManager($config);
-        $filterManager->addLoader('thumbnail', $loader);
-
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $request
-            ->expects($this->once())
-            ->method('getMimeType')
-            ->with('jpg')
-            ->will($this->returnValue('image/jpeg'))
-        ;
-
-        $response = $filterManager->get($request, 'thumbnail', $image, $this->fixturesDir.'/assets/cats.jpeg');
-
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('image/jpeg', $response->headers->get('Content-Type'));
+        $filterManager->applyFilter($image, 'thumbnail', array(
+            'quality' => 50,
+        ));
     }
 
-    public function testApplyFilterSet()
+    public function testUseDefaultFilterConfigOnApplyFilter()
     {
-        $image = $this->getMockImage();
-
-        $thumbConfig = array(
-            'size' => array(180, 180),
-            'mode' => 'outbound',
+        $filterConfig = array(
+            'foo' => 'fooVal',
+            'bar' => 'barVal',
         );
 
-        $config = $this->getMockFilterConfiguration();
-        $config
-            ->expects($this->atLeastOnce())
-            ->method('get')
-            ->with('thumbnail')
-            ->will($this->returnValue(array(
+        $config = new FilterConfiguration(array(
+            'thumbnail' => array(
                 'filters' => array(
-                    'thumbnail' => $thumbConfig,
-                ),
-            )))
+                    'theFilter' => $filterConfig
+                )
+            )
+        ));
+
+        $image = $this->getMockImage();
+        $image
+            ->expects($this->once())
+            ->method('get')
+            ->with('png', array('quality' => 100))
+            ->will($this->returnValue('aBinaryContent'))
         ;
 
         $loader = $this->getMockLoader();
         $loader
             ->expects($this->once())
             ->method('load')
-            ->with($image, $thumbConfig)
+            ->with($this->identicalTo($image), $filterConfig)
             ->will($this->returnValue($image))
         ;
 
-        $filterManager = new FilterManager($config);
-        $filterManager->addLoader('thumbnail', $loader);
+        $filterManager = new FilterManager($config, $this->getMockImagine());
+        $filterManager->addLoader('theFilter', $loader);
 
-        $this->assertSame($image, $filterManager->applyFilter($image, 'thumbnail'));
+        $filterManager->applyFilter($image, 'thumbnail');
+    }
+
+    public function testUseCustomFilterConfigOnApplyFilter()
+    {
+        $filterConfig = array(
+            'foo' => 'fooVal',
+            'bar' => 'barVal',
+        );
+
+        $config = new FilterConfiguration(array(
+            'thumbnail' => array(
+                'filters' => array()
+            )
+        ));
+
+        $image = $this->getMockImage();
+        $image
+            ->expects($this->once())
+            ->method('get')
+            ->with('png', array('quality' => 100))
+            ->will($this->returnValue('aBinaryContent'))
+        ;
+
+        $loader = $this->getMockLoader();
+        $loader
+            ->expects($this->once())
+            ->method('load')
+            ->with($this->identicalTo($image), $filterConfig)
+            ->will($this->returnValue($image))
+        ;
+
+        $filterManager = new FilterManager($config, $this->getMockImagine());
+        $filterManager->addLoader('theFilter', $loader);
+
+        $filterManager->applyFilter($image, 'thumbnail', array(
+            'filters' => array(
+                'theFilter' => $filterConfig
+            ),
+        ));
+    }
+
+    public function testMergeDefaultAndCustomFilterConfigOnApplyFilter()
+    {
+        $filterConfig = array(
+            'foo' => 'fooVal',
+            'bar' => 'barDefaultVal',
+        );
+
+        $config = new FilterConfiguration(array(
+            'thumbnail' => array(
+                'filters' => array(
+                    'theFilter' => $filterConfig
+                )
+            )
+        ));
+
+        $image = $this->getMockImage();
+        $image
+            ->expects($this->once())
+            ->method('get')
+            ->with('png', array('quality' => 100))
+        ;
+
+        $loader = $this->getMockLoader();
+        $loader
+            ->expects($this->once())
+            ->method('load')
+            ->with($this->identicalTo($image), array(
+                'foo' => 'fooVal',
+                'bar' => 'barCustomVal'
+            ))
+            ->will($this->returnValue($image))
+        ;
+
+        $filterManager = new FilterManager($config, $this->getMockImagine());
+        $filterManager->addLoader('theFilter', $loader);
+
+        $filterManager->applyFilter($image, 'thumbnail', array(
+            'filters' => array(
+                'theFilter' => array(
+                    'bar' => 'barCustomVal'
+                )
+            ),
+        ));
+    }
+
+    public function testExecuteAllConfiguredFiltersOnApplyFilter()
+    {
+        $config = new FilterConfiguration(array(
+            'thumbnail' => array(
+                'filters' => array(
+                    'firstFilter' => array(),
+                    'secondFilter' => array(),
+                )
+            )
+        ));
+
+        $image = $this->getMockImage();
+        $image
+            ->expects($this->once())
+            ->method('get')
+            ->with('png', array('quality' => 100))
+            ->will($this->returnValue('aBinaryContent'))
+        ;
+
+        $firstLoader = $this->getMockLoader();
+        $firstLoader
+            ->expects($this->once())
+            ->method('load')
+            ->with($this->identicalTo($image), array())
+            ->will($this->returnValue($image))
+        ;
+
+        $secondLoader = $this->getMockLoader();
+        $secondLoader
+            ->expects($this->once())
+            ->method('load')
+            ->with($this->identicalTo($image), array())
+            ->will($this->returnValue($image))
+        ;
+
+        $filterManager = new FilterManager($config, $this->getMockImagine());
+        $filterManager->addLoader('firstFilter', $firstLoader);
+        $filterManager->addLoader('secondFilter', $secondLoader);
+
+        $filterManager->applyFilter($image, 'thumbnail');
+    }
+
+    public function testThrowsIfRequiredFilterWasNotAddedOnApplyFilter()
+    {
+        $config = new FilterConfiguration(array(
+            'thumbnail' => array(
+                'filters' => array(
+                    'theFilter' => array(),
+                )
+            )
+        ));
+
+        $filterManager = new FilterManager($config, $this->getMockImagine());
+
+        $this->setExpectedException('InvalidArgumentException', 'Could not find filter loader for "theFilter" filter type');
+        $filterManager->applyFilter($this->getMockImage(), 'thumbnail');
     }
 
     protected function getMockLoader()
     {
         return $this->getMock('Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
+    }
+
+    protected function getMockImagine()
+    {
+        return $this->getMock('Imagine\Image\ImagineInterface');
     }
 }

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,14 @@ Upgrade
 * [CacheResolver] Now resolve method has to return the url of the image.
 * [CacheResolver] New `isStored` method was added.
 * [CacheResolver] The method `getBrowserPath` was removed.
+* [CacheResolver] `store` signature was changed. Now it requires `$path`, before it was `$targetPath`.
+* [FilterManager] Method `get` was removed.
+* [FilterManager] New, third parameter `config` was added to `applyFilter` method. It allows to change config in runtime.
+* [FilterConfiguration] Set method does not return a config anymore.
+* [FilterConfiguration] Allow set an empty filter config.
+* [FilterConfiguration] Set default `quality` option if not configured equal to 100.
+* [FilterConfiguration] Set default `format` option if not configured equal to NULL.
+* [FilterConfiguration] Set default `filters` option if not configured equal to empty array.
+* [Logger] Symfony `LoggerInterface` was replaced with PSR-3 one.
 * [DataLoader] `LoaderInterface::find` now can return string or `BinaryInterface` instance.
 * [DataLoader] `DataManager::find` now can return `BinaryInterface` instance only.
-* [Logger] Symfony `LoggerInterface` was replaced with PSR-3 one.


### PR DESCRIPTION
It is based on https://github.com/liip/LiipImagineBundle/pull/284 PR so please consider reviewing and merging that one first.

To say briefly about changes done and future:
- Remove FilterManger::get method
- Extend FilterConfiguration to support runtime configuration feature.
- Use `Image` instance in CacheResolver::store method instead of Response.
- CacheResolver::store must not return anything.
- ...
