### PR TITLE
Add missing link to the filters doc

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -11,6 +11,7 @@ performance, altered images can be cached locally and in Amazon S3 service.
     installation
     introduction
     basic-usage
+    filters
     configuration
     data-loaders
     cache-resolvers


### PR DESCRIPTION
Missing link on http://symfony.com/doc/master/bundles/LiipImagineBundle/index.html page.