### PR TITLE
Amend path resolution handlers and outside root check conditional in FileSystemLoader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 composer.phar
 vendor/
 Tests/Functional/app/web/media/cache
+.idea/

--- a/Exception/InvalidArgumentException.php
+++ b/Exception/InvalidArgumentException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Liip\ImagineBundle\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}


### PR DESCRIPTION
Fixes #763 by allowing "../" in both root and asset paths. Loading assets is still "chrooted" within the root path using a simple (and quick!) strpos check.

Test included!