### PR TITLE
Replaced deprecated factory_class and factory_method

### DIFF
--- a/Resources/doc/cache-resolver/aws_s3.rst
+++ b/Resources/doc/cache-resolver/aws_s3.rst
@@ -64,8 +64,7 @@ You have to set up the services required:
     services:
         acme.amazon_s3:
             class: Aws\S3\S3Client
-            factory_class: Aws\S3\S3Client
-            factory_method:  factory
+            factory: [Aws\S3\S3Client, factory]
             arguments:
                 -
                     key: %amazon.s3.key%
@@ -87,8 +86,7 @@ must be an associative array containing key and secret.
 
     acme.amazon_s3:
         class: Aws\S3\S3Client
-        factory_class: Aws\S3\S3Client
-        factory_method:  factory
+        factory: [Aws\S3\S3Client, factory]
         arguments:
             -
                 credentials: { key: %amazon.s3.key%, secret: %amazon.s3.secret% }


### PR DESCRIPTION
Removed the deprecated `factory_class` and `factory_method` service definition options and replaced them with the `factory` option.

Should I also still reference the old way for Symfony <2.6 usage?