### PR TITLE
Tempdir for postprocessors

### DIFF
--- a/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
@@ -35,19 +35,33 @@ class JpegOptimPostProcessor implements PostProcessorInterface, ConfigurablePost
     protected $progressive;
 
     /**
+     * Directory where temporary file will be written.
+     *
+     * @var string
+     */
+    protected $tempDir;
+
+    /**
      * Constructor.
      *
      * @param string $jpegoptimBin Path to the jpegoptim binary
      * @param bool   $stripAll     Strip all markers from output
      * @param int    $max          Set maximum image quality factor
      * @param bool   $progressive  Force output to be progressive
+     * @param string $tempDir      Directory where temporary file will be written
      */
-    public function __construct($jpegoptimBin = '/usr/bin/jpegoptim', $stripAll = true, $max = null, $progressive = true)
-    {
+    public function __construct(
+        $jpegoptimBin = '/usr/bin/jpegoptim',
+        $stripAll = true,
+        $max = null,
+        $progressive = true,
+        $tempDir = ''
+    ) {
         $this->jpegoptimBin = $jpegoptimBin;
         $this->stripAll = $stripAll;
         $this->max = $max;
         $this->progressive = $progressive;
+        $this->tempDir = $tempDir ?: sys_get_temp_dir();
     }
 
     /**
@@ -119,8 +133,9 @@ class JpegOptimPostProcessor implements PostProcessorInterface, ConfigurablePost
             return $binary;
         }
 
-        if (false === $input = tempnam(sys_get_temp_dir(), 'imagine_jpegoptim')) {
-            throw new \RuntimeException(sprintf('Temp file can not be created in "%s".', sys_get_temp_dir()));
+        $tempDir = array_key_exists('temp_dir', $options) ? $options['temp_dir'] : $this->tempDir;
+        if (false === $input = tempnam($tempDir, 'imagine_jpegoptim')) {
+            throw new \RuntimeException(sprintf('Temp file can not be created in "%s".', $tempDir));
         }
 
         $pb = new ProcessBuilder(array($this->jpegoptimBin));

--- a/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
@@ -30,17 +30,26 @@ class OptiPngPostProcessor implements PostProcessorInterface, ConfigurablePostPr
     protected $stripAll;
 
     /**
+     * Directory where temporary file will be written.
+     *
+     * @var string
+     */
+    protected $tempDir;
+
+    /**
      * Constructor.
      *
      * @param string $optipngBin Path to the optipng binary
      * @param int    $level      Optimization level
      * @param bool   $stripAll   Strip metadata objects
+     * @param string $tempDir    Directory where temporary file will be written
      */
-    public function __construct($optipngBin = '/usr/bin/optipng', $level = 7, $stripAll = true)
+    public function __construct($optipngBin = '/usr/bin/optipng', $level = 7, $stripAll = true, $tempDir = '')
     {
         $this->optipngBin = $optipngBin;
         $this->level = $level;
         $this->stripAll = $stripAll;
+        $this->tempDir = $tempDir ?: sys_get_temp_dir();
     }
 
     /**
@@ -72,8 +81,9 @@ class OptiPngPostProcessor implements PostProcessorInterface, ConfigurablePostPr
             return $binary;
         }
 
-        if (false === $input = tempnam(sys_get_temp_dir(), 'imagine_optipng')) {
-            throw new \RuntimeException(sprintf('Temp file can not be created in "%s".', sys_get_temp_dir()));
+        $tempDir = array_key_exists('temp_dir', $options) ? $options['temp_dir'] : $this->tempDir;
+        if (false === $input = tempnam($tempDir, 'imagine_optipng')) {
+            throw new \RuntimeException(sprintf('Temp file can not be created in "%s".', $tempDir));
         }
 
         $pb = new ProcessBuilder(array($this->optipngBin));

--- a/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
@@ -52,7 +52,7 @@ class OptiPngPostProcessor implements PostProcessorInterface, ConfigurablePostPr
      */
     public function process(BinaryInterface $binary)
     {
-        $this->processWithConfiguration($binary, array());
+        return $this->processWithConfiguration($binary, array());
     }
 
     /**

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -74,11 +74,13 @@
         <parameter key="liip_imagine.jpegoptim.stripAll">true</parameter>
         <parameter key="liip_imagine.jpegoptim.max">null</parameter>
         <parameter key="liip_imagine.jpegoptim.progressive">true</parameter>
+        <parameter key="liip_imagine.jpegoptim.tempDir">null</parameter>
 
         <parameter key="liip_imagine.filter.post_processor.optipng.class">Liip\ImagineBundle\Imagine\Filter\PostProcessor\OptiPngPostProcessor</parameter>
         <parameter key="liip_imagine.optipng.binary">/usr/bin/optipng</parameter>
         <parameter key="liip_imagine.optipng.level">7</parameter>
         <parameter key="liip_imagine.optipng.stripAll">true</parameter>
+        <parameter key="liip_imagine.optipng.tempDir">null</parameter>
 
         <parameter key="liip_imagine.filter.post_processor.pngquant.class">Liip\ImagineBundle\Imagine\Filter\PostProcessor\PngquantPostProcessor</parameter>
         <parameter key="liip_imagine.pngquant.binary">/usr/bin/pngquant</parameter>
@@ -307,12 +309,14 @@
             <argument>%liip_imagine.jpegoptim.stripAll%</argument>
             <argument>%liip_imagine.jpegoptim.max%</argument>
             <argument>%liip_imagine.jpegoptim.progressive%</argument>
+            <argument>%liip_imagine.jpegoptim.tempDir%</argument>
             <tag name="liip_imagine.filter.post_processor" post_processor="jpegoptim" />
         </service>
         <service id="liip_imagine.filter.post_processor.optipng" class="%liip_imagine.filter.post_processor.optipng.class%">
             <argument>%liip_imagine.optipng.binary%</argument>
             <argument>%liip_imagine.optipng.level%</argument>
             <argument>%liip_imagine.optipng.stripAll%</argument>
+            <argument>%liip_imagine.optipng.tempDir%</argument>
             <tag name="liip_imagine.filter.post_processor" post_processor="optipng" />
         </service>
         <service id="liip_imagine.filter.post_processor.pngquant" class="%liip_imagine.filter.post_processor.pngquant.class%">

--- a/Resources/doc/filters.rst
+++ b/Resources/doc/filters.rst
@@ -430,6 +430,10 @@ for example:
         # When true, --all-progressive is passed to jpegoptim, which results in the output being a progressive jpeg.
         liip_imagine.jpegoptim.progressive: true
 
+      # The directory where temporary file will be written. By default it's empty, and computed using `sys_get_temp_dir()`
+      # You can set it to `/run/shm` or something similar for writing temporary files in-memory, for decrease of disk load
+      liip_imagine.jpegoptim.tempDir: ""
+
 .. _`Symfony Service Container`: http://symfony.com/doc/current/book/service_container.html
 
 
@@ -455,6 +459,10 @@ for example:
 
       # The optimisation level to be used by optipng. Defaults to 7.
       liip_imagine.optipng.level: 7
+
+      # The directory where temporary file will be written. By default is empty, and computed using `sys_get_temp_dir()`
+      # You can set it to `/run/shm` or something similar for writing temporary files in-memory, for decrease of disk load
+      liip_imagine.optipng.tempDir: ""
 
 .. _`Symfony Service Container`: http://symfony.com/doc/current/book/service_container.html
 


### PR DESCRIPTION
Added optional configuration parameter `$tempDir` for JpegOptim and OptiPng post processors. It allows lesser disk load by usage of in-memory directory for temporary file creation. 

Also fixed previously introduced bug in OptiPngPostProcessor.