### PR TITLE
Scale filter and Downscale and Upscale as derivatives, with a new feature

### DIFF
--- a/Imagine/Filter/Loader/DownscaleFilterLoader.php
+++ b/Imagine/Filter/Loader/DownscaleFilterLoader.php
@@ -2,41 +2,22 @@
 
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
-use Imagine\Filter\Basic\Resize;
-use Imagine\Image\ImageInterface;
-use Imagine\Image\Box;
-
 /**
- * downscale filter.
+ * Downscale filter.
+ *
+ * @author Devi Prasad <https://github.com/deviprsd21>
  */
-class DownscaleFilterLoader implements LoaderInterface
+class DownscaleFilterLoader extends ScaleFilterLoader
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function load(ImageInterface $image, array $options = array())
-    {
-        if (!isset($options['max'])) {
-            throw new \InvalidArgumentException('Missing max option.');
-        }
+    public function __construct () {
+        parent::__construct('max', 'by', false);
+    }
 
-        list($width, $height) = $options['max'];
+    protected function calcAbsoluteRatio ($ratio) {
+        return 1 - ($ratio > 1 ? $ratio - floor($ratio) : $ratio);
+    }
 
-        $size = $image->getSize();
-        $origWidth = $size->getWidth();
-        $origHeight = $size->getHeight();
-
-        if ($origWidth > $width || $origHeight > $height) {
-            $widthRatio = $width / $origWidth;
-            $heightRatio = $height / $origHeight;
-
-            $ratio = min($widthRatio, $heightRatio);
-
-            $filter = new Resize(new Box($origWidth * $ratio, $origHeight * $ratio));
-
-            return $filter->apply($image);
-        }
-
-        return $image;
+    protected function isImageProcessable ($ratio) {
+        return $ratio < 1;
     }
 }

