### PR TITLE
Quote strings starting '%' in YAML

### DIFF
--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -4,24 +4,24 @@ parameters:
 
 framework:
     #esi:             ~
-    #translator:      { fallback: %locale% }
+    #translator:      { fallback: "%locale%" }
     test: ~
     templating:      { engines: ['php'] }
     session:
         storage_id: session.storage.mock_file
-    secret:          %secret%
+    secret:          "%secret%"
     router:          { resource: "%kernel.root_dir%/config/routing.yml" }
-    default_locale:  %locale%
+    default_locale:  "%locale%"
 
 liip_imagine:
     loaders:
         default:
             filesystem:
-                data_root: %kernel.root_dir%/web
+                data_root: "%kernel.root_dir%/web"
     resolvers:
         default:
             web_path:
-                web_root: %kernel.root_dir%/web
+                web_root: "%kernel.root_dir%/web"
                 cache_prefix: media/cache
 
     filter_sets:


### PR DESCRIPTION
As of Symfony 3.1, having unquoted scalars starting with “%” in YAML is deprecated, and will throw an exception in Symfony 4.0. This PR adds quotes to the few instances present.