### PR TITLE
Return string, not Twig_Markup object in Twig extension

### DIFF
--- a/Templating/ImagineExtension.php
+++ b/Templating/ImagineExtension.php
@@ -42,10 +42,7 @@ class ImagineExtension extends \Twig_Extension
      */
     public function filter($path, $filter, array $runtimeConfig = array())
     {
-        return new \Twig_Markup(
-            $this->cacheManager->getBrowserPath($path, $filter, $runtimeConfig),
-            'utf8'
-        );
+        return $this->cacheManager->getBrowserPath($path, $filter, $runtimeConfig);
     }
 
     /**


### PR DESCRIPTION
Returning a markup object breaks interoperability with the Symfony assets extension. More details here: https://github.com/symfony/symfony/pull/15158