### PR TITLE
Make AwsS3Resolver compatible with SDK v3

### DIFF
--- a/Imagine/Cache/Resolver/AwsS3Resolver.php
+++ b/Imagine/Cache/Resolver/AwsS3Resolver.php
@@ -2,7 +2,6 @@
 
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
-use Aws\S3\Enum\CannedAcl;
 use Aws\S3\S3Client;
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotStorableException;
@@ -56,7 +55,7 @@ class AwsS3Resolver implements ResolverInterface
      * @param array    $getOptions A list of options to be passed when retrieving the object url from Amazon S3.
      * @param array    $putOptions A list of options to be passed when saving the object to Amazon S3.
      */
-    public function __construct(S3Client $storage, $bucket, $acl = CannedAcl::PUBLIC_READ, array $getOptions = array(), $putOptions = array())
+    public function __construct(S3Client $storage, $bucket, $acl = 'public-read', array $getOptions = array(), $putOptions = array())
     {
         $this->storage = $storage;
         $this->bucket = $bucket;

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 
     "suggest": {
         "twig/twig":                "If you'd want to use some handy twig filters",
-        "aws/aws-sdk-php":          "Add it if you'd like to use aws v2 resolver",
+        "aws/aws-sdk-php":          "Add it if you'd like to use aws v2 or v3 resolver",
         "amazonwebservices/aws-sdk-for-php": "Add it if you'd like to use aws v1 resolver",
         "monolog/monolog":          "If you'd want to write logs"
     },


### PR DESCRIPTION
AwsS3Resolver is not compatible with AWS SDK v3 released earlier today because `Enum` constants were removed (refer: http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/migration.html#enum-classes-have-been-removed)

This simple commit should make the resolver compatible with v3. 