### PR TITLE
Catch more exceptions in stream loader to throw NotLoadableException

### DIFF
--- a/Binary/Loader/StreamLoader.php
+++ b/Binary/Loader/StreamLoader.php
@@ -53,12 +53,16 @@ class StreamLoader implements LoaderInterface
              * file_exists() is not used as not all wrappers support stat() to actually check for existing resources.
              */
             if (($this->context && !$resource = @fopen($name, 'r', null, $this->context)) || !$resource = @fopen($name, 'r')) {
-                throw new NotLoadableException(sprintf('Source image %s not found.', $name));
+                throw new \Exception();
             }
 
             // Closing the opened stream to avoid locking of the resource to find.
             fclose($resource);
+        } catch (\Exception $e) {
+            throw new NotLoadableException(sprintf('Source image %s not found.', $name));
+        }
 
+        try {
             $content = file_get_contents($name, null, $this->context);
         } catch (\Exception $e) {
             throw new NotLoadableException(sprintf('Source image %s could not be loaded.', $name, $e));

--- a/Binary/Loader/StreamLoader.php
+++ b/Binary/Loader/StreamLoader.php
@@ -44,21 +44,21 @@ class StreamLoader implements LoaderInterface
     {
         $name = $this->wrapperPrefix.$path;
 
-        /*
-         * This looks strange, but at least in PHP 5.3.8 it will raise an E_WARNING if the 4th parameter is null.
-         * fopen() will be called only once with the correct arguments.
-         *
-         * The error suppression is solely to determine whether the file exists.
-         * file_exists() is not used as not all wrappers support stat() to actually check for existing resources.
-         */
-        if (($this->context && !$resource = @fopen($name, 'r', null, $this->context)) || !$resource = @fopen($name, 'r')) {
-            throw new NotLoadableException(sprintf('Source image %s not found.', $name));
-        }
-
-        // Closing the opened stream to avoid locking of the resource to find.
-        fclose($resource);
-
         try {
+            /*
+             * This looks strange, but at least in PHP 5.3.8 it will raise an E_WARNING if the 4th parameter is null.
+             * fopen() will be called only once with the correct arguments.
+             *
+             * The error suppression is solely to determine whether the file exists.
+             * file_exists() is not used as not all wrappers support stat() to actually check for existing resources.
+             */
+            if (($this->context && !$resource = @fopen($name, 'r', null, $this->context)) || !$resource = @fopen($name, 'r')) {
+                throw new NotLoadableException(sprintf('Source image %s not found.', $name));
+            }
+
+            // Closing the opened stream to avoid locking of the resource to find.
+            fclose($resource);
+
             $content = file_get_contents($name, null, $this->context);
         } catch (\Exception $e) {
             throw new NotLoadableException(sprintf('Source image %s could not be loaded.', $name, $e));


### PR DESCRIPTION
I use Stream Loader with AWS SDK S3 stream wrapper (`s3://...`) and it does not catch S3Exception thrown by the wrapper on fopen function when the desired file does not exist on S3. The `try..catch` block captures `\Exception` only on `file_get_contents` which is too late. See the stack trace below.

```

  [Aws\S3\Exception\S3Exception]
  Error executing Aws\S3\S3Client::getObject() on ""; String could not be parsed as XML

Exception trace:
...
...
...
 Aws\Common\AwsClient->execute() at /var/www/xxx/vendor/aws/aws-sdk-php/src/S3/StreamWrapper.php:610
 Aws\S3\StreamWrapper->openReadStream() at /var/www/xxx/vendor/aws/aws-sdk-php/src/S3/StreamWrapper.php:125
 Aws\S3\StreamWrapper->stream_open() at n/a:n/a
 fopen() at /var/www/xxx/vendor/liip/imagine-bundle/Liip/ImagineBundle/Binary/Loader/StreamLoader.php:54
 Liip\ImagineBundle\Binary\Loader\StreamLoader->find() at /var/www/xxx/vendor/liip/imagine-bundle/Liip/ImagineBundle/Imagine/Data/DataManager.php:118
 Liip\ImagineBundle\Imagine\Data\DataManager->find() at /var/www/xxx/vendor/liip/imagine-bundle/Liip/ImagineBundle/Command/ResolveCacheCommand.php:71
 Liip\ImagineBundle\Command\ResolveCacheCommand->execute() at /var/www/xxx/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:252
 Symfony\Component\Console\Command\Command->run() at /var/www/xxx/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:882
 Symfony\Component\Console\Application->doRunCommand() at /var/www/xxx/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:195
 Symfony\Component\Console\Application->doRun() at /var/www/xxx/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:96
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /var/www/xxx/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:126
 Symfony\Component\Console\Application->run() at /var/www/xxx/bin/console:21
```

This PR tries to address this problem by wrapping more lines in `try..catch` block in `StreamLoader::find` to trigger `NotLoadableException`, like below:

```

  [Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException]
  Source image s3://mybucket/test/image2.jpg not found.

Exception trace:
 () at /var/www/xxx/vendor/liip/imagine-bundle/Liip/ImagineBundle/Binary/Loader/StreamLoader.php:71
 Liip\ImagineBundle\Binary\Loader\StreamLoader->find() at /var/www/xxx/vendor/liip/imagine-bundle/Liip/ImagineBundle/Imagine/Data/DataManager.php:118
 Liip\ImagineBundle\Imagine\Data\DataManager->find() at /var/www/xxx/vendor/liip/imagine-bundle/Liip/ImagineBundle/Command/ResolveCacheCommand.php:71
 Liip\ImagineBundle\Command\ResolveCacheCommand->execute() at /var/www/xxx/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:252
 Symfony\Component\Console\Command\Command->run() at /var/www/xxx/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:882
 Symfony\Component\Console\Application->doRunCommand() at /var/www/xxx/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:195
 Symfony\Component\Console\Application->doRun() at /var/www/xxx/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:96
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /var/www/xxx/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:126
 Symfony\Component\Console\Application->run() at /var/www/xxx/bin/console:21
```