--- a/Imagine/Filter/Loader/DownscaleFilterLoader.php
+++ b/Imagine/Filter/Loader/DownscaleFilterLoader.php
@@ -9,15 +9,18 @@ namespace Liip\ImagineBundle\Imagine\Filter\Loader;
  */
 class DownscaleFilterLoader extends ScaleFilterLoader
 {
-    public function __construct () {
+    public function __construct()
+    {
         parent::__construct('max', 'by', false);
     }
 
-    protected function calcAbsoluteRatio ($ratio) {
+    protected function calcAbsoluteRatio($ratio)
+    {
         return 1 - ($ratio > 1 ? $ratio - floor($ratio) : $ratio);
     }
 
-    protected function isImageProcessable ($ratio) {
+    protected function isImageProcessable($ratio)
+    {
         return $ratio < 1;
     }
 }

--- a/Imagine/Filter/Loader/ScaleFilterLoader.php
+++ b/Imagine/Filter/Loader/ScaleFilterLoader.php
@@ -13,7 +13,8 @@ use Imagine\Image\Box;
  */
 class ScaleFilterLoader implements LoaderInterface
 {
-    public function __construct ($dimentionKey = 'dim', $ratioKey = 'to', $absoluteRatio = true) {
+    public function __construct($dimentionKey = 'dim', $ratioKey = 'to', $absoluteRatio = true)
+    {
         $this->dimentionKey = $dimentionKey;
         $this->ratioKey = $ratioKey;
         $this->absoluteRatio = $absoluteRatio;
@@ -34,7 +35,7 @@ class ScaleFilterLoader implements LoaderInterface
 
         if (isset($options[$this->ratioKey])) {
             $ratio = $this->absoluteRatio ? $options[$this->ratioKey] : $this->calcAbsoluteRatio($options[$this->ratioKey]);
-        } else if (isset($options[$this->dimentionKey])) {
+        } elseif (isset($options[$this->dimentionKey])) {
             list($width, $height) = $options[$this->dimentionKey];
 
             $widthRatio = $width / $origWidth;
@@ -45,7 +46,7 @@ class ScaleFilterLoader implements LoaderInterface
             } else {
                 $ratio = min($widthRatio, $heightRatio);
             }
-        }        
+        }
 
         if ($this->isImageProcessable($ratio)) {
             $filter = new Resize(new Box(round($origWidth * $ratio), round($origHeight * $ratio)));
@@ -56,11 +57,13 @@ class ScaleFilterLoader implements LoaderInterface
         return $image;
     }
 
-    protected function calcAbsoluteRatio ($ratio) {
+    protected function calcAbsoluteRatio($ratio)
+    {
         return $ratio;
     }
 
-    protected function isImageProcessable ($ratio) {
+    protected function isImageProcessable($ratio)
+    {
         return true;
     }
 }

--- a/Imagine/Filter/Loader/ScaleFilterLoader.php
+++ b/Imagine/Filter/Loader/ScaleFilterLoader.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Liip\ImagineBundle\Imagine\Filter\Loader;
+
+use Imagine\Filter\Basic\Resize;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\Box;
+
+/**
+ * Scale filter.
+ *
+ * @author Devi Prasad <https://github.com/deviprsd21>
+ */
+class ScaleFilterLoader implements LoaderInterface
+{
+    public function __construct ($dimentionKey = 'dim', $ratioKey = 'to', $absoluteRatio = true) {
+        $this->dimentionKey = $dimentionKey;
+        $this->ratioKey = $ratioKey;
+        $this->absoluteRatio = $absoluteRatio;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(ImageInterface $image, array $options = array())
+    {
+        if (!isset($options[$this->dimentionKey]) && !isset($options[$this->ratioKey])) {
+            throw new \InvalidArgumentException("Missing $this->dimentionKey or $this->ratioKey option.");
+        }
+
+        $size = $image->getSize();
+        $origWidth = $size->getWidth();
+        $origHeight = $size->getHeight();
+
+        if (isset($options[$this->ratioKey])) {
+            $ratio = $this->absoluteRatio ? $options[$this->ratioKey] : $this->calcAbsoluteRatio($options[$this->ratioKey]);
+        } else if (isset($options[$this->dimentionKey])) {
+            list($width, $height) = $options[$this->dimentionKey];
+
+            $widthRatio = $width / $origWidth;
+            $heightRatio = $height / $origHeight;
+
+            if (null == $width || null == $height) {
+                $ratio = max($widthRatio, $heightRatio);
+            } else {
+                $ratio = min($widthRatio, $heightRatio);
+            }
+        }        
+
+        if ($this->isImageProcessable($ratio)) {
+            $filter = new Resize(new Box(round($origWidth * $ratio), round($origHeight * $ratio)));
+
+            return $filter->apply($image);
+        }
+
+        return $image;
+    }
+
+    protected function calcAbsoluteRatio ($ratio) {
+        return $ratio;
+    }
+
+    protected function isImageProcessable ($ratio) {
+        return true;
+    }
+}

--- a/Imagine/Filter/Loader/UpscaleFilterLoader.php
+++ b/Imagine/Filter/Loader/UpscaleFilterLoader.php
@@ -2,43 +2,23 @@
 
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
-use Imagine\Filter\Basic\Resize;
-use Imagine\Image\ImageInterface;
-use Imagine\Image\Box;
-
 /**
  * Upscale filter.
  *
  * @author Maxime Colin <contact@maximecolin.fr>
+ * @author Devi Prasad <https://github.com/deviprsd21>
  */
-class UpscaleFilterLoader implements LoaderInterface
+class UpscaleFilterLoader extends ScaleFilterLoader
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function load(ImageInterface $image, array $options = array())
-    {
-        if (!isset($options['min'])) {
-            throw new \InvalidArgumentException('Missing min option.');
-        }
+    public function __construct () {
+        parent::__construct('min', 'by', false);
+    }
+    
+    protected function calcAbsoluteRatio ($ratio) {
+        return 1 + $ratio;
+    }
 
-        list($width, $height) = $options['min'];
-
-        $size = $image->getSize();
-        $origWidth = $size->getWidth();
-        $origHeight = $size->getHeight();
-
-        if ($origWidth < $width || $origHeight < $height) {
-            $widthRatio = $width / $origWidth;
-            $heightRatio = $height / $origHeight;
-
-            $ratio = $widthRatio > $heightRatio ? $widthRatio : $heightRatio;
-
-            $filter = new Resize(new Box(round($origWidth * $ratio), round($origHeight * $ratio)));
-
-            return $filter->apply($image);
-        }
-
-        return $image;
+    protected function isImageProcessable ($ratio) {
+        return $ratio > 1;
     }
 }

--- a/Imagine/Filter/Loader/UpscaleFilterLoader.php
+++ b/Imagine/Filter/Loader/UpscaleFilterLoader.php
@@ -10,15 +10,18 @@ namespace Liip\ImagineBundle\Imagine\Filter\Loader;
  */
 class UpscaleFilterLoader extends ScaleFilterLoader
 {
-    public function __construct () {
+    public function __construct()
+    {
         parent::__construct('min', 'by', false);
     }
-    
-    protected function calcAbsoluteRatio ($ratio) {
+
+    protected function calcAbsoluteRatio($ratio)
+    {
         return 1 + $ratio;
     }
 
-    protected function isImageProcessable ($ratio) {
+    protected function isImageProcessable($ratio)
+    {
         return $ratio > 1;
     }
 }

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -40,6 +40,7 @@
         <parameter key="liip_imagine.filter.loader.watermark.class">Liip\ImagineBundle\Imagine\Filter\Loader\WatermarkFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.strip.class">Liip\ImagineBundle\Imagine\Filter\Loader\StripFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.background.class">Liip\ImagineBundle\Imagine\Filter\Loader\BackgroundFilterLoader</parameter>
+        <parameter key="liip_imagine.filter.loader.scale.class">Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.upscale.class">Liip\ImagineBundle\Imagine\Filter\Loader\UpscaleFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.downscale.class">Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.auto_rotate.class">Liip\ImagineBundle\Imagine\Filter\Loader\AutoRotateFilterLoader</parameter>
@@ -191,6 +192,10 @@
 
         <service id="liip_imagine.filter.loader.strip" class="%liip_imagine.filter.loader.strip.class%">
             <tag name="liip_imagine.filter.loader" loader="strip" />
+        </service>
+
+        <service id="liip_imagine.filter.loader.scale" class="%liip_imagine.filter.loader.scale.class%">
+            <tag name="liip_imagine.filter.loader" loader="scale" />
         </service>
 
         <service id="liip_imagine.filter.loader.upscale" class="%liip_imagine.filter.loader.upscale.class%">

--- a/Resources/doc/filters.rst
+++ b/Resources/doc/filters.rst
@@ -65,12 +65,26 @@ annotated configuration examples:
                 filters:
                     relative_resize: { scale: 2.5 }   # Transforms 50x40 to 125x100
 
+The ``scale`` filter
+~~~~~~~~~~~~~~~~~~~~~~
+
+It performs an upscale or downscale transformation on your image to increase its size to the
+given dimensions or ratio:
+
+.. code-block:: yaml
+
+    liip_imagine:
+        filter_sets:
+            my_thumb:
+                filters:
+                    scale: { dim: [600, 750] } #or { to: 1.56 } -> Upscales to [936, 1170] | { to: 0.66 } -> Downscales to [396, 495]
+
 
 The ``upscale`` filter
 ~~~~~~~~~~~~~~~~~~~~~~
 
 It performs an upscale transformation on your image to increase its size to the
-given dimensions:
+given dimensions or ratio:
 
 .. code-block:: yaml
 
@@ -78,13 +92,13 @@ given dimensions:
         filter_sets:
             my_thumb:
                 filters:
-                    upscale: { min: [800, 600] }
+                    upscale: { min: [800, 600] } #or { by: 0.7 } -> Upscales to [1360, 1020]
 
 The ``downscale`` filter
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 It performs a downscale transformation on your image to reduce its size to the
-given dimensions:
+given dimensions or ratio:
 
 .. code-block:: yaml
 
@@ -92,7 +106,7 @@ given dimensions:
         filter_sets:
             my_thumb:
                 filters:
-                    downscale: { max: [1980, 1280] }
+                    downscale: { max: [1980, 1280] } #or { by: 0.6 } -> Downscales to [792, 512]
 
 The ``crop`` filter
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Like I suggested in #770 Creating a new filter **scale** and deriving upscale and downscale from it will be much clear. Other than that, there are new options like **by** or **to** depending upon filter where a relative ratio or absolute ratio respectively can be set to up or down scale the image. For example, 

```yaml
filters:
    downscale: { max: [50, 70] } #or { by: 0.6 } -> Downscales to 40%
    upscale: { min: [200,null] } #or { by: 0.7 } -> Upscales to 170%
    scale: { dim: [600,750] } #or { to: 1.56 } -> Upscales to 156% | { to: 0.66 } -> Downscales to 66%
```
Though relative_resize has a scale method, the scale filter is more flexible than the latter.