### PR TITLE
Cleanup FileSystemLoader (Followup to #775)

### DIFF
--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -38,7 +38,7 @@ class FileSystemLoader implements LoaderInterface
         $this->mimeTypeGuesser = $mimeTypeGuesser;
         $this->extensionGuesser = $extensionGuesser;
 
-        if (!($realRootPath = realpath($rootPath))) {
+        if (empty($rootPath) || !($realRootPath = realpath($rootPath))) {
             throw new InvalidArgumentException(sprintf('Root image path not resolvable "%s"', $rootPath));
         }
 
@@ -50,16 +50,12 @@ class FileSystemLoader implements LoaderInterface
      */
     public function find($path)
     {
-        if (!($absolutePath = realpath($this->rootPath.DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR)))) {
+        if (!($absolutePath = realpath($this->rootPath.DIRECTORY_SEPARATOR.$path))) {
             throw new NotLoadableException(sprintf('Source image not resolvable "%s"', $path));
         }
 
         if (0 !== strpos($absolutePath, $this->rootPath)) {
             throw new NotLoadableException(sprintf('Source image invalid "%s" as it is outside of the defined root path', $absolutePath));
-        }
-
-        if (false == file_exists($absolutePath)) {
-            throw new NotLoadableException(sprintf('Source image not found in "%s"', $absolutePath));
         }
 
         $mimeType = $this->mimeTypeGuesser->guess($absolutePath);

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -41,6 +41,20 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testThrowExceptionIfRootPathIsEmpty()
+    {
+        $this->setExpectedException(
+            'Liip\ImagineBundle\Exception\InvalidArgumentException',
+            'Root image path not resolvable'
+        );
+
+        new FileSystemLoader(
+            MimeTypeGuesser::getInstance(),
+            ExtensionGuesser::getInstance(),
+            ''
+        );
+    }
+
     public function testThrowExceptionIfRootPathDoesNotExist()
     {
         $this->setExpectedException(


### PR DESCRIPTION
This is a quick followup to #775.

The call to `file_exists()` is redundant and no longer required, as `realpath()` will already return false if the path does not exist.

Additionally, the call to `ltrim()` is no longer needed as `realpath()` will resolve the path properly, even if there are two slashes due to the root path and relative path concatenation.

Lastly, the `ltrim()` call may have also previously been a security consideration that would disallow the `data_root` being set to an empty string and absolute paths being passed as the relative path to `find()`. This is mitigated by the new check in the constructor that ensures `data_root` is not empty. A test for this edge-case is included.

(If someone really wants to push the boundaries of acceptable security, they can still set `data_root` to `/` and effectively pass absolute paths to the `find()` method, though this is a horrible idea... :-) )