### PR TITLE
pass transparency value to Imagine\Image\Color in background filter

### DIFF
--- a/Imagine/Filter/Loader/BackgroundFilterLoader.php
+++ b/Imagine/Filter/Loader/BackgroundFilterLoader.php
@@ -19,7 +19,7 @@ class BackgroundFilterLoader implements LoaderInterface
      */
     public function load(ImageInterface $image, array $options = array())
     {
-        $background = new Color(isset($options['color']) ? $options['color'] : '#fff', isset($options['transparency']) ? $options['transparency'] : 100);
+        $background = new Color(isset($options['color']) ? $options['color'] : '#fff', isset($options['transparency']) ? $options['transparency'] : 0);
         $topLeft = new Point(0, 0);
         $size = $image->getSize();
 


### PR DESCRIPTION
This allows to generate images composited to a (partly) transparent background. It defaults to 0 which is the default value from Imagine\Image\Color, so this is not bc breaking.

update:
changed default value
