### PR TITLE
Fix crash when no post processor is defined

### DIFF
--- a/Imagine/Filter/FilterManager.php
+++ b/Imagine/Filter/FilterManager.php
@@ -141,6 +141,7 @@ class FilterManager
      */
     public function applyPostProcessors(BinaryInterface $binary, $config)
     {
+        $config += array('post_processors' => array());
         foreach ($config['post_processors'] as $postProcessorName => $postProcessorOptions) {
             if (!isset($this->postProcessors[$postProcessorName])) {
                 throw new \InvalidArgumentException(sprintf(

--- a/Tests/Imagine/Filter/FilterManagerTest.php
+++ b/Tests/Imagine/Filter/FilterManagerTest.php
@@ -1098,6 +1098,18 @@ class FilterManagerTest extends AbstractTest
         $filterManager->applyFilter($binary, 'thumbnail');
     }
 
+    public function testApplyPostProcessorsWhenNotDefined()
+    {
+        $binary = $this->getMock('Liip\ImagineBundle\Binary\BinaryInterface');
+        $filterManager = new FilterManager(
+            $this->createFilterConfigurationMock(),
+            $this->createImagineMock(),
+            $this->getMockMimeTypeGuesser()
+        );
+
+        $this->assertSame($binary, $filterManager->applyPostProcessors($binary, array()));
+    }
+
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|LoaderInterface
      */


### PR DESCRIPTION
Exception:

> ContextErrorException: Notice: Undefined index: post_processors in /var/www/foo/vendor/liip/imagine-bundle/Liip/ImagineBundle/Imagine/Filter/FilterManager.php line 144

This happens in eZ Publish, where post processors are not (yet) supported.

Ping @crevillo
