### PR TITLE
Fixed doc errors reported by docs build tool

### DIFF
--- a/Resources/doc/cache-resolvers.rst
+++ b/Resources/doc/cache-resolvers.rst
@@ -1,11 +1,14 @@
 Built-In CacheResolver
 ======================
 
-* :doc:`Web path <cache-resolver/web_path>`
-* :doc:`AmazonS3 <cache-resolver/amazons3>`
-* :doc:`AwsS3 <cache-resolver/aws_s3>` - for SDK version
-* :doc:`CacheResolver <cache-resolver/cache>`
-* :doc:`ProxyResolver <cache-resolver/proxy>`
+.. toctree::
+    :maxdepth: 1
+
+    cache-resolver/web_path
+    cache-resolver/amazons3
+    cache-resolver/aws_s3
+    cache-resolver/cache
+    cache-resolver/proxy
 
 Changing the default cache resolver
 -----------------------------------

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -55,13 +55,11 @@ There are several configuration options available:
   the standard web_path resolver is used)
 * ``data_loader`` - name of a custom data loader. Default value: ``filesystem``
   (which means the standard filesystem loader is used).
-* ``controller``:
-
+* ``controller``
   * ``filter_action`` - name of the controller action to use in the route loader.
     Default value: ``liip_imagine.controller:filterAction``
   * ``filter_runtime_action`` - name of the controller action to use in the route
     loader for runtimeconfig images. Default value: ``liip_imagine.controller:filterRuntimeAction``
-
 * ``driver`` - one of the three drivers: ``gd``, ``imagick``, ``gmagick``.
   Default value: ``gd``
 * ``filter_sets`` - specify the filter sets that you want to define and use.

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -55,11 +55,13 @@ There are several configuration options available:
   the standard web_path resolver is used)
 * ``data_loader`` - name of a custom data loader. Default value: ``filesystem``
   (which means the standard filesystem loader is used).
-* ``controller``
+* ``controller``:
+
   * ``filter_action`` - name of the controller action to use in the route loader.
     Default value: ``liip_imagine.controller:filterAction``
   * ``filter_runtime_action`` - name of the controller action to use in the route
     loader for runtimeconfig images. Default value: ``liip_imagine.controller:filterRuntimeAction``
+
 * ``driver`` - one of the three drivers: ``gd``, ``imagick``, ``gmagick``.
   Default value: ``gd``
 * ``filter_sets`` - specify the filter sets that you want to define and use.
@@ -71,9 +73,12 @@ Each filter set that you specify has the following options:
 * ``post_processors`` - sets post-processors to be applied on filtered image
   (see Post-Processors section in the :doc:`filters chapter <filters>` for details).
 * ``quality`` - override the default quality of 100 for the generated images. **(deprecated)**
-* ``jpeg_quality`` - override the quality for jpeg images (this overrides the ``quality`` option above)
-* ``png_compression_level`` - set the compression level for png images (0-9) (this overrides the ``quality`` option above)
-* ``png_compression_filter`` - set the compression filter for png images (see the ``filters`` parameter for ``imagepng`` function in `PHP manual`_ for more details)
+* ``jpeg_quality`` - override the quality for jpeg images (this overrides the
+  ``quality`` option above)
+* ``png_compression_level`` - set the compression level for png images (0-9)
+  (this overrides the ``quality`` option above)
+* ``png_compression_filter`` - set the compression filter for png images (see the
+  ``filters`` parameter for ``imagepng`` function in `PHP manual`_ for more details)
 * ``cache`` - override the default cache setting.
 * ``data_loader`` - override the default data loader.
 * ``route`` - optional list of route requirements, defaults and options using in

--- a/Resources/doc/data-loaders.rst
+++ b/Resources/doc/data-loaders.rst
@@ -1,9 +1,12 @@
 Built-In DataLoader
 ===================
 
-* :doc:`FileSystem <data-loader/filesystem>`
-* :doc:`MongoDB GridFS <data-loader/gridfs>`
-* :doc:`Stream <data-loader/stream>`
+.. toctree::
+    :maxdepth: 1
+
+    data-loader/filesystem
+    data-loader/gridfs
+    data-loader/stream
 
 Other data loaders
 ------------------

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -5,12 +5,14 @@ This bundle allows to alter images in certain ways, such as scaling or rotating
 them, creating thumbnails, adding watermarks, etc. In order to not hurt application
 performance, altered images can be cached locally and in Amazon S3 service.
 
-* :doc:`Installation <installation>`
-* :doc:`Introduction <introduction>`
-* :doc:`Basic usage <basic-usage>`
-* :doc:`Configuration <configuration>`
-* :doc:`Filters <filters>`
-* :doc:`DataLoaders <data-loaders>`
-* :doc:`CacheResolvers <cache-resolvers>`
-* :doc:`CacheManager <cache-manager>`
-* :doc:`Commands <commands>`
+.. toctree::
+    :maxdepth: 1
+
+    installation
+    introduction
+    basic-usage
+    configuration
+    data-loaders
+    cache-resolvers
+    cache-manager
+    commands


### PR DESCRIPTION
We recently reenabled the "docs build error reporting" on symfony.com and these are the errors shows for this bundle:

```
var/docs/rst/liip-liipimagine-bundle/en/master/configuration.rst:60: ERROR: Unexpected indentation.
var/docs/rst/liip-liipimagine-bundle/en/master/configuration.rst:61: WARNING: Block quote ends without a blank line; unexpected unindent.
var/docs/rst/liip-liipimagine-bundle/en/master/filters.rst:8: WARNING: Title underline too short.
var/docs/rst/liip-liipimagine-bundle/en/master/cache-manager.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/cache-resolver/amazons3.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/cache-resolver/aws_s3.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/cache-resolver/cache.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/cache-resolver/proxy.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/cache-resolver/web_path.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/cache-resolvers.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/configuration.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/data-loader/filesystem.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/data-loader/gridfs.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/data-loader/stream.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/data-loaders.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/filters.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/installation.rst:: WARNING: document isn't included in any toctree
var/docs/rst/liip-liipimagine-bundle/en/master/introduction.rst:: WARNING: document isn't included in any toctree
```

In this PR I'm trying to fix all of them. Before merging, I'd like to ask to our RST experts (@xabbuh and @WouterJ) if they agree with the changes related to `.. toctree`. Thanks!