### PR TITLE
[1.0][WebResolver] Use baseUrl and port while generating image path.

### DIFF
--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -120,19 +120,31 @@ class WebPathResolver implements ResolverInterface
         return $this->cachePrefix.'/'.$filter.'/'.$path;
     }
 
-    protected function getBaseurl()
+    /**
+     * @return string
+     */
+    protected function getBaseUrl()
     {
-        if ($this->requestContext->getScheme() == 'http') {
-            $port = $this->requestContext->getHttpPort() != 80 ? ':'.$this->requestContext->getHttpPort() : '';
-        } else {
-            $port = $this->requestContext->getHttpsPort() != 443 ? ':'.$this->requestContext->getHttpsPort() : '';
+        $port = '';
+        if ('https' == $this->requestContext->getScheme() && $this->requestContext->getHttpsPort() != 443) {
+            $port =  ":{$this->requestContext->getHttpsPort()}";
         }
-        $pathinfo = pathinfo($this->requestContext->getBaseurl());
-        $subpath = $pathinfo['dirname'] != '/' ? $pathinfo['dirname'] : '';
-        return sprintf('%s://%s',
+
+        if ('http' == $this->requestContext->getScheme() && $this->requestContext->getHttpPort() != 80) {
+            $port =  ":{$this->requestContext->getHttpPort()}";
+        }
+
+        $baseUrl = $this->requestContext->getBaseUrl();
+        if ('.php' == substr($this->requestContext->getBaseUrl(), -4)) {
+            $baseUrl = pathinfo($this->requestContext->getBaseurl(), PATHINFO_DIRNAME);
+        }
+        $baseUrl = rtrim($baseUrl, '/');
+
+        return sprintf('%s://%s%s%s',
             $this->requestContext->getScheme(),
-            $this->requestContext->getHost().$port.$subpath
+            $this->requestContext->getHost(),
+            $port,
+            $baseUrl
         );
     }
 }
-

--- a/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
@@ -152,6 +152,86 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testComposeSchemaHostAndBasePathWithPhpFileAndFileUrlOnResolve()
+    {
+        $requestContext = new RequestContext;
+        $requestContext->setScheme('theSchema');
+        $requestContext->setHost('theHost');
+        $requestContext->setBaseUrl('/theBasePath/app.php');
+
+        $resolver = new WebPathResolver(
+            $this->createFilesystemMock(),
+            $requestContext,
+            '/aWebRoot',
+            'aCachePrefix'
+        );
+
+        $this->assertEquals(
+            'theschema://theHost/theBasePath/aCachePrefix/aFilter/aPath',
+            $resolver->resolve('aPath', 'aFilter')
+        );
+    }
+
+    public function testComposeSchemaHostAndBasePathWithDirsOnlyAndFileUrlOnResolve()
+    {
+        $requestContext = new RequestContext;
+        $requestContext->setScheme('theSchema');
+        $requestContext->setHost('theHost');
+        $requestContext->setBaseUrl('/theBasePath/theSubBasePath');
+
+        $resolver = new WebPathResolver(
+            $this->createFilesystemMock(),
+            $requestContext,
+            '/aWebRoot',
+            'aCachePrefix'
+        );
+
+        $this->assertEquals(
+            'theschema://theHost/theBasePath/theSubBasePath/aCachePrefix/aFilter/aPath',
+            $resolver->resolve('aPath', 'aFilter')
+        );
+    }
+
+    public function testComposeSchemaHttpAndCustomPortAndFileUrlOnResolve()
+    {
+        $requestContext = new RequestContext;
+        $requestContext->setScheme('http');
+        $requestContext->setHost('theHost');
+        $requestContext->setHttpPort(88);
+
+        $resolver = new WebPathResolver(
+            $this->createFilesystemMock(),
+            $requestContext,
+            '/aWebRoot',
+            'aCachePrefix'
+        );
+
+        $this->assertEquals(
+            'http://theHost:88/aCachePrefix/aFilter/aPath',
+            $resolver->resolve('aPath', 'aFilter')
+        );
+    }
+
+    public function testComposeSchemaHttpsAndCustomPortAndFileUrlOnResolve()
+    {
+        $requestContext = new RequestContext;
+        $requestContext->setScheme('https');
+        $requestContext->setHost('theHost');
+        $requestContext->setHttpsPort(444);
+
+        $resolver = new WebPathResolver(
+            $this->createFilesystemMock(),
+            $requestContext,
+            '/aWebRoot',
+            'aCachePrefix'
+        );
+
+        $this->assertEquals(
+            'https://theHost:444/aCachePrefix/aFilter/aPath',
+            $resolver->resolve('aPath', 'aFilter')
+        );
+    }
+
     public function testDumpBinaryContentOnStore()
     {
         $binary = new Binary('theContent', 'aMimeType', 'aFormat');


### PR DESCRIPTION
This PR was based on https://github.com/liip/LiipImagineBundle/pull/353 with some additions and tests. 

It has to fix https://github.com/liip/LiipImagineBundle/issues/361, https://github.com/liip/LiipImagineBundle/issues/360, https://github.com/liip/LiipImagineBundle/issues/352, https://github.com/liip/LiipImagineBundle/issues/349
