### PR TITLE
Add visibility argument to flysystem resolver

### DIFF
--- a/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
@@ -18,6 +18,7 @@ class FlysystemResolverFactory implements ResolverFactoryInterface
         $resolverDefinition->replaceArgument(0, new Reference($config['filesystem_service']));
         $resolverDefinition->replaceArgument(2, $config['root_url']);
         $resolverDefinition->replaceArgument(3, $config['cache_prefix']);
+        $resolverDefinition->addArgument($config['visibility']);
         $resolverDefinition->addTag('liip_imagine.cache.resolver', array(
             'resolver' => $resolverName,
         ));
@@ -46,6 +47,7 @@ class FlysystemResolverFactory implements ResolverFactoryInterface
                 ->scalarNode('filesystem_service')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('cache_prefix')->defaultValue(null)->end()
                 ->scalarNode('root_url')->isRequired()->cannotBeEmpty()->end()
+                ->enumNode('visibility')->values(array('public', 'private'))->defaultValue('public')->end()
             ->end()
         ;
     }

--- a/Imagine/Cache/Resolver/FlysystemResolver.php
+++ b/Imagine/Cache/Resolver/FlysystemResolver.php
@@ -2,6 +2,7 @@
 
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
+use League\Flysystem\AdapterInterface;
 use League\Flysystem\Filesystem;
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;
@@ -35,18 +36,29 @@ class FlysystemResolver implements ResolverInterface
     protected $cacheRoot;
 
     /**
+     * Flysystem specific visibility.
+     *
+     * @see AdapterInterface
+     *
+     * @var string
+     */
+    protected $visibility;
+
+    /**
      * FlysystemResolver constructor.
      *
      * @param Filesystem     $flysystem
      * @param RequestContext $requestContext
-     * @param $rootUrl
-     * @param string $cachePrefix
+     * @param string         $rootUrl
+     * @param string         $cachePrefix
+     * @param string         $visibility
      */
     public function __construct(
         Filesystem $flysystem,
         RequestContext $requestContext,
         $rootUrl,
-        $cachePrefix = 'media/cache'
+        $cachePrefix = 'media/cache',
+        $visibility = AdapterInterface::VISIBILITY_PUBLIC
     ) {
         $this->flysystem = $flysystem;
         $this->requestContext = $requestContext;
@@ -54,6 +66,7 @@ class FlysystemResolver implements ResolverInterface
         $this->webRoot = rtrim($rootUrl, '/');
         $this->cachePrefix = ltrim(str_replace('//', '/', $cachePrefix), '/');
         $this->cacheRoot = $this->cachePrefix;
+        $this->visibility = $visibility;
     }
 
     /**
@@ -118,7 +131,8 @@ class FlysystemResolver implements ResolverInterface
     {
         $this->flysystem->put(
             $this->getFilePath($path, $filter),
-            $binary->getContent()
+            $binary->getContent(),
+            ['visibility' => $this->visibility]
         );
     }
 

--- a/Resources/doc/cache-resolver/flysystem.rst
+++ b/Resources/doc/cache-resolver/flysystem.rst
@@ -21,6 +21,7 @@ Create resolver
                     filesystem_service: oneup_flysystem.profile_photos_filesystem
                     root_url: http://images.example.com
                     cache_prefix: media/cache
+                    visibility: public
     oneup_flysystem:
         adapters:
             profile_photos:
@@ -39,6 +40,11 @@ There are several configuration options available:
 * ``cache_prefix`` - this is used for the image path generation. This will be the
   prefix inside the given Flysystem.
   Default value: ``media/cache``
+* ``visibility`` - one of the two predefined flysystem visibility constants
+  (``AdapterInterface::VISIBILITY_PUBLIC`` [``public``] / ``AdapterInterface::VISIBILITY_PRIVATE`` [``private``])
+  The visibility is applied, when the objects are stored on a flysystem filesystem.
+  You will most probably want to leave the default or explicitly set ``public``.
+  Default value: ``public``
 
 Usage
 -----


### PR DESCRIPTION
Before this, there was no way to modify the visibility in a central place,
which was fine for local resolvers, or with predefined acls.

This changeset introduces a new `visibility` argument on the FlysystemResolver
that will be taken into account everytime a cache object is written to a flysystem
filesystem.

The default is public, so that cached objects are accessible from the outside,
which should be sensible.