### PR TITLE
Incorporate feedback from @WouterJ for PR 651

### DIFF
--- a/Resources/doc/basic-usage.rst
+++ b/Resources/doc/basic-usage.rst
@@ -9,7 +9,6 @@ you want to thumbnail an image to a size of 120x90 pixels:
 .. code-block:: yaml
 
     # app/config/config.yml
-
     liip_imagine:
         resolvers:
            default:
@@ -22,22 +21,22 @@ you want to thumbnail an image to a size of 120x90 pixels:
                 filters:
                     thumbnail: { size: [120, 90], mode: outbound }
 
-You've now defined a filter set called `my_thumb` that performs a thumbnail transformation.
-We'll learn more about available transformations later, but for now, this
-new filter can be used immediately in a template:
+You've now defined a filter set called `my_thumb` that performs a thumbnail 
+transformation. We'll learn more about available transformations later, but 
+for now, this new filter can be used immediately in a template:
 
-.. code-block:: jinja
+.. configuration-block:
 
-    <img src="{{ '/relative/path/to/image.jpg' | imagine_filter('my_thumb') }}" />
+    .. code-block:: html+jinja
 
-Or if you're using PHP templates:
+        <img src="{{ '/relative/path/to/image.jpg'|imagine_filter('my_thumb') }}" />
 
-.. code-block:: php
-    
-    <img src="<?php $this['imagine']->filter('/relative/path/to/image.jpg', 'my_thumb') ?>" />
+    .. code-block:: html+php
 
-Behind the scenes, the bundles applies the filter(s) to the image on the first
-request and then caches the image to a similar path. On the next request,
+        <img src="<?php echo $this['imagine']->filter('/relative/path/to/image.jpg', 'my_thumb') ?>" />
+
+Behind the scenes, the bundles applies the filter(s) to the image on the 
+first request and then caches the image to a similar path. On the next request,
 the cached image would be served directly from the file system.
 
 In this example, the final rendered path would be something like
@@ -46,32 +45,33 @@ would save the filtered image file.
 
 You can also pass some options at runtime:
 
-.. code-block:: jinja
+.. configuration-block:
 
-    {% set runtimeConfig = {"thumbnail": {"size": [50, 50] }} %}
-    <img src="{{ '/relative/path/to/image.jpg' | imagine_filter('my_thumb', runtimeConfig) }}" />
+    .. code-block:: html+jinja
 
-Or if you're using PHP templates:
+        {% set runtimeConfig = {"thumbnail": {"size": [50, 50] }} %}
+        <img src="{{ '/relative/path/to/image.jpg' | imagine_filter('my_thumb', runtimeConfig) }}" />
 
-.. code-block:: php
+    .. code-block:: html+php
 
-    <?php
-    $runtimeConfig = array(
-        "thumbnail" => array(
-            "size" => array(50, 50)
-        )
-    );
-    ?>
+        <?php
+        $runtimeConfig = array(
+            "thumbnail" => array(
+                "size" => array(50, 50)
+            )
+        );
+        ?>
 
-    <img src="<?php $this['imagine']->filter('/relative/path/to/image.jpg', 'my_thumb', $runtimeConfig) ?>" />
+        <img src="<?php echo $this['imagine']->filter('/relative/path/to/image.jpg', 'my_thumb', $runtimeConfig) ?>" />
 
 Also you can resolve image url from console:
 
-.. code-block:: jinja
+.. code-block:: bash
 
-    app/console liip:imagine:cache:resolve relative/path/to/image.jpg relative/path/to/image2.jpg --filters=my_thumb --filters=thumbnail_default
+    $ php app/console liip:imagine:cache:resolve relative/path/to/image.jpg relative/path/to/image2.jpg --filters=my_thumb --filters=thumbnail_default
 
-Where only paths required parameter. They are separated by space. If you omit filters option will be applied all available filters.
+Where only paths required parameter. They are separated by space. If you
+omit filters option will be applied all available filters.
 
 If you need to access filtered image URL in your controller:
 
@@ -79,16 +79,18 @@ If you need to access filtered image URL in your controller:
     
     $this->get('liip_imagine.cache.manager')->getBrowserPath('/relative/path/to/image.jpg', 'my_thumb', true),
 
-In this case, the final rendered path would contain some random data in the path
-`/media/cache/my_thumb/S8rrlhhQ/relative/path/to/image.jpg`. This is where Imagine
-would save the filtered image file.
+In this case, the final rendered path would contain some random data in the 
+path ``/media/cache/my_thumb/S8rrlhhQ/relative/path/to/image.jpg``. This is where 
+Imagine would save the filtered image file.
 
 .. note::
-    Using the ``dev`` environment you might find that the images are not properly rendered when
-    using the template helper. This is likely caused by having ``intercept_redirect`` enabled in your
-    application configuration. To ensure that the images are rendered disable this option:
 
-    .. code-block:: jinja
+    Using the ``dev`` environment you might find that the images are not properly 
+    rendered when using the template helper. This is likely caused by having 
+    ``intercept_redirect`` enabled in your application configuration. To ensure 
+    that the images are rendered disable this option:
+
+    .. code-block:: yaml
         
         web_profiler:
             intercept_redirects: false


### PR DESCRIPTION
This fixes issues in `basic_usage.rst` mentioned in [PR 651](https://github.com/liip/LiipImagineBundle/pull/651):
* Combined PHP/Twig examples
* Fixed line lengths
* Fixed RST problems and Symfony doc standards compliance
* Made console example Windows-compatible 