### PR TITLE
GridFSLoader Bug

### DIFF
--- a/Imagine/Data/Loader/GridFSLoader.php
+++ b/Imagine/Data/Loader/GridFSLoader.php
@@ -44,14 +44,12 @@ class GridFSLoader implements LoaderInterface
     {
         $image = $this->dm
             ->getRepository($this->class)
-            ->findAll()
-            ->getCollection()
-            ->findOne(array("_id" => new \MongoId($id)));
+            ->find(new \MongoId($id));
 
         if (!$image) {
             throw new NotFoundHttpException(sprintf('Source image not found with id "%s"', $id));
         }
 
-        return $this->imagine->load($image['file']->getBytes());
+        return $this->imagine->load($image->getFile()->getBytes());
     }
 }


### PR DESCRIPTION
Modified the way to access the actual image since an update to the latest vendors brought up the following issue:

```
Fatal error: Call to a member function getCollection() on a non-object in /vendor/liip/imagine-bundle/Liip/ImagineBundle/Imagine/Data/Loader/GridFSLoader.php on line 48
```

Tickets:
- Fixes liip/LiipImagineBundle#305
