### PR TITLE
Removed UrlGenerator deprecations from symfony 2.8

### DIFF
--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -6,6 +6,7 @@ use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Liip\ImagineBundle\ImagineEvents;
@@ -164,12 +165,12 @@ class CacheManager
         );
 
         if (empty($runtimeConfig)) {
-            $filterUrl = $this->router->generate('liip_imagine_filter', $params, true);
+            $filterUrl = $this->router->generate('liip_imagine_filter', $params, UrlGeneratorInterface::ABSOLUTE_URL);
         } else {
             $params['filters'] = $runtimeConfig;
             $params['hash'] = $this->signer->sign($path, $runtimeConfig);
 
-            $filterUrl = $this->router->generate('liip_imagine_filter_runtime', $params, true);
+            $filterUrl = $this->router->generate('liip_imagine_filter_runtime', $params, UrlGeneratorInterface::ABSOLUTE_URL);
         }
 
         return $filterUrl;

--- a/Tests/Imagine/Cache/CacheManagerTest.php
+++ b/Tests/Imagine/Cache/CacheManagerTest.php
@@ -8,6 +8,7 @@ use Liip\ImagineBundle\Tests\AbstractTest;
 use Liip\ImagineBundle\Imagine\Cache\Signer;
 use Liip\ImagineBundle\ImagineEvents;
 use Liip\ImagineBundle\Events\CacheResolveEvent;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @covers Liip\ImagineBundle\Imagine\Cache\CacheManager
@@ -290,7 +291,7 @@ class CacheManagerTest extends AbstractTest
                     'path' => $path,
                     'filter' => 'thumbnail',
                 ),
-                true
+                UrlGeneratorInterface::ABSOLUTE_URL
             )
             ->will($this->returnValue($expectedUrl))
         ;


### PR DESCRIPTION
Hello!

With Symfony 2.8, the UrlGenerator params have changed to generate absolute urls.
Instead of true, the param should be UrlGeneratorInterface::ABSOLUTE_URL

I changed the functionality to work with symfony 3.0.

Greetings from munich,
Sebastian