### PR TITLE
context parameter cannot be an empty string

### DIFF
--- a/Binary/Loader/StreamLoader.php
+++ b/Binary/Loader/StreamLoader.php
@@ -34,7 +34,7 @@ class StreamLoader implements LoaderInterface
             throw new \InvalidArgumentException('The given context is no valid resource.');
         }
 
-        $this->context = $context;
+        $this->context = empty($context) ? null : $context;
     }
 
     /**


### PR DESCRIPTION
I got a case where I get my `context` as an empty string. It should be handled as null I guess.