### PR TITLE
Use is_file() instead of Filesystem::exists()

### DIFF
--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -63,7 +63,7 @@ class WebPathResolver implements ResolverInterface
      */
     public function isStored($path, $filter)
     {
-        return $this->filesystem->exists($this->getFilePath($path, $filter));
+        return is_file($this->getFilePath($path, $filter));
     }
 
     /**


### PR DESCRIPTION
`Filesystem::exists()` will return true no matter what, even if the file is actually a directory. This happens e.g. if you pass an empty path to the Twig filter. I know this breaks the Filesystem encapsulation but there is no `is_file()` equivalent in Filesystem.