### PR TITLE
StreamLoader-exception-arguments

### DIFF
--- a/Binary/Loader/StreamLoader.php
+++ b/Binary/Loader/StreamLoader.php
@@ -61,7 +61,7 @@ class StreamLoader implements LoaderInterface
         try {
             $content = file_get_contents($name, null, $this->context);
         } catch (\Exception $e) {
-            throw new NotLoadableException(sprintf('Source image %s could not be loaded.', $name), $e);
+            throw new NotLoadableException(sprintf('Source image %s could not be loaded.', $name), $e->getCode(), $e);
         }
 
         if (false === $content) {


### PR DESCRIPTION
Fix wrong arguments when throwing NotLoadableException. Previous exception must be third argument