### PR TITLE
Tempdir for postprocessors

### DIFF
--- a/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
@@ -35,19 +35,33 @@ class JpegOptimPostProcessor implements PostProcessorInterface, ConfigurablePost
     protected $progressive;
 
     /**
+     * Directory where temporary file will be written.
+     *
+     * @var string
+     */
+    protected $tempDir;
+
+    /**
      * Constructor.
      *
      * @param string $jpegoptimBin Path to the jpegoptim binary
      * @param bool   $stripAll     Strip all markers from output
      * @param int    $max          Set maximum image quality factor
      * @param bool   $progressive  Force output to be progressive
+     * @param string $tempDir      Directory where temporary file will be written
      */
-    public function __construct($jpegoptimBin = '/usr/bin/jpegoptim', $stripAll = true, $max = null, $progressive = true)
-    {
+    public function __construct(
+        $jpegoptimBin = '/usr/bin/jpegoptim',
+        $stripAll = true,
+        $max = null,
+        $progressive = true,
+        $tempDir = '/run/shm/'
+    ) {
         $this->jpegoptimBin = $jpegoptimBin;
         $this->stripAll = $stripAll;
         $this->max = $max;
         $this->progressive = $progressive;
+        $this->tempDir = $tempDir;
     }
 
     /**
@@ -119,8 +133,9 @@ class JpegOptimPostProcessor implements PostProcessorInterface, ConfigurablePost
             return $binary;
         }
 
-        if (false === $input = tempnam(sys_get_temp_dir(), 'imagine_jpegoptim')) {
-            throw new \RuntimeException(sprintf('Temp file can not be created in "%s".', sys_get_temp_dir()));
+        $tempDir = array_key_exists('temp_dir', $options) ? $options['temp_dir'] : $this->tempDir;
+        if (false === $input = tempnam($tempDir, 'imagine_jpegoptim')) {
+            throw new \RuntimeException(sprintf('Temp file can not be created in "%s".', $tempDir));
         }
 
         $pb = new ProcessBuilder(array($this->jpegoptimBin));

--- a/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
@@ -61,7 +61,7 @@ class OptiPngPostProcessor implements PostProcessorInterface, ConfigurablePostPr
      */
     public function process(BinaryInterface $binary)
     {
-        $this->processWithConfiguration($binary, array());
+        return $this->processWithConfiguration($binary, array());
     }
 
     /**

--- a/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
@@ -30,17 +30,26 @@ class OptiPngPostProcessor implements PostProcessorInterface, ConfigurablePostPr
     protected $stripAll;
 
     /**
+     * Directory where temporary file will be written.
+     *
+     * @var string
+     */
+    protected $tempDir;
+
+    /**
      * Constructor.
      *
      * @param string $optipngBin Path to the optipng binary
      * @param int    $level      Optimization level
      * @param bool   $stripAll   Strip metadata objects
+     * @param string $tempDir    Directory where temporary file will be written
      */
-    public function __construct($optipngBin = '/usr/bin/optipng', $level = 7, $stripAll = true)
+    public function __construct($optipngBin = '/usr/bin/optipng', $level = 7, $stripAll = true, $tempDir = '/run/shm/')
     {
         $this->optipngBin = $optipngBin;
         $this->level = $level;
         $this->stripAll = $stripAll;
+        $this->tempDir = $tempDir;
     }
 
     /**
@@ -72,8 +81,9 @@ class OptiPngPostProcessor implements PostProcessorInterface, ConfigurablePostPr
             return $binary;
         }
 
-        if (false === $input = tempnam(sys_get_temp_dir(), 'imagine_optipng')) {
-            throw new \RuntimeException(sprintf('Temp file can not be created in "%s".', sys_get_temp_dir()));
+        $tempDir = array_key_exists('temp_dir', $options) ? $options['temp_dir'] : $this->tempDir;
+        if (false === $input = tempnam($tempDir, 'imagine_optipng')) {
+            throw new \RuntimeException(sprintf('Temp file can not be created in "%s".', $tempDir));
         }
 
         $pb = new ProcessBuilder(array($this->optipngBin));


### PR DESCRIPTION
Hi again, guys! 

My company use this bundle in production (thank you very much for this, buy the way). 
We had a problem with too much disk writes because of use OptiPng and Jpegoptim post processors write temporary files on hard drive. I suggest to use for this purpose `/run/shm` folder by default, which should be present on all modern linux distros. 

If you're not ok with that, I can return previous default directory. 

PS: I thought about implement it using stdin and stdout like in others PostProcessors, but Optipng doesn't support this feature, and Jpegoptim supports it only for version 1.4+ (while default version in Ubuntu 14.04 is 1.3).

PS2: also I fixed bugfix, accidentally introduced by me a in [previous PR](https://github.com/liip/LiipImagineBundle/pull/764/files#diff-22cf136767e2f2ef8d453e5673d09397R55) :)