### PR TITLE
added background_image filter

### DIFF
--- a/Imagine/Filter/Loader/BackgroundFilterLoader.php
+++ b/Imagine/Filter/Loader/BackgroundFilterLoader.php
@@ -1,6 +1,7 @@
 <?php
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
+use Imagine\Image\Box;
 use Imagine\Image\Color;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
@@ -20,7 +21,16 @@ class BackgroundFilterLoader implements LoaderInterface
     {
         $background = new Color(isset($options['color']) ? $options['color'] : '#fff');
         $topLeft = new Point(0, 0);
-        $canvas = $this->imagine->create($image->getSize(), $background);
+        $size = $image->getSize();
+
+        if (isset($options['size'])) {
+            list($width, $height) = $options['size'];
+
+            $size = new Box($width, $height);
+            $topLeft = new Point(($width - $image->getSize()->getWidth()) / 2, ($height - $image->getSize()->getHeight()) / 2);
+        }
+
+        $canvas = $this->imagine->create($size, $background);
 
         return $canvas->paste($image, $topLeft);
     }

--- a/Resources/doc/filters.md
+++ b/Resources/doc/filters.md
@@ -107,6 +107,16 @@ liip_imagine:
                 background: { color: '#00FFFF' }
 ```
 
+If you provide a `size` it will create a new image (this size and given color), and apply the original image on top:
+
+``` yaml
+liip_imagine:
+    filter_sets:
+        my_thumb:
+            filters:
+                background: { size: [1026, 684], color: '#fff' }
+```
+
 ### The `watermark` filter
 
 The watermark filter pastes a second image onto your image while keeping its ratio.


### PR DESCRIPTION
tweaked the background filter:
### The `background` filter

The background filter can now create a background-image with dimensions and color, default is white (#FFF). where you can put other images/filters ontop

Configuration looks like this:

``` yaml
liip_imagine:
    filter_sets:
        my_thumb:
            filters:
                background: { size: [1026, 684], color: '#fff' }
```
