### PR TITLE
clean filename for WebPathResolver

### DIFF
--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -69,7 +69,11 @@ class WebPathResolver implements ResolverInterface
      */
     public function isStored($path, $filter)
     {
-        return is_file($this->getFilePath($path, $filter));
+        return is_file(
+            $this->cleanPath(
+                $this->getFilePath($path, $filter)
+            )
+        );
     }
 
     /**
@@ -78,9 +82,27 @@ class WebPathResolver implements ResolverInterface
     public function store(BinaryInterface $binary, $path, $filter)
     {
         $this->filesystem->dumpFile(
-            $this->getFilePath($path, $filter),
+            $this->cleanPath(
+                $this->getFilePath($path, $filter)
+            ),
             $binary->getContent()
         );
+    }
+
+    /**
+     * remove url part with parameters
+     * from filename
+     *
+     * @param $path
+     * @return string
+     */
+    public function cleanPath($path)
+    {
+        if (false !== ($pos = strpos($path, '?'))) {
+            $path = substr($path, 0, $pos);
+        }
+
+        return $path;
     }
 
     /**


### PR DESCRIPTION

This PR help us make filename more friendly for file system. It is can be helpful when we user url with some parameters and path.

Example of url:
```
    http://gravatar.com/avatar/e4fb8bac7961505d218aba493994e1d8?s=80&r=g&d=mm
```

It will be converted into `avatar/e4fb8bac7961505d218aba493994e1d8` and that name can be successfully saved.

Example of config:
```
liip_imagine:
    loaders:
        ...
        stream.url:
            stream:
                wrapper: http://www.gravatar.com/

    ...
    filter_sets:
        ...
        cache_url_medium:
            data_loader: stream.url
            quality: 70
            filters:
                thumbnail: { size: [77, 81], mode: outbound }

```



