### PR TITLE
[WIP] Add option "image_path_property_path" to the image type.

### DIFF
--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -86,6 +86,11 @@ class LiipImagineExtension extends Extension
         $resources = $container->hasParameter('twig.form.resources') ? $container->getParameter('twig.form.resources') : array();
         $resources[] = 'LiipImagineBundle:Form:form_div_layout.html.twig';
         $container->setParameter('twig.form.resources', $resources);
+
+        if ($container->has('form.property_accessor')) {
+            $container->getDefinition('liip_imagine.form.type.image')
+                ->replaceArgument(0, new Reference('form.property_accessor'));
+        }
     }
 
     /**

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -5,22 +5,42 @@ namespace Liip\ImagineBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
- * ImageType.
+ * ImageType provides ability upload file and display preview of image.
  *
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
+ * @author Konstantin Myakshin <koc-dp@yandex.ru>
  */
 class ImageType extends AbstractType
 {
+    /**
+     * @var PropertyAccessorInterface
+     */
+    private $propertyAccessor;
+
+    public function __construct(PropertyAccessorInterface $propertyAccessor = null)
+    {
+        $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
+    }
+
     /**
      * {@inheritdoc}
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['image_path'] = $options['image_path'];
+        $imagePath = $options['image_path'];
+        if ($options['image_path_property_path']) {
+            $imagePath = $this->propertyAccessor->getValue($options['data'], $options['image_path_property_path']);
+        }
+
+        $view->vars['image_path'] = $imagePath;
         $view->vars['image_filter'] = $options['image_filter'];
         $view->vars['image_attr'] = $options['image_attr'];
         $view->vars['link_url'] = $options['link_url'];
@@ -34,16 +54,34 @@ class ImageType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setRequired(array(
-            'image_path',
             'image_filter',
         ));
 
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setDefined(array('image_path'));
+        } else {
+            $resolver->setOptional(array('image_path'));
+        }
+
         $resolver->setDefaults(array(
+            'image_path_property_path' => null,
             'image_attr' => array(),
             'link_url' => null,
             'link_filter' => null,
             'link_attr' => array(),
         ));
+
+        $normalizer = function (Options $options, $value) {
+            if (null !== $value) {
+                $options['image_path'] = null;
+
+                return $value;
+            } elseif (!isset($options['image_path'])) {
+                throw new MissingOptionsException('You should provide "image_path" or "image_path_property_path" option value.');
+            }
+        };
+
+        $resolver->setNormalizer('image_path_property_path', $normalizer);
     }
 
     /**

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -59,7 +59,7 @@ class ImageType extends AbstractType
 
         if (method_exists($resolver, 'setDefined')) {
             $resolver->setDefined(array('image_path'));
-        } else {
+        } else { // BC layer for Symfony < 2.6
             $resolver->setOptional(array('image_path'));
         }
 
@@ -81,7 +81,12 @@ class ImageType extends AbstractType
             }
         };
 
-        $resolver->setNormalizer('image_path_property_path', $normalizer);
+        if (method_exists($resolver, 'setNormalizer')) {
+            $resolver->setNormalizer('image_path_property_path', $normalizer);
+        } else { // BC layer for Symfony < 2.6
+            $resolver->setNormalizers(array('image_path_property_path', $normalizer));
+        }
+
     }
 
     /**

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -241,6 +241,7 @@
         <!-- Form types -->
 
         <service id="liip_imagine.form.type.image" class="%liip_imagine.form.type.image.class%">
+            <argument type="service" id="property_accessor" />
             <tag name="form.type" alias="liip_imagine_image" />
         </service>
 


### PR DESCRIPTION
This PR add possibility provide property path for reading image instead of calling methods by hand.

``` php
$builder
// old
    ->add('image', 'liip_imagine_image', array('image_filter' => 'sq40', 'image_path' => $options['data']->getWebPath()))
// new
    ->add('image', 'liip_imagine_image', array('image_filter' => 'sq40', 'image_path_property_path' => 'webPath'))
```

TODO: 
- [ ] write tests
- [ ] add docs for form type.
