### PR TITLE
Check $filters is an array

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -127,6 +127,10 @@ class ImagineController
         try {
             $filters = $request->query->get('filters', array());
 
+            if (!is_array($filters)) {
+                throw new NotFoundHttpException(sprintf('Filters must be an array. Value was "%s"', $filters));
+            }
+
             if (true !== $this->signer->check($hash, $path, $filters)) {
                 throw new BadRequestHttpException(sprintf(
                     'Signed url does not pass the sign check for path "%s" and filter "%s" and runtime config %s',

--- a/Imagine/Filter/Loader/RotateFilterLoader.php
+++ b/Imagine/Filter/Loader/RotateFilterLoader.php
@@ -16,7 +16,7 @@ class RotateFilterLoader implements LoaderInterface
      * Loads and applies a filter on the given image.
      *
      * @param ImageInterface $image
-     * @param array $options
+     * @param array          $options
      *
      * @return ManipulatorInterface
      */

--- a/Tests/Functional/Controller/ImagineControllerTest.php
+++ b/Tests/Functional/Controller/ImagineControllerTest.php
@@ -96,6 +96,18 @@ class ImagineControllerTest extends WebTestCase
 
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage Filters must be an array. Value was "some-string"
+     */
+    public function testShouldThrowNotFoundHttpExceptionIfFiltersNotArray()
+    {
+        $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/rc/invalidHash/images/cats.jpeg?'.http_build_query(array(
+            'filters' => 'some-string',
+            '_hash'   => 'hash',
+        )));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      * @expectedExceptionMessage Source image could not be found
      */
     public function testShouldThrowNotFoundHttpExceptionIfFileNotExists()


### PR DESCRIPTION
Every now and again I get the following error:

```
[2015-04-24 14:19:57] request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\ContextErrorException: "Catchable Fatal Error: Argument 3 passed to Liip\ImagineBundle\Imagine\Cache\Signer::check() must be of the type array, string given, called in application/releases/20150424033514/vendor/liip/imagine-bundle/Liip/ImagineBundle/Controller/ImagineController.php on line 130 and defined" at application/releases/20150424033514/vendor/liip/imagine-bundle/Liip/ImagineBundle/Imagine/Cache/Signer.php line 37 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\ContextErrorException(code: 0): Catchable Fatal Error: Argument 3 passed to Liip\\ImagineBundle\\Imagine\\Cache\\Signer::check() must be of the type array, string given, called in application/releases/20150424033514/vendor/liip/imagine-bundle/Liip/ImagineBundle/Controller/ImagineController.php on line 130 and defined at application/releases/20150424033514/vendor/liip/imagine-bundle/Liip/ImagineBundle/Imagine/Cache/Signer.php:37)"} []
```

I believe this is because someone is modifying the query parameters for runtime config requests. This patch resolves this issue.