### PR TITLE
Fixed wrong rotation for flipped images in auto_rotate filter

### DIFF
--- a/Imagine/Filter/Loader/AutoRotateFilterLoader.php
+++ b/Imagine/Filter/Loader/AutoRotateFilterLoader.php
@@ -86,7 +86,7 @@ class AutoRotateFilterLoader implements LoaderInterface
             return isset($data['Orientation']) ? $data['Orientation'] : null;
         }
 
-        return null;
+        return;
     }
 
     /**

--- a/Imagine/Filter/Loader/AutoRotateFilterLoader.php
+++ b/Imagine/Filter/Loader/AutoRotateFilterLoader.php
@@ -77,6 +77,7 @@ class AutoRotateFilterLoader implements LoaderInterface
                 $orientation = $image->metadata()->offsetGet($orientationKey);
 
                 if ($orientation) {
+                    $image->metadata()->offsetSet($orientationKey, '1');
                     return intval($orientation);
                 }
             }

--- a/Imagine/Filter/Loader/AutoRotateFilterLoader.php
+++ b/Imagine/Filter/Loader/AutoRotateFilterLoader.php
@@ -11,15 +11,15 @@ use Imagine\Image\ImageInterface;
  */
 class AutoRotateFilterLoader implements LoaderInterface
 {
-    protected $orientationKeys = array(
+    protected $orientationKeys = [
         'exif.Orientation',
         'ifd0.Orientation',
-    );
+    ];
 
     /**
      * {@inheritDoc}
      */
-    public function load(ImageInterface $image, array $options = array())
+    public function load(ImageInterface $image, array $options = [])
     {
         if ($orientation = $this->getOrientation($image)) {
             // Rotates if necessary.
@@ -92,7 +92,7 @@ class AutoRotateFilterLoader implements LoaderInterface
      *
      * @param int $orientation
      *
-     * @return boolean
+     * @return bool
      */
     private function isFlipped($orientation)
     {

--- a/Imagine/Filter/Loader/AutoRotateFilterLoader.php
+++ b/Imagine/Filter/Loader/AutoRotateFilterLoader.php
@@ -85,6 +85,8 @@ class AutoRotateFilterLoader implements LoaderInterface
 
             return isset($data['Orientation']) ? $data['Orientation'] : null;
         }
+
+        return null;
     }
 
     /**

--- a/Imagine/Filter/Loader/AutoRotateFilterLoader.php
+++ b/Imagine/Filter/Loader/AutoRotateFilterLoader.php
@@ -17,7 +17,7 @@ class AutoRotateFilterLoader implements LoaderInterface
     ];
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(ImageInterface $image, array $options = [])
     {

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -2,6 +2,7 @@
 
 namespace Liip\ImagineBundle\Tests;
 
+use Imagine\Image\Metadata\MetadataBag;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Symfony\Component\Filesystem\Filesystem;
@@ -90,6 +91,11 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
     protected function getMockImage()
     {
         return $this->getMock('Imagine\Image\ImageInterface');
+    }
+
+    protected function getMockMetaData()
+    {
+        return $this->getMock('Imagine\Image\Metadata\MetadataBag');
     }
 
     protected function createImagineMock()

--- a/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
@@ -13,6 +13,8 @@ use Liip\ImagineBundle\Tests\AbstractTest;
  */
 class AutoRotateFilterLoaderTest extends AbstractTest
 {
+    private $orientationKey = 'exif.Orientation';
+
     /**
      * Starts a test with expected results.
      *
@@ -32,6 +34,13 @@ class AutoRotateFilterLoaderTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('offsetGet')
             ->willReturn($exifValue);
+
+        if ($exifValue && $exifValue !== '1') {
+            $metaData
+                ->expects($this->once())
+                ->method('offsetSet')
+                ->with($this->orientationKey, '1');
+        }
 
         // Mocks the image and makes it use the fake meta data.
         $image = $this->getMockImage();
@@ -55,36 +64,88 @@ class AutoRotateFilterLoaderTest extends AbstractTest
         $loader->load($image);
     }
 
-    public function testLoadAllExifs()
+    /*
+     * Possible rotation values
+     * 1: 0°
+     * 2: 0° flipped horizontally
+     * 3: 180°
+     * 4: 180° flipped horizontally
+     * 5: 90° flipped horizontally
+     * 6: 90°
+     * 7: -90° flipped horizontally
+     * 8: -90°
+     * No metadata means no rotation nor flip.
+     */
+
+    /**
+     * 1: no rotation
+     */
+    public function testLoadExif1()
     {
-        /*
-         * Possible rotation values
-         * 1: 0°
-         * 2: 0° flipped horizontally
-         * 3: 180°
-         * 4: 180° flipped horizontally
-         * 5: 90° flipped horizontally
-         * 6: 90°
-         * 7: -90° flipped horizontally
-         * 8: -90°
-         * No metadata means no rotation nor flip.
-         */
+        $this->loadExif('1', null, false);
+    }
 
-        // Test cases: rotation value from EXIF, expected rotation, expected horizontal flip.
-        $testCases = [
-            ['1', null, false],
-            ['2', null, true],
-            ['3', 180, false],
-            ['4', 180, true],
-            ['5', 90, true],
-            ['6', 90, false],
-            ['7', -90, true],
-            ['8', -90, false],
-            [null, null, false],
-        ];
+    /**
+     * 2: no rotation flipped horizontally
+     */
+    public function testLoadExif2()
+    {
+        $this->loadExif('2', null, true);
+    }
 
-        foreach ($testCases as $testCase) {
-            $this->loadExif($testCase[0], $testCase[1], $testCase[2]);
-        }
+    /**
+     * 3: 180°
+     */
+    public function testLoadExif3()
+    {
+        $this->loadExif('3', 180, false);
+    }
+
+    /**
+     * 4: 180° flipped horizontally
+     */
+    public function testLoadExif4()
+    {
+        $this->loadExif('4', 180, true);
+    }
+
+    /**
+     * 5: 90° flipped horizontally
+     */
+    public function testLoadExif5()
+    {
+        $this->loadExif('5', 90, true);
+    }
+
+    /**
+     * 6: 90°
+     */
+    public function testLoadExif6()
+    {
+        $this->loadExif('6', 90, false);
+    }
+
+    /**
+     * 7: -90° flipped horizontally
+     */
+    public function testLoadExif7()
+    {
+        $this->loadExif('7', -90, true);
+    }
+
+    /**
+     * 8: -90°
+     */
+    public function testLoadExif8()
+    {
+        $this->loadExif('8', null - 90, false);
+    }
+
+    /**
+     * No rotation info: no rotation nor flip
+     */
+    public function testLoadExifNull()
+    {
+        $this->loadExif(null, null, false);
     }
 }

--- a/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
@@ -73,14 +73,14 @@ class AutoRotateFilterLoaderTest extends AbstractTest
 
         // Test cases: rotation value from EXIF, expected rotation, expected horizontal flip.
         $testCases = [
-            ["1", null, false],
-            ["2", null, true],
-            ["3", 180, false],
-            ["4", 180, true],
-            ["5", 90, true],
-            ["6", 90, false],
-            ["7", -90, true],
-            ["8", -90, false],
+            ['1', null, false],
+            ['2', null, true],
+            ['3', 180, false],
+            ['4', 180, true],
+            ['5', 90, true],
+            ['6', 90, false],
+            ['7', -90, true],
+            ['8', -90, false],
         ];
 
         foreach ($testCases as $testCase) {

--- a/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
@@ -17,12 +17,12 @@ class AutoRotateFilterLoaderTest extends AbstractTest
 
     /**
      * Starts a test with expected results.
+     *
      * @param $exifValue {String} The exif value to be returned by the metadata mock.
      * @param $expectCallRotateValue {null|number} The expected rotation value, null if no rotation is expected.
      * @param $expectCallFlip {Boolean} True if a horizontal flip is expected, false otherwise.
      */
-    private function loadExif($exifValue, $expectCallRotateValue, $expectCallFlip)
-    {
+    private function loadExif($exifValue, $expectCallRotateValue, $expectCallFlip) {
         $loader = new AutoRotateFilterLoader();
 
         // Mocks the metadata and makes it return the expected exif value for the rotation.
@@ -32,8 +32,7 @@ class AutoRotateFilterLoaderTest extends AbstractTest
             ->expects($this->once())
             ->method('offsetGet')
             ->with($this->orientationKey)
-            ->willReturn($exifValue)
-        ;
+            ->willReturn($exifValue);
 
         // Mocks the image and makes it use the fake meta data.
         $image = $this->getMockImage();
@@ -41,28 +40,23 @@ class AutoRotateFilterLoaderTest extends AbstractTest
         $image
             ->expects($this->once())
             ->method('metadata')
-            ->willReturn($metaData)
-        ;
+            ->willReturn($metaData);
 
         // Checks that rotate is called with $expectCallRotateValue, or not called at all if $expectCallRotateValue is null.
         $image
             ->expects($expectCallRotateValue !== null ? $this->once() : $this->never())
             ->method('rotate')
-            ->with($expectCallRotateValue)
-        ;
+            ->with($expectCallRotateValue);
 
         // Checks that rotate is called if $expectCallFlip is true, not called if $expectCallFlip is false.
         $image
             ->expects($expectCallFlip ? $this->once() : $this->never())
-            ->method('flipHorizontally')
-        ;
+            ->method('flipHorizontally');
 
         $loader->load($image);
     }
 
-
-    public function testLoadAllExifs()
-    {
+    public function testLoadAllExifs() {
         /*
          * Possible rotation values
          * 1: 0°
@@ -76,16 +70,16 @@ class AutoRotateFilterLoaderTest extends AbstractTest
          */
 
         // Test cases: rotation value from EXIF, expected rotation, expected horizontal flip.
-        $testCases = array(
-            array("1", null, false),
-            array("2", null, true),
-            array("3", 180, false),
-            array("4", 180, true),
-            array("5", 90, true),
-            array("6", 90, false),
-            array("7", -90, true),
-            array("8", -90, false),
-        );
+        $testCases = [
+            ["1", null, false],
+            ["2", null, true],
+            ["3", 180, false],
+            ["4", 180, true],
+            ["5", 90, true],
+            ["6", 90, false],
+            ["7", -90, true],
+            ["8", -90, false]
+        ];
 
         foreach ($testCases as $testCase) {
             $this->loadExif($testCase[0], $testCase[1], $testCase[2]);

--- a/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
@@ -13,8 +13,6 @@ use Liip\ImagineBundle\Tests\AbstractTest;
  */
 class AutoRotateFilterLoaderTest extends AbstractTest
 {
-    private $orientationKey = 'exif.Orientation';
-
     /**
      * Starts a test with expected results.
      *
@@ -27,19 +25,19 @@ class AutoRotateFilterLoaderTest extends AbstractTest
         $loader = new AutoRotateFilterLoader();
 
         // Mocks the metadata and makes it return the expected exif value for the rotation.
+        // If $exifValue is null, it means the image doesn't contain any metadata.
         $metaData = $this->getMockMetaData();
 
         $metaData
-            ->expects($this->once())
+            ->expects($this->atLeastOnce())
             ->method('offsetGet')
-            ->with($this->orientationKey)
             ->willReturn($exifValue);
 
         // Mocks the image and makes it use the fake meta data.
         $image = $this->getMockImage();
 
         $image
-            ->expects($this->once())
+            ->expects($this->atLeastOnce())
             ->method('metadata')
             ->willReturn($metaData);
 
@@ -69,6 +67,7 @@ class AutoRotateFilterLoaderTest extends AbstractTest
          * 6: 90°
          * 7: -90° flipped horizontally
          * 8: -90°
+         * No metadata means no rotation nor flip.
          */
 
         // Test cases: rotation value from EXIF, expected rotation, expected horizontal flip.
@@ -81,6 +80,7 @@ class AutoRotateFilterLoaderTest extends AbstractTest
             ['6', 90, false],
             ['7', -90, true],
             ['8', -90, false],
+            [null, null, false],
         ];
 
         foreach ($testCases as $testCase) {

--- a/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Liip\ImagineBundle\Tests\Filter;
+
+use Liip\ImagineBundle\Imagine\Filter\Loader\AutoRotateFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
+
+/**
+ * Test cases for RotateFilterLoader class.
+ * Depending on the EXIF value checks whether rotate and flip are called.
+ *
+ * @covers Liip\ImagineBundle\Imagine\Filter\Loader\AutoRotateFilterLoader
+ */
+class AutoRotateFilterLoaderTest extends AbstractTest
+{
+    private $orientationKey = 'exif.Orientation';
+
+    /**
+     * Starts a test with expected results.
+     * @param $exifValue {String} The exif value to be returned by the metadata mock.
+     * @param $expectCallRotateValue {null|number} The expected rotation value, null if no rotation is expected.
+     * @param $expectCallFlip {Boolean} True if a horizontal flip is expected, false otherwise.
+     */
+    private function loadExif($exifValue, $expectCallRotateValue, $expectCallFlip)
+    {
+        $loader = new AutoRotateFilterLoader();
+
+        // Mocks the metadata and makes it return the expected exif value for the rotation.
+        $metaData = $this->getMockMetaData();
+
+        $metaData
+            ->expects($this->once())
+            ->method('offsetGet')
+            ->with($this->orientationKey)
+            ->willReturn($exifValue)
+        ;
+
+        // Mocks the image and makes it use the fake meta data.
+        $image = $this->getMockImage();
+
+        $image
+            ->expects($this->once())
+            ->method('metadata')
+            ->willReturn($metaData)
+        ;
+
+        // Checks that rotate is called with $expectCallRotateValue, or not called at all if $expectCallRotateValue is null.
+        $image
+            ->expects($expectCallRotateValue !== null ? $this->once() : $this->never())
+            ->method('rotate')
+            ->with($expectCallRotateValue)
+        ;
+
+        // Checks that rotate is called if $expectCallFlip is true, not called if $expectCallFlip is false.
+        $image
+            ->expects($expectCallFlip ? $this->once() : $this->never())
+            ->method('flipHorizontally')
+        ;
+
+        $loader->load($image);
+    }
+
+
+    public function testLoadAllExifs()
+    {
+        /*
+         * Possible rotation values
+         * 1: 0°
+         * 2: 0° flipped horizontally
+         * 3: 180°
+         * 4: 180° flipped horizontally
+         * 5: 90° flipped horizontally
+         * 6: 90°
+         * 7: -90° flipped horizontally
+         * 8: -90°
+         */
+
+        // Test cases: rotation value from EXIF, expected rotation, expected horizontal flip.
+        $testCases = array(
+            array("1", null, false),
+            array("2", null, true),
+            array("3", 180, false),
+            array("4", 180, true),
+            array("5", 90, true),
+            array("6", 90, false),
+            array("7", -90, true),
+            array("8", -90, false),
+        );
+
+        foreach ($testCases as $testCase) {
+            $this->loadExif($testCase[0], $testCase[1], $testCase[2]);
+        }
+    }
+}

--- a/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
@@ -22,7 +22,8 @@ class AutoRotateFilterLoaderTest extends AbstractTest
      * @param $expectCallRotateValue {null|number} The expected rotation value, null if no rotation is expected.
      * @param $expectCallFlip {Boolean} True if a horizontal flip is expected, false otherwise.
      */
-    private function loadExif($exifValue, $expectCallRotateValue, $expectCallFlip) {
+    private function loadExif($exifValue, $expectCallRotateValue, $expectCallFlip)
+    {
         $loader = new AutoRotateFilterLoader();
 
         // Mocks the metadata and makes it return the expected exif value for the rotation.
@@ -56,7 +57,8 @@ class AutoRotateFilterLoaderTest extends AbstractTest
         $loader->load($image);
     }
 
-    public function testLoadAllExifs() {
+    public function testLoadAllExifs()
+    {
         /*
          * Possible rotation values
          * 1: 0°
@@ -78,7 +80,7 @@ class AutoRotateFilterLoaderTest extends AbstractTest
             ["5", 90, true],
             ["6", 90, false],
             ["7", -90, true],
-            ["8", -90, false]
+            ["8", -90, false],
         ];
 
         foreach ($testCases as $testCase) {


### PR DESCRIPTION
The original code was not rotating (nor flipping) flipped images.

The code has been tested using those images https://github.com/recurser/exif-orientation-examples