### PR TITLE
Ignore invalid exif orientations

### DIFF
--- a/Imagine/Filter/Loader/AutoRotateFilterLoader.php
+++ b/Imagine/Filter/Loader/AutoRotateFilterLoader.php
@@ -24,9 +24,7 @@ class AutoRotateFilterLoader implements LoaderInterface
     {
         if ($orientation = $this->getOrientation($image)) {
             if ($orientation < 1 || $orientation > 8) {
-                throw new InvalidArgumentException(
-                    sprintf('The image has wrong EXIF orientation tag (%d)', $orientation)
-                );
+                return $image;
             }
 
             // Rotates if necessary.

--- a/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
@@ -156,12 +156,16 @@ class AutoRotateFilterLoaderTest extends AbstractTest
     /**
      * Theoretically Orientation is `short` (uint16), so it could be anything
      * from [0; 65535].
-     *
-     * @expectedException \Imagine\Exception\InvalidArgumentException
      */
-    public function testLoadExifInvalid()
+    public static function getInvalidOrientations()
     {
-        $this->loadExif('10', null, false);
+        return array(array(0, 9, 255, 65535));
+    }
+
+    /** @dataProvider getInvalidOrientations */
+    public function testLoadExifInvalid($orientation)
+    {
+        $this->loadExif($orientation, null, false);
     }
 
     /**


### PR DESCRIPTION
While exif orientation values should theoretically only be between 1 and 8, the reality is different. We’ve seen all kinds of values from 0 to 256 to 65535.