### PR TITLE
Fix deprecated twig filter syntax

### DIFF
--- a/Templating/ImagineExtension.php
+++ b/Templating/ImagineExtension.php
@@ -27,7 +27,7 @@ class ImagineExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFunction('imagine_filter', array($this, 'filter')),
+            new \Twig_SimpleFilter('imagine_filter', array($this, 'filter'))
         );
     }
 

--- a/Templating/ImagineExtension.php
+++ b/Templating/ImagineExtension.php
@@ -27,7 +27,7 @@ class ImagineExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'imagine_filter' => new \Twig_Filter_Method($this, 'filter'),
+            new \Twig_SimpleFunction('imagine_filter', array($this, 'filter')),
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/orm":             "~2.3",
         "doctrine/mongodb-odm":     "1.0.*",
         "doctrine/cache":           "~1.1",
-        "twig/twig":                "~1.0",
+        "twig/twig":                "~1.12",
         "aws/aws-sdk-php":          "~2.4",
         "amazonwebservices/aws-sdk-for-php": "~1.0",
         "psr/log":                  "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
 
     "suggest": {
-        "twig/twig":                "If you'd want to use some handy twig filters",
+        "twig/twig":                "If you'd want to use some handy twig filters, version 1.12 or greater required",
         "aws/aws-sdk-php":          "Add it if you'd like to use aws v2 or v3 resolver",
         "amazonwebservices/aws-sdk-for-php": "Add it if you'd like to use aws v1 resolver",
         "monolog/monolog":          "If you'd want to write logs"


### PR DESCRIPTION
With the release of Twig 1.21, deprecated calls in twig are being logged. Noticed this one.