### PR TITLE
Remove url part with parameters from filename.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -100,7 +100,9 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('driver')->defaultValue('gd')
                     ->validate()
-                        ->ifTrue(function ($v) { return !in_array($v, array('gd', 'imagick', 'gmagick')); })
+                        ->ifTrue(function ($v) {
+                            return !in_array($v, array('gd', 'imagick', 'gmagick'));
+                        })
                         ->thenInvalid('Invalid imagine driver specified: %s')
                     ->end()
                 ->end()

--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -60,7 +60,10 @@ class WebPathResolver implements ResolverInterface
     {
         return sprintf('%s/%s',
             $this->getBaseUrl(),
-            $this->getFileUrl($path, $filter)
+            $this->getFileUrl(
+                $this->cleanPath($path),
+                $filter
+            )
         );
     }
 
@@ -69,7 +72,11 @@ class WebPathResolver implements ResolverInterface
      */
     public function isStored($path, $filter)
     {
-        return is_file($this->getFilePath($path, $filter));
+        return is_file(
+            $this->cleanPath(
+                $this->getFilePath($path, $filter)
+            )
+        );
     }
 
     /**
@@ -78,9 +85,26 @@ class WebPathResolver implements ResolverInterface
     public function store(BinaryInterface $binary, $path, $filter)
     {
         $this->filesystem->dumpFile(
-            $this->getFilePath($path, $filter),
+            $this->cleanPath(
+                $this->getFilePath($path, $filter)
+            ),
             $binary->getContent()
         );
+    }
+
+    /**
+     * Transform url to hashed filname.
+     *
+     * @param $path
+     *
+     * @return string
+     */
+    public function cleanPath($path)
+    {
+        $dir = pathinfo($path, PATHINFO_DIRNAME);
+        $filename = pathinfo($path, PATHINFO_FILENAME);
+
+        return $dir.DIRECTORY_SEPARATOR.sha1($filename);
     }
 
     /**

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -4,24 +4,24 @@ parameters:
 
 framework:
     #esi:             ~
-    #translator:      { fallback: %locale% }
+    #translator:      { fallback: "%locale%" }
     test: ~
     templating:      { engines: ['php'] }
     session:
         storage_id: session.storage.mock_file
-    secret:          %secret%
+    secret:          "%secret%"
     router:          { resource: "%kernel.root_dir%/config/routing.yml" }
-    default_locale:  %locale%
+    default_locale:  "%locale%"
 
 liip_imagine:
     loaders:
         default:
             filesystem:
-                data_root: %kernel.root_dir%/web
+                data_root: "%kernel.root_dir%/web"
     resolvers:
         default:
             web_path:
-                web_root: %kernel.root_dir%/web
+                web_root: "%kernel.root_dir%/web"
                 cache_prefix: media/cache
 
     filter_sets:

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -20,5 +20,5 @@ namespace Symfony\Component\ExpressionLanguage {
 
     interface ExpressionFunctionProviderInterface
     {
-    };
+    }
 }


### PR DESCRIPTION
This PR help us make filename more friendly for file system. It can be helpful when we use url with some parameters and path.

Example of url:
```
    http://gravatar.com/avatar/e4fb8bac7961505d218aba493994e1d8?s=80&r=g&d=mm
```

It will be converted into `avatar/e4fb8bac7961505d218aba493994e1d8` and that name can be successfully saved.

Example of config:
```
liip_imagine:
    loaders:
        ...
        stream.url:
            stream:
                wrapper: http://www.gravatar.com/

    ...
    filter_sets:
        ...
        cache_url_medium:
            data_loader: stream.url
            quality: 70
            filters:
                thumbnail: { size: [77, 81], mode: outbound }

```


This PR  was recreated form PR #753 