### PR TITLE
StreamLoader : try urlencode() if not found

### DIFF
--- a/Binary/Loader/StreamLoader.php
+++ b/Binary/Loader/StreamLoader.php
@@ -52,7 +52,11 @@ class StreamLoader implements LoaderInterface
          * file_exists() is not used as not all wrappers support stat() to actually check for existing resources.
          */
         if (($this->context && !$resource = @fopen($name, 'r', null, $this->context)) || !$resource = @fopen($name, 'r')) {
-            throw new NotLoadableException(sprintf('Source image %s not found.', $name));
+            if ($resource = @fopen($this->wrapperPrefix.urlencode($path), 'r')) {
+                $name = $this->wrapperPrefix.urlencode($path);
+            } else {
+                throw new NotLoadableException(sprintf('Source image %s not found.', $name));
+            }
         }
 
         // Closing the opened stream to avoid locking of the resource to find.


### PR DESCRIPTION
I had a problem fetching a file path, **with spaces and accents**, on S3 (`Source image ... not found.`), while this image URL *(the one thrown in the error message)* was working from my web browser.

Using `urlencode` on the path fixed the issue.

If you don't think it's a good idea please don't hesitate to leave a comment !