### PR TITLE
No redirect option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -103,6 +103,7 @@ class Configuration implements ConfigurationInterface
                         ->thenInvalid('Invalid imagine driver specified: %s')
                     ->end()
                 ->end()
+                ->scalarNode('redirect')->defaultValue(false)->end()
                 ->scalarNode('cache')->defaultValue('default')->end()
                 ->scalarNode('cache_base_path')->defaultValue('')->end()
                 ->scalarNode('data_loader')->defaultValue('default')->end()

--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -70,6 +70,8 @@ class LiipImagineExtension extends Extension
         $container->setParameter('liip_imagine.controller.filter_action', $config['controller']['filter_action']);
         $container->setParameter('liip_imagine.controller.filter_runtime_action', $config['controller']['filter_runtime_action']);
 
+        $container->setParameter('liip_imagine.controller.redirect', $config['redirect']);
+
         $resources = $container->hasParameter('twig.form.resources') ? $container->getParameter('twig.form.resources') : array();
         $resources[] = 'LiipImagineBundle:Form:form_div_layout.html.twig';
         $container->setParameter('twig.form.resources', $resources);

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -97,6 +97,7 @@
             <argument type="service" id="liip_imagine.filter.manager" />
             <argument type="service" id="liip_imagine.cache.manager" />
             <argument type="service" id="liip_imagine.cache.signer" />
+            <argument>%liip_imagine.controller.redirect%</argument>
         </service>
 
         <service id="liip_imagine.meta_data.reader" class="%liip_imagine.meta_data.reader.class%" public="false" />


### PR DESCRIPTION
This partially fixes #429. I know that tests are failing, but I need some help to setup tests on OS X. 

``` php
<?php
// LiipImagineBundle/Tests/Functional/Controller/ImagineControllerTest.php
$this->webRoot = self::$kernel->getContainer()->getParameter('kernel.root_dir').'/web';
$this->cacheRoot = $this->webRoot.'/media/cache';
$this->filesystem = new Filesystem;
$this->filesystem->remove($this->cacheRoot);
```

This generates path to unexisting folder, maybe some one can give me some points?
