### PR TITLE
List deprecation - closes #731

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 sudo: false

--- a/Imagine/Filter/Loader/BackgroundFilterLoader.php
+++ b/Imagine/Filter/Loader/BackgroundFilterLoader.php
@@ -32,7 +32,8 @@ class BackgroundFilterLoader implements LoaderInterface
         $size = $image->getSize();
 
         if (isset($options['size'])) {
-            list($width, $height) = $options['size'];
+            $width = isset($options['size'][0]) ? $options['size'][0] : null;
+            $height = isset($options['size'][1]) ? $options['size'][1] : null;
 
             $position = isset($options['position']) ? $options['position'] : 'center';
             switch ($position) {

--- a/Imagine/Filter/Loader/CropFilterLoader.php
+++ b/Imagine/Filter/Loader/CropFilterLoader.php
@@ -14,8 +14,11 @@ class CropFilterLoader implements LoaderInterface
      */
     public function load(ImageInterface $image, array $options = array())
     {
-        list($x, $y) = $options['start'];
-        list($width, $height) = $options['size'];
+        $x = isset($options['start'][0]) ? $options['start'][0] : null;
+        $y = isset($options['start'][1]) ? $options['start'][1] : null;
+
+        $width = isset($options['size'][0]) ? $options['size'][0] : null;
+        $height = isset($options['size'][1]) ? $options['size'][1] : null;
 
         $filter = new Crop(new Point($x, $y), new Box($width, $height));
         $image = $filter->apply($image);

--- a/Imagine/Filter/Loader/PasteFilterLoader.php
+++ b/Imagine/Filter/Loader/PasteFilterLoader.php
@@ -29,7 +29,9 @@ class PasteFilterLoader implements LoaderInterface
      */
     public function load(ImageInterface $image, array $options = array())
     {
-        list($x, $y) = $options['start'];
+        $x = isset($options['start'][0]) ? $options['start'][0] : null;
+        $y = isset($options['start'][1]) ? $options['start'][1] : null;
+
         $destImage = $this->imagine->open($this->rootPath.'/'.$options['image']);
 
         return $image->paste($destImage, new Point($x, $y));

--- a/Imagine/Filter/Loader/RelativeResizeFilterLoader.php
+++ b/Imagine/Filter/Loader/RelativeResizeFilterLoader.php
@@ -18,7 +18,7 @@ class RelativeResizeFilterLoader implements LoaderInterface
      */
     public function load(ImageInterface $image, array $options = array())
     {
-        if (list($method, $parameter) = each($options)) {
+        foreach ($options as $method => $parameter) {
             $filter = new RelativeResize($method, $parameter);
 
             return $filter->apply($image);

--- a/Imagine/Filter/Loader/ResizeFilterLoader.php
+++ b/Imagine/Filter/Loader/ResizeFilterLoader.php
@@ -18,7 +18,8 @@ class ResizeFilterLoader implements LoaderInterface
      */
     public function load(ImageInterface $image, array $options = array())
     {
-        list($width, $height) = $options['size'];
+        $width = isset($options['size'][0]) ? $options['size'][0] : null;
+        $height = isset($options['size'][1]) ? $options['size'][1] : null;
 
         $filter = new Resize(new Box($width, $height));
 

--- a/Imagine/Filter/Loader/ScaleFilterLoader.php
+++ b/Imagine/Filter/Loader/ScaleFilterLoader.php
@@ -24,7 +24,7 @@ class ScaleFilterLoader implements LoaderInterface
     protected $ratioKey;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $absoluteRatio;
 
@@ -51,8 +51,8 @@ class ScaleFilterLoader implements LoaderInterface
         if (isset($options[$this->ratioKey])) {
             $ratio = $this->absoluteRatio ? $options[$this->ratioKey] : $this->calcAbsoluteRatio($options[$this->ratioKey]);
         } elseif (isset($options[$this->dimensionKey])) {
-            $size   = $options[$this->dimensionKey];
-            $width  = isset($size[0]) ? $size[0] : null;
+            $size = $options[$this->dimensionKey];
+            $width = isset($size[0]) ? $size[0] : null;
             $height = isset($size[1]) ? $size[1] : null;
 
             $widthRatio = $width / $origWidth;

--- a/Imagine/Filter/Loader/ScaleFilterLoader.php
+++ b/Imagine/Filter/Loader/ScaleFilterLoader.php
@@ -13,9 +13,24 @@ use Imagine\Image\Box;
  */
 class ScaleFilterLoader implements LoaderInterface
 {
-    public function __construct($dimentionKey = 'dim', $ratioKey = 'to', $absoluteRatio = true)
+    /**
+     * @var string
+     */
+    protected $dimensionKey;
+
+    /**
+     * @var string
+     */
+    protected $ratioKey;
+
+    /**
+     * @var boolean
+     */
+    protected $absoluteRatio;
+
+    public function __construct($dimensionKey = 'dim', $ratioKey = 'to', $absoluteRatio = true)
     {
-        $this->dimentionKey = $dimentionKey;
+        $this->dimensionKey = $dimensionKey;
         $this->ratioKey = $ratioKey;
         $this->absoluteRatio = $absoluteRatio;
     }
@@ -25,8 +40,8 @@ class ScaleFilterLoader implements LoaderInterface
      */
     public function load(ImageInterface $image, array $options = array())
     {
-        if (!isset($options[$this->dimentionKey]) && !isset($options[$this->ratioKey])) {
-            throw new \InvalidArgumentException("Missing $this->dimentionKey or $this->ratioKey option.");
+        if (!isset($options[$this->dimensionKey]) && !isset($options[$this->ratioKey])) {
+            throw new \InvalidArgumentException("Missing $this->dimensionKey or $this->ratioKey option.");
         }
 
         $size = $image->getSize();
@@ -35,8 +50,10 @@ class ScaleFilterLoader implements LoaderInterface
 
         if (isset($options[$this->ratioKey])) {
             $ratio = $this->absoluteRatio ? $options[$this->ratioKey] : $this->calcAbsoluteRatio($options[$this->ratioKey]);
-        } elseif (isset($options[$this->dimentionKey])) {
-            list($width, $height) = $options[$this->dimentionKey];
+        } elseif (isset($options[$this->dimensionKey])) {
+            $size   = $options[$this->dimensionKey];
+            $width  = isset($size[0]) ? $size[0] : null;
+            $height = isset($size[1]) ? $size[1] : null;
 
             $widthRatio = $width / $origWidth;
             $heightRatio = $height / $origHeight;

--- a/Imagine/Filter/Loader/ThumbnailFilterLoader.php
+++ b/Imagine/Filter/Loader/ThumbnailFilterLoader.php
@@ -25,7 +25,8 @@ class ThumbnailFilterLoader implements LoaderInterface
             $filter = ImageInterface::FILTER_UNDEFINED;
         }
 
-        list($width, $height) = $options['size'];
+        $width  = isset($options['size'][0]) ? $options['size'][0] : null;
+        $height = isset($options['size'][1]) ? $options['size'][1] : null;
 
         $size = $image->getSize();
         $origWidth = $size->getWidth();

--- a/Imagine/Filter/Loader/ThumbnailFilterLoader.php
+++ b/Imagine/Filter/Loader/ThumbnailFilterLoader.php
@@ -25,7 +25,7 @@ class ThumbnailFilterLoader implements LoaderInterface
             $filter = ImageInterface::FILTER_UNDEFINED;
         }
 
-        $width  = isset($options['size'][0]) ? $options['size'][0] : null;
+        $width = isset($options['size'][0]) ? $options['size'][0] : null;
         $height = isset($options['size'][1]) ? $options['size'][1] : null;
 
         $size = $image->getSize();

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -54,7 +54,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 
     protected function getMockCacheManager()
     {
-        return $this->getMock('Liip\ImagineBundle\Imagine\Cache\CacheManager', array(), array(), '', false);
+        return $this->getMockBuilder('Liip\ImagineBundle\Imagine\Cache\CacheManager')->getMock();
     }
 
     /**
@@ -62,7 +62,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function createFilterConfigurationMock()
     {
-        return $this->getMock('Liip\ImagineBundle\Imagine\Filter\FilterConfiguration');
+        return $this->getMockBuilder('Liip\ImagineBundle\Imagine\Filter\FilterConfiguration')->getMock();
     }
 
     /**
@@ -70,7 +70,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function createRouterMock()
     {
-        return $this->getMock('Symfony\Component\Routing\RouterInterface');
+        return $this->getMockBuilder('Symfony\Component\Routing\RouterInterface')->getMock();
     }
 
     /**
@@ -78,27 +78,27 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function createResolverMock()
     {
-        return $this->getMock('Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface');
+        return $this->getMockBuilder('Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface')->getMock();
     }
 
     protected function createEventDispatcherMock()
     {
-        return $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        return $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
     }
 
     protected function getMockImage()
     {
-        return $this->getMock('Imagine\Image\ImageInterface');
+        return $this->getMockBuilder('Imagine\Image\ImageInterface')->getMock();
     }
 
     protected function getMockMetaData()
     {
-        return $this->getMock('Imagine\Image\Metadata\MetadataBag');
+        return $this->getMockBuilder('Imagine\Image\Metadata\MetadataBag')->getMock();
     }
 
     protected function createImagineMock()
     {
-        return $this->getMock('Imagine\Image\ImagineInterface');
+        return $this->getMockBuilder('Imagine\Image\ImagineInterface')->getMock();
     }
 
     protected function tearDown()

--- a/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
@@ -11,22 +11,16 @@ use Imagine\Image\Point;
  * Test cases for CropFilterLoader class.
  *
  * @covers Liip\ImagineBundle\Imagine\Filter\Loader\CropFilterLoader
+ *
+ * @author Alex Wilson <a@ax.gy>
  */
 class CropFilterLoaderTest extends AbstractTest
 {
     /**
-     * @var int
-     */
-    const DUMMY_IMAGE_WIDTH = 500;
-
-    /**
-     * @var int
-     */
-    const DUMMY_IMAGE_HEIGHT = 600;
-
-    /**
-     * @param int $width
-     * @param int $height
+     * @param int[] $coordinates
+     * @param int[] $area
+     *
+     * @covers CropFilterLoader::load
      *
      * @dataProvider cropDataProvider
      */
@@ -40,10 +34,6 @@ class CropFilterLoaderTest extends AbstractTest
 
         $loader = new CropFilterLoader();
 
-        $mockImageSize = new Box(
-            self::DUMMY_IMAGE_WIDTH,
-            self::DUMMY_IMAGE_HEIGHT
-        );
         $image = $this->getMockImage();
         $image->expects($this->once())
             ->method('crop')

--- a/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
@@ -20,7 +20,7 @@ class CropFilterLoaderTest extends AbstractTest
      * @param int[] $coordinates
      * @param int[] $area
      *
-     * @covers CropFilterLoader::load
+     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\CropFilterLoader::load
      *
      * @dataProvider cropDataProvider
      */

--- a/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Liip\ImagineBundle\Tests\Filter;
+
+use Liip\ImagineBundle\Imagine\Filter\Loader\CropFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
+use Imagine\Image\Box;
+use Imagine\Image\Point;
+
+/**
+ * Test cases for CropFilterLoader class.
+ *
+ * @covers Liip\ImagineBundle\Imagine\Filter\Loader\CropFilterLoader
+ */
+class CropFilterLoaderTest extends AbstractTest
+{
+    /**
+     * @var int
+     */
+    const DUMMY_IMAGE_WIDTH = 500;
+
+    /**
+     * @var int
+     */
+    const DUMMY_IMAGE_HEIGHT = 600;
+
+    /**
+     * @param int $width
+     * @param int $height
+     *
+     * @dataProvider cropDataProvider
+     */
+    public function testLoad($coordinates, $area)
+    {
+        $x = $coordinates[0];
+        $y = $coordinates[1];
+
+        $width = $area[0];
+        $height = $area[1];
+
+        $loader = new CropFilterLoader();
+
+        $mockImageSize = new Box(
+            self::DUMMY_IMAGE_WIDTH,
+            self::DUMMY_IMAGE_HEIGHT
+        );
+        $image = $this->getMockImage();
+        $image->expects($this->once())
+            ->method('crop')
+            ->with(new Point($x, $y), new Box($width, $height))
+            ->willReturn($image);
+
+        $options = array();
+        $options['start'] = $coordinates;
+        $options['size'] = $area;
+
+        $result = $loader->load($image, $options);
+    }
+
+    /**
+     * @returns array Array containing coordinate and width/height pairs.
+     */
+    public function cropDataProvider()
+    {
+        return array(
+            array(array(140, 130), array(200, 129)),
+            array(array(30, 60), array(50, 50)),
+            array(array(400, 500), array(1, 30)),
+        );
+    }
+}

--- a/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
@@ -34,7 +34,7 @@ class DownscaleFilterLoaderTest extends AbstractTest
             })
         ;
 
-        $loader->load($image, array('max' => array(100, 100)));
+        $loader->load($image, array('max' => array(100, 90)));
 
         return array($initialSize, $resultSize);
     }
@@ -56,6 +56,6 @@ class DownscaleFilterLoaderTest extends AbstractTest
     {
         list($initialSize, $resultSize) = $sizes;
         $this->assertLessThanOrEqual(100, $resultSize->getHeight());
-        $this->assertLessThanOrEqual(100, $resultSize->getWidth());
+        $this->assertLessThanOrEqual(90, $resultSize->getWidth());
     }
 }

--- a/Tests/Imagine/Filter/Loader/PasteFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/PasteFilterLoaderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Liip\ImagineBundle\Tests\Filter;
+
+use Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
+use Imagine\Image\Box;
+use Imagine\Image\Point;
+
+/**
+ * Test cases for PasteFilterLoader class.
+ *
+ * @covers Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader
+ *
+ * @author Alex Wilson <a@ax.gy>
+ */
+class PasteFilterLoaderTest extends AbstractTest
+{
+    /**
+     * @var int
+     */
+    const DUMMY_IMAGE_WIDTH = 500;
+
+    /**
+     * @var int
+     */
+    const DUMMY_IMAGE_HEIGHT = 600;
+
+    /**
+     * @param int   $x
+     * @param int   $y
+     * @param Point $expected
+     *
+     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader::load
+     *
+     * @dataProvider pasteProvider
+     */
+    public function testLoad($x, $y, $expected)
+    {
+        $mockImageSize = new Box(
+            self::DUMMY_IMAGE_WIDTH,
+            self::DUMMY_IMAGE_HEIGHT
+        );
+        $image = $this->getMockImage();
+        $image->method('getSize')->willReturn($mockImageSize);
+        $image->method('copy')->willReturn($image);
+        $image->expects($this->once())
+            ->method('paste')
+            ->with($image, $expected)
+            ->willReturn($image);
+
+        $imagineMock = $this->createImagineMock();
+        $imagineMock
+            ->method('open')
+            ->willReturn($image);
+        $loader = new PasteFilterLoader($imagineMock, '');
+
+        $options = array();
+        $options['start'] = array($x, $y);
+        $options['image'] = '';
+
+        $result = $loader->load($image, $options);
+    }
+
+    /**
+     * @returns array Array containing coordinates to paste.
+     */
+    public function pasteProvider()
+    {
+        return array(
+            array(200, 129, new Point(200, 129)),
+            array(50, 50, new Point(50, 50)),
+            array(1, 30, new Point(1, 30)),
+        );
+    }
+}

--- a/Tests/Imagine/Filter/Loader/ResizeFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ResizeFilterLoaderTest.php
@@ -19,7 +19,7 @@ class ResizeFilterLoaderTest extends AbstractTest
      * @param int $width
      * @param int $height
      *
-     * @covers ResizeFilterLoader::load
+     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ResizeFilterLoader::load
      *
      * @dataProvider resizeDataProvider
      */

--- a/Tests/Imagine/Filter/Loader/ResizeFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ResizeFilterLoaderTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Liip\ImagineBundle\Tests\Filter;
+
+use Liip\ImagineBundle\Imagine\Filter\Loader\ResizeFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
+use Imagine\Image\Box;
+
+/**
+ * Test cases for ResizeFilterLoader class.
+ *
+ * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ResizeFilterLoader
+ *
+ * @author Alex Wilson <a@ax.gy>
+ */
+class ResizeFilterLoaderTest extends AbstractTest
+{
+    /**
+     * @param int $width
+     * @param int $height
+     *
+     * @covers ResizeFilterLoader::load
+     *
+     * @dataProvider resizeDataProvider
+     */
+    public function testLoad($width, $height)
+    {
+        $loader = new ResizeFilterLoader();
+
+        $image = $this->getMockImage();
+        $image->expects($this->once())
+            ->method('resize')
+            ->with(new Box($width, $height))
+            ->willReturn($image);
+
+        $options = array();
+        $options['size'] = array($width, $height);
+
+        $result = $loader->load($image, $options);
+    }
+
+    /**
+     * @returns array Array containing width/height pairs.
+     */
+    public function resizeDataProvider()
+    {
+        return array(
+            array(140, 130),
+            array(30, 60),
+            array(400, 500),
+        );
+    }
+}

--- a/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Liip\ImagineBundle\Tests\Filter;
+
+use Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
+use Imagine\Image\Box;
+
+/**
+ * Test cases for ScaleFilterLoader class.
+ *
+ * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader
+ *
+ * @author Alex Wilson <a@ax.gy>
+ */
+class ScaleFilterLoaderTest extends AbstractTest
+{
+    /**
+     * @var int
+     */
+    const DUMMY_IMAGE_WIDTH = 500;
+
+    /**
+     * @var int
+     */
+    const DUMMY_IMAGE_HEIGHT = 600;
+
+    protected function getMockImage()
+    {
+        $mockImageSize = new Box(
+            self::DUMMY_IMAGE_WIDTH,
+            self::DUMMY_IMAGE_HEIGHT
+        );
+        $mockImage = parent::getMockImage();
+        $mockImage->method('getSize')->willReturn(new Box(
+            self::DUMMY_IMAGE_WIDTH,
+            self::DUMMY_IMAGE_HEIGHT
+        ));
+        return $mockImage;
+    }
+
+    /**
+     * @covers ScaleFilterLoader::load
+     */
+    public function testItShouldPreserveRatio()
+    {
+        $loader = new ScaleFilterLoader();
+        $image = $this->getMockImage();
+        $image->expects($this->once())
+            ->method('resize')
+            ->with(new Box(
+                self::DUMMY_IMAGE_WIDTH,
+                self::DUMMY_IMAGE_HEIGHT
+            ))
+            ->willReturn($image);
+
+        $result = $loader->load($image, array(
+          'to' => 1.0
+        ));
+    }
+
+    /**
+     * @param int[] $dimension
+     * @param Box $expected
+     *
+     * @covers ScaleFilterLoader::load
+     *
+     * @dataProvider dimensionsDataProvider
+     */
+    public function testItShouldUseDimensions($dimensions, $expected)
+    {
+        $loader = new ScaleFilterLoader();
+
+        $image = $this->getMockImage();
+        $image->expects($this->once())
+            ->method('resize')
+            ->with($expected)
+            ->willReturn($image);
+
+        $options = array(
+            'dim' => $dimensions
+        );
+
+        $result = $loader->load($image, $options);
+    }
+
+    /**
+     * @covers ScaleFilterLoader::load
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function itShouldThrowInvalidArgumentException()
+    {
+        (new ScaleFilterLoader('foo', 'bar'))
+          ->load($this->getMockImage(), array());
+    }
+
+
+    /**
+     * @returns array Array containing coordinate and width/height pairs.
+     */
+    public function dimensionsDataProvider()
+    {
+        return array(
+            array(array(150, 150), new Box(125, 150)),
+            array(array(30, 60), new Box(30, 36)),
+            array(array(1000, 1200), new Box(1000, 1200)),
+        );
+    }
+}

--- a/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
@@ -36,11 +36,12 @@ class ScaleFilterLoaderTest extends AbstractTest
             self::DUMMY_IMAGE_WIDTH,
             self::DUMMY_IMAGE_HEIGHT
         ));
+
         return $mockImage;
     }
 
     /**
-     * @covers ScaleFilterLoader::load
+     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader::load
      */
     public function testItShouldPreserveRatio()
     {
@@ -55,15 +56,15 @@ class ScaleFilterLoaderTest extends AbstractTest
             ->willReturn($image);
 
         $result = $loader->load($image, array(
-          'to' => 1.0
+          'to' => 1.0,
         ));
     }
 
     /**
      * @param int[] $dimension
-     * @param Box $expected
+     * @param Box   $expected
      *
-     * @covers ScaleFilterLoader::load
+     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader::load
      *
      * @dataProvider dimensionsDataProvider
      */
@@ -78,23 +79,22 @@ class ScaleFilterLoaderTest extends AbstractTest
             ->willReturn($image);
 
         $options = array(
-            'dim' => $dimensions
+            'dim' => $dimensions,
         );
 
         $result = $loader->load($image, $options);
     }
 
     /**
-     * @covers ScaleFilterLoader::load
+     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader::load
      *
      * @expectedException \InvalidArgumentException
      */
     public function itShouldThrowInvalidArgumentException()
     {
-        (new ScaleFilterLoader('foo', 'bar'))
-          ->load($this->getMockImage(), array());
+        $scale = new ScaleFilterLoader('foo', 'bar');
+        $scale->load($this->getMockImage(), array());
     }
-
 
     /**
      * @returns array Array containing coordinate and width/height pairs.

--- a/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Liip\ImagineBundle\Tests\Filter;
+
+use Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
+use Imagine\Image\Palette\Grayscale;
+use Imagine\Image\Box;
+
+/**
+ * Test cases for ThumbnailFilterLoader class.
+ *
+ * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader
+ */
+class ThumbnailFilterLoaderTest extends AbstractTest
+{
+    /**
+     * @var int
+     */
+    const DUMMY_IMAGE_WIDTH = 500;
+
+    /**
+     * @var int
+     */
+    const DUMMY_IMAGE_HEIGHT = 600;
+
+    /**
+     * @param int $width
+     * @param int $height
+     * @param Box $expected
+     *
+     * @dataProvider heightWidthProvider
+     */
+    public function testLoad($width, $height, $expected)
+    {
+        $loader = new ThumbnailFilterLoader();
+
+        $mockImageSize = new Box(
+            self::DUMMY_IMAGE_WIDTH,
+            self::DUMMY_IMAGE_HEIGHT
+        );
+        $image = $this->getMockImage();
+        $image->method('getSize')->willReturn($mockImageSize);
+        $image->method('copy')->willReturn($image);
+        $image->expects($this->once())
+            ->method('thumbnail')
+            ->with($expected)
+            ->willReturn($image);
+
+        $options = [];
+        $options['size'] = [$width, $height];
+        $options['allow_upscale'] = true;
+
+        $result = $loader->load($image, $options);
+    }
+
+   /**
+     * @returns array Array containing width/height pairs and an expected size.
+     */
+    public function heightWidthProvider()
+    {
+        return [
+            [200, 129, new Box(200, 129)],
+            [50, 50, new Box(50, 50)],
+            [1, 30, new Box(1, 30)],
+            [null, 60, new Box(50, 60)],
+            [50, null, new Box(50, 60)],
+            [1000, 1000, new Box(1000, 1000)]
+        ];
+    }
+}

--- a/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
@@ -10,6 +10,8 @@ use Imagine\Image\Box;
  * Test cases for ThumbnailFilterLoader class.
  *
  * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader
+ *
+ * @author Alex Wilson <a@ax.gy>
  */
 class ThumbnailFilterLoaderTest extends AbstractTest
 {
@@ -27,6 +29,8 @@ class ThumbnailFilterLoaderTest extends AbstractTest
      * @param int $width
      * @param int $height
      * @param Box $expected
+     *
+     * @covers ThumbnailFilterLoader::load
      *
      * @dataProvider heightWidthProvider
      */

--- a/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
@@ -47,8 +47,8 @@ class ThumbnailFilterLoaderTest extends AbstractTest
             ->with($expected)
             ->willReturn($image);
 
-        $options = [];
-        $options['size'] = [$width, $height];
+        $options = array();
+        $options['size'] = array($width, $height);
         $options['allow_upscale'] = true;
 
         $result = $loader->load($image, $options);
@@ -59,13 +59,13 @@ class ThumbnailFilterLoaderTest extends AbstractTest
      */
     public function heightWidthProvider()
     {
-        return [
-            [200, 129, new Box(200, 129)],
-            [50, 50, new Box(50, 50)],
-            [1, 30, new Box(1, 30)],
-            [null, 60, new Box(50, 60)],
-            [50, null, new Box(50, 60)],
-            [1000, 1000, new Box(1000, 1000)]
-        ];
+        return array(
+            array(200, 129, new Box(200, 129)),
+            array(50, 50, new Box(50, 50)),
+            array(1, 30, new Box(1, 30)),
+            array(null, 60, new Box(50, 60)),
+            array(50, null, new Box(50, 60)),
+            array(1000, 1000, new Box(1000, 1000))
+        );
     }
 }

--- a/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
@@ -4,7 +4,6 @@ namespace Liip\ImagineBundle\Tests\Filter;
 
 use Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
-use Imagine\Image\Palette\Grayscale;
 use Imagine\Image\Box;
 
 /**
@@ -54,7 +53,7 @@ class ThumbnailFilterLoaderTest extends AbstractTest
         $result = $loader->load($image, $options);
     }
 
-   /**
+    /**
      * @returns array Array containing width/height pairs and an expected size.
      */
     public function heightWidthProvider()
@@ -65,7 +64,7 @@ class ThumbnailFilterLoaderTest extends AbstractTest
             array(1, 30, new Box(1, 30)),
             array(null, 60, new Box(50, 60)),
             array(50, null, new Box(50, 60)),
-            array(1000, 1000, new Box(1000, 1000))
+            array(1000, 1000, new Box(1000, 1000)),
         );
     }
 }

--- a/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
@@ -30,7 +30,7 @@ class ThumbnailFilterLoaderTest extends AbstractTest
      * @param int $height
      * @param Box $expected
      *
-     * @covers ThumbnailFilterLoader::load
+     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader::load
      *
      * @dataProvider heightWidthProvider
      */


### PR DESCRIPTION
- [x] Migrating away from `list()`, due to its unpredictable nature between different versions of PHP.
- [x] Increasing code coverage of FilterLoaders with regression tests.
- [x] Enabling test suite for PHP 7.1.
