### PR TITLE
fix invalid in_array

### DIFF
--- a/Imagine/Cache/Resolver/CacheResolver.php
+++ b/Imagine/Cache/Resolver/CacheResolver.php
@@ -200,11 +200,9 @@ class CacheResolver implements ResolverInterface
         // Create or update the index list containing all cache keys for a given image and filter pairing.
         $indexKey = $this->generateIndexKey($cacheKey);
         if ($this->cache->contains($indexKey)) {
-            $index = $this->cache->fetch($indexKey);
+            $index = (array)$this->cache->fetch($indexKey);
 
-            if (!is_array($index)) {
-                $index = array($cacheKey);
-            } elseif (!in_array($cacheKey, $index)) {
+            if (!in_array($cacheKey, $index)) {
                 $index[] = $cacheKey;
             }
         } else {

--- a/Imagine/Cache/Resolver/CacheResolver.php
+++ b/Imagine/Cache/Resolver/CacheResolver.php
@@ -202,7 +202,9 @@ class CacheResolver implements ResolverInterface
         if ($this->cache->contains($indexKey)) {
             $index = $this->cache->fetch($indexKey);
 
-            if (!in_array($cacheKey, $index)) {
+            if (!is_array($index)) {
+                $index = array($cacheKey);
+            } elseif (!in_array($cacheKey, $index)) {
                 $index[] = $cacheKey;
             }
         } else {


### PR DESCRIPTION
under some circumstances it seems `$index` is not always an array. therefore we do the default stuff