### PR TITLE
Updated docs for features introduced in Symfony 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ If you want to use the service in another service, you have to simulate a new re
 ``` php
 $imagemanagerResponse = $this->container
     ->get('liip_imagine.controller')
-        ->filterAction($this->container->get('request'), 'uploads/foo.jpg', 'my_thumb');
+        ->filterAction(new Symfony\Component\HttpFoundation\Request(), 'uploads/foo.jpg', 'my_thumb');
 ```
 
 ## Outside the web root

--- a/Resources/doc/filters.rst
+++ b/Resources/doc/filters.rst
@@ -263,7 +263,7 @@ A simple example showing how to change the filter configuration dynamically.
             $this->cacheManager->store($filteredBinary, $path, $filter);
         }
 
-        return new RedirectResponse($this->cacheManager->resolve($path, $filter), 301);
+        return new RedirectResponse($this->cacheManager->resolve($path, $filter), Response::HTTP_MOVED_PERMANENTLY);
     }
 
 Post-Processors

--- a/Resources/doc/filters.rst
+++ b/Resources/doc/filters.rst
@@ -266,6 +266,10 @@ A simple example showing how to change the filter configuration dynamically.
         return new RedirectResponse($this->cacheManager->resolve($path, $filter), Response::HTTP_MOVED_PERMANENTLY);
     }
 
+.. note::
+
+    The constant ``Response::HTTP_MOVED_PERMANENTLY`` was introduced in version 2.4. Developers using older versions of Symfony, please replace the constant by ``301``.
+
 Post-Processors
 ---------------
 


### PR DESCRIPTION
Symfony 2.4 introduced constants for HTTP status codes to make code more readable. See: http://symfony.com/blog/new-in-symfony-2-4-using-constants-for-http-status-code.

Also introduced was the request stack with the request service being deprecated for removal in 3.0. See: http://symfony.com/blog/new-in-symfony-2-4-the-request-stack. As the filterAction() doesn't actually depend on the request, I suggest injecting an empty request object.