### PR TITLE
Add FileBinary[Interface] to support large files without loading them in memory unnecessarily

### DIFF
--- a/Binary/FileBinaryInterface.php
+++ b/Binary/FileBinaryInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Liip\ImagineBundle\Binary;
+
+interface FileBinaryInterface extends BinaryInterface
+{
+    /**
+     * @return string
+     */
+    public function getPath();
+}

--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -2,7 +2,7 @@
 
 namespace Liip\ImagineBundle\Binary\Loader;
 
-use Liip\ImagineBundle\Model\Binary;
+use Liip\ImagineBundle\Model\FileBinary;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
@@ -57,8 +57,8 @@ class FileSystemLoader implements LoaderInterface
 
         $mimeType = $this->mimeTypeGuesser->guess($absolutePath);
 
-        return new Binary(
-            file_get_contents($absolutePath),
+        return new FileBinary(
+            $absolutePath,
             $mimeType,
             $this->extensionGuesser->guess($mimeType)
         );

--- a/Imagine/Filter/FilterManager.php
+++ b/Imagine/Filter/FilterManager.php
@@ -4,6 +4,7 @@ namespace Liip\ImagineBundle\Imagine\Filter;
 
 use Imagine\Image\ImagineInterface;
 use Liip\ImagineBundle\Binary\BinaryInterface;
+use Liip\ImagineBundle\Binary\FileBinaryInterface;
 use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
 use Liip\ImagineBundle\Imagine\Filter\PostProcessor\PostProcessorInterface;
 use Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface;
@@ -100,7 +101,11 @@ class FilterManager
             $config
         );
 
-        $image = $this->imagine->load($binary->getContent());
+        if ($binary instanceof FileBinaryInterface) {
+            $image = $this->imagine->open($binary->getPath());
+        } else {
+            $image = $this->imagine->load($binary->getContent());
+        }
 
         foreach ($config['filters'] as $eachFilter => $eachOptions) {
             if (!isset($this->loaders[$eachFilter])) {

--- a/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
@@ -3,7 +3,8 @@
 namespace Liip\ImagineBundle\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;
-use Liip\ImagineBundle\Model\Binary;
+use Liip\ImagineBundle\Binary\FileBinaryInterface;
+use Liip\ImagineBundle\Model\FileBinary;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\ProcessBuilder;
 
@@ -112,7 +113,11 @@ class JpegOptimPostProcessor implements PostProcessorInterface
         }
 
         $pb->add($input = tempnam(sys_get_temp_dir(), 'imagine_jpegoptim'));
-        file_put_contents($input, $binary->getContent());
+        if ($binary instanceof FileBinaryInterface) {
+            copy($binary->getPath(), $input);
+        } else {
+            file_put_contents($input, $binary->getContent());
+        }
 
         $proc = $pb->getProcess();
         $proc->run();
@@ -122,7 +127,7 @@ class JpegOptimPostProcessor implements PostProcessorInterface
             throw new ProcessFailedException($proc);
         }
 
-        $result = new Binary(file_get_contents($input), $binary->getMimeType(), $binary->getFormat());
+        $result = new FileBinary($input, $binary->getMimeType(), $binary->getFormat());
 
         unlink($input);
 

--- a/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
@@ -3,7 +3,8 @@
 namespace Liip\ImagineBundle\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;
-use Liip\ImagineBundle\Model\Binary;
+use Liip\ImagineBundle\Binary\FileBinaryInterface;
+use Liip\ImagineBundle\Model\FileBinary;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\ProcessBuilder;
 
@@ -42,7 +43,11 @@ class OptiPngPostProcessor implements PostProcessorInterface
 
         $pb->add('--o7');
         $pb->add($input = tempnam(sys_get_temp_dir(), 'imagine_optipng'));
-        file_put_contents($input, $binary->getContent());
+        if ($binary instanceof FileBinaryInterface) {
+            copy($binary->getPath(), $input);
+        } else {
+            file_put_contents($input, $binary->getContent());
+        }
 
         $proc = $pb->getProcess();
         $proc->run();
@@ -52,7 +57,7 @@ class OptiPngPostProcessor implements PostProcessorInterface
             throw new ProcessFailedException($proc);
         }
 
-        $result = new Binary(file_get_contents($input), $binary->getMimeType(), $binary->getFormat());
+        $result = new FileBinary($input, $binary->getMimeType(), $binary->getFormat());
 
         unlink($input);
 

--- a/Model/FileBinary.php
+++ b/Model/FileBinary.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Liip\ImagineBundle\Model;
+
+use Liip\ImagineBundle\Binary\FileBinaryInterface;
+
+class FileBinary implements FileBinaryInterface
+{
+    /**
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * @var string
+     */
+    protected $mimeType;
+
+    /**
+     * @var string
+     */
+    protected $format;
+
+    /**
+     * @param string $content
+     * @param string $mimeType
+     * @param string $format
+     */
+    public function __construct($path, $mimeType, $format = null)
+    {
+        $this->path = $path;
+        $this->mimeType = $mimeType;
+        $this->format = $format;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent()
+    {
+        return file_get_contents($this->path);
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMimeType()
+    {
+        return $this->mimeType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+}

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -102,7 +102,7 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
 
         $binary = $loader->find($path);
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $binary);
+        $this->assertInstanceOf('Liip\ImagineBundle\Model\FileBinary', $binary);
         $this->assertStringStartsWith('text/', $binary->getMimeType());
     }
 }


### PR DESCRIPTION
This works in combination with https://github.com/avalanche123/Imagine/pull/479 to allow me to generate thumbnails for very large images (>1GB) with low memory usage (tested with 50MB) vs needing to increase the memory usage to a few gigs.

It should be BC as far as I can tell.