### PR TITLE
Downscale filter scales an image to fit bounding box

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -100,7 +100,9 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('driver')->defaultValue('gd')
                     ->validate()
-                        ->ifTrue(function ($v) { return !in_array($v, array('gd', 'imagick', 'gmagick')); })
+                        ->ifTrue(function ($v) {
+                            return !in_array($v, array('gd', 'imagick', 'gmagick'));
+                        })
                         ->thenInvalid('Invalid imagine driver specified: %s')
                     ->end()
                 ->end()

--- a/Imagine/Filter/Loader/DownscaleFilterLoader.php
+++ b/Imagine/Filter/Loader/DownscaleFilterLoader.php
@@ -30,7 +30,7 @@ class DownscaleFilterLoader implements LoaderInterface
             $widthRatio = $width / $origWidth;
             $heightRatio = $height / $origHeight;
 
-            $ratio = $widthRatio > $heightRatio ? $widthRatio : $heightRatio;
+            $ratio = min($widthRatio, $heightRatio);
 
             $filter = new Resize(new Box($origWidth * $ratio, $origHeight * $ratio));
 

--- a/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Liip\ImagineBundle\Tests\Filter;
+
+use Imagine\Image\Box;
+use Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
+
+/**
+ * Test cases for DownscaleFilterLoader class.
+ *
+ * @covers Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader
+ *
+ * @author Minin Anton <anton.a.minin@gmail.com>
+ */
+class DownscaleFilterLoaderTest extends AbstractTest
+{
+    public function testItWorksSomeHow()
+    {
+        $loader = new DownscaleFilterLoader();
+
+        $initialSize = new Box(50, 200);
+        $resultSize = new Box(50, 200);
+
+        $image = $this->getMockImage();
+        $image
+            ->method('getSize')
+            ->willReturn($initialSize)
+        ;
+        $image
+            ->method('resize')
+            ->willReturnCallback(function ($box) use (&$resultSize) {
+                $resultSize = $box;
+            })
+        ;
+
+        $loader->load($image, ['max' => [100, 100]]);
+
+        return [$initialSize, $resultSize];
+    }
+
+    /**
+     * @depends testItWorksSomeHow
+     */
+    public function testDontScaleUp($sizes)
+    {
+        list($initialSize, $resultSize) = $sizes;
+        $this->assertLessThanOrEqual($initialSize->getHeight(), $resultSize->getHeight());
+        $this->assertLessThanOrEqual($initialSize->getWidth(), $resultSize->getWidth());
+    }
+
+    /**
+     * @depends testItWorksSomeHow
+     */
+    public function testFitBoundingBox($sizes)
+    {
+        list($initialSize, $resultSize) = $sizes;
+        $this->assertLessThanOrEqual(100, $resultSize->getHeight());
+        $this->assertLessThanOrEqual(100, $resultSize->getWidth());
+    }
+}

--- a/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
@@ -34,9 +34,9 @@ class DownscaleFilterLoaderTest extends AbstractTest
             })
         ;
 
-        $loader->load($image, ['max' => [100, 100]]);
+        $loader->load($image, array('max' => array(100, 100)));
 
-        return [$initialSize, $resultSize];
+        return array($initialSize, $resultSize);
     }
 
     /**


### PR DESCRIPTION
```
liip_imagine:
    filter_sets:
        my_downscale:
            filters:
                downscale: { max: [400,400] }  # Transforms 800x1600 to 200x400 rather than 400x800
```