### PR TITLE
[resolver] Add ability to force resolver.

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -78,9 +78,10 @@ class ImagineController
     {
         // decoding special characters and whitespaces from path obtained from url
         $path = urldecode($path);
+        $resolver = $request->get('resolver');
 
         try {
-            if (!$this->cacheManager->isStored($path, $filter)) {
+            if (!$this->cacheManager->isStored($path, $filter, $resolver)) {
                 try {
                     $binary = $this->dataManager->find($filter, $path);
                 } catch (NotLoadableException $e) {
@@ -94,11 +95,12 @@ class ImagineController
                 $this->cacheManager->store(
                     $this->filterManager->applyFilter($binary, $filter),
                     $path,
-                    $filter
+                    $filter,
+                    $resolver
                 );
             }
 
-            return new RedirectResponse($this->cacheManager->resolve($path, $filter), 301);
+            return new RedirectResponse($this->cacheManager->resolve($path, $filter, $resolver), 301);
         } catch (NonExistingFilterException $e) {
             $message = sprintf('Could not locate filter "%s" for path "%s". Message was "%s"', $filter, $path, $e->getMessage());
 
@@ -127,6 +129,8 @@ class ImagineController
      */
     public function filterRuntimeAction(Request $request, $hash, $path, $filter)
     {
+        $resolver = $request->get('resolver');
+
         try {
             $filters = $request->query->get('filters', array());
 
@@ -160,10 +164,11 @@ class ImagineController
                     'filters' => $filters,
                 )),
                 $rcPath,
-                $filter
+                $filter,
+                $resolver
             );
 
-            return new RedirectResponse($this->cacheManager->resolve($rcPath, $filter), 301);
+            return new RedirectResponse($this->cacheManager->resolve($rcPath, $filter, $resolver), 301);
         } catch (NonExistingFilterException $e) {
             $message = sprintf('Could not locate filter "%s" for path "%s". Message was "%s"', $filter, $hash.'/'.$path, $e->getMessage());
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -43,6 +43,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('resolvers')
                     ->useAttributeAsKey('name')
                     ->prototype('array')
+                        ->performNoDeepMerging()
         ;
         $this->addResolversSections($resolversPrototypeNode);
 

--- a/Templating/ImagineExtension.php
+++ b/Templating/ImagineExtension.php
@@ -37,12 +37,13 @@ class ImagineExtension extends \Twig_Extension
      * @param string $path
      * @param string $filter
      * @param array  $runtimeConfig
+     * @param string $resolver
      *
      * @return \Twig_Markup
      */
-    public function filter($path, $filter, array $runtimeConfig = array())
+    public function filter($path, $filter, array $runtimeConfig = array(), $resolver = null)
     {
-        return $this->cacheManager->getBrowserPath($path, $filter, $runtimeConfig);
+        return $this->cacheManager->getBrowserPath($path, $filter, $runtimeConfig, $resolver);
     }
 
     /**

--- a/Tests/Binary/Loader/GridFSLoaderTest.php
+++ b/Tests/Binary/Loader/GridFSLoaderTest.php
@@ -24,7 +24,10 @@ class GridFSLoaderTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         if (!extension_loaded('mongodb')) {
-            $this->markTestSkipped('ext/mongodb not installed');
+            $this->markTestSkipped('ext/mongodb is not installed');
+        }
+        if (!class_exists('Doctrine\MongoDB\GridFSFile')) {
+            $this->markTestSkipped('doctrine mongo odm is not installed');
         }
         $this->repo = $this->getMockBuilder('Doctrine\ODM\MongoDB\DocumentRepository')->disableOriginalConstructor()->getMock();
 


### PR DESCRIPTION
**The problem:** Right now filters are coupled to resolvers (or vice versa) and it limits us a lot. For example we are not able to use s3 links in the backend (without cdn cache) and cdn links on frontend. This could be achieved right now by duplicating all filters + a prefix. The other problem: We are not able to reuse filters with different resolvers. We have to duplicate them all the time.

**Solution:** The big goal is to decouple resolvers from filters, and ideally data loaders from filters too. It'll be done for v2 and most likely there will be BC breaks. 

This PR just adds ability to force the resolver, it is a small step towards the bigger goal. it is BC way. 

