### PR TITLE
Fix tempnam usages

### DIFF
--- a/Binary/SimpleMimeTypeGuesser.php
+++ b/Binary/SimpleMimeTypeGuesser.php
@@ -24,7 +24,9 @@ class SimpleMimeTypeGuesser implements MimeTypeGuesserInterface
      */
     public function guess($binary)
     {
-        $tmpFile = tempnam(sys_get_temp_dir(), 'liip-imagine-bundle');
+        if (false === $tmpFile = tempnam(sys_get_temp_dir(), 'liip-imagine-bundle')) {
+            throw new \RuntimeException(sprintf('Temp file can not be created in "%s".', sys_get_temp_dir()));
+        }
 
         try {
             file_put_contents($tmpFile, $binary);

--- a/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
@@ -96,6 +96,10 @@ class JpegOptimPostProcessor implements PostProcessorInterface
             return $binary;
         }
 
+        if (false === $input = tempnam(sys_get_temp_dir(), 'imagine_jpegoptim')) {
+            throw new \RuntimeException(sprintf('Temp file can not be created in "%s".', sys_get_temp_dir()));
+        }
+
         $pb = new ProcessBuilder(array($this->jpegoptimBin));
 
         if ($this->stripAll) {
@@ -112,7 +116,7 @@ class JpegOptimPostProcessor implements PostProcessorInterface
             $pb->add('--all-normal');
         }
 
-        $pb->add($input = tempnam(sys_get_temp_dir(), 'imagine_jpegoptim'));
+        $pb->add($input);
         if ($binary instanceof FileBinaryInterface) {
             copy($binary->getPath(), $input);
         } else {

--- a/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
@@ -39,10 +39,14 @@ class OptiPngPostProcessor implements PostProcessorInterface
             return $binary;
         }
 
-        $pb = new ProcessBuilder(array($this->optipngBin));
+        if (false === $input = tempnam(sys_get_temp_dir(), 'imagine_optipng')) {
+            throw new \RuntimeException(sprintf('Temp file can not be created in "%s".', sys_get_temp_dir()));
+        }
 
+        $pb = new ProcessBuilder(array($this->optipngBin));
         $pb->add('--o7');
-        $pb->add($input = tempnam(sys_get_temp_dir(), 'imagine_optipng'));
+        $pb->add($input);
+
         if ($binary instanceof FileBinaryInterface) {
             copy($binary->getPath(), $input);
         } else {


### PR DESCRIPTION
`tempnam` returns false if the temporary file can not be created. This happens for example when the system temp dir is restricted by `open_basedir` and it leads hard to understand errors.