### PR TITLE
fix auto rotate

### DIFF
--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -8,6 +8,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class LiipImagineExtension extends Extension
@@ -62,12 +63,13 @@ class LiipImagineExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('imagine.xml');
 
-        $container->setAlias('liip_imagine', new Alias('liip_imagine.'.$config['driver']));
-
-        if (!class_exists('Imagine\Image\Metadata\MetadataReaderInterface')) {
-            $container->getDefinition('liip_imagine.'.$config['driver'])->removeMethodCall('setMetadataReader');
+        if (interface_exists('Imagine\Image\Metadata\MetadataReaderInterface')) {
+            $container->getDefinition('liip_imagine.'.$config['driver'])->addMethodCall('setMetadataReader', array(new Reference('liip_imagine.meta_data.reader')));
+        } else {
             $container->removeDefinition('liip_imagine.meta_data.reader');
         }
+
+        $container->setAlias('liip_imagine', new Alias('liip_imagine.'.$config['driver']));
 
         $container->setParameter('liip_imagine.cache.resolver.default', $config['cache']);
 

--- a/Imagine/Filter/Loader/AutoRotateFilterLoader.php
+++ b/Imagine/Filter/Loader/AutoRotateFilterLoader.php
@@ -11,6 +11,12 @@ use Imagine\Image\ImageInterface;
  */
 class AutoRotateFilterLoader implements LoaderInterface
 {
+
+    protected $orientationKeys = array(
+        'exif.Orientation',
+        'ifd0.Orientation'
+    );
+
     /**
      * {@inheritDoc}
      */
@@ -61,7 +67,15 @@ class AutoRotateFilterLoader implements LoaderInterface
     {
         //>0.6 imagine meta data interface
         if (method_exists($image, 'metadata')) {
-            return $image->metadata()->offsetGet('exif.Orientation');
+            foreach ($this->orientationKeys as $orientationKey) {
+                $orientation = $image->metadata()->offsetGet($orientationKey);
+
+                if ($orientation) {
+                    return $orientation;
+                }
+            }
+
+            return null;
         } else {
             $data = exif_read_data("data://image/jpeg;base64," . base64_encode($image->get('jpg')));
             return isset($data['Orientation']) ? $data['Orientation'] : null;

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -103,9 +103,7 @@
 
         <!-- ImagineInterface instances -->
 
-        <service id="liip_imagine" alias="liip_imagine.gd">
-            <call method="setMetadataReader"><argument type="service" id="liip_imagine.meta_data.reader" /></call>
-        </service>
+        <service id="liip_imagine" alias="liip_imagine.gd" />
 
         <service id="liip_imagine.gd" class="%liip_imagine.gd.class%" public="false" />
 


### PR DESCRIPTION
I faced 2 problems getting the images rotated correctly when directly uploaded by my iphone (reported from other phones like android too).
1. The method call defined in `imagine.xml` on the `liip_imagine` alias did not work. When compiling the DI there were no added method call.
2. The picture form my iphone hat the orientation saved under the key `ifd0.Orientatio` and not as hardcoded under `exif.Orientation`

With the provided solution my directly uploaded pictures get autorotated correctly.
