### PR TITLE
Added php_cs.dist / Updated .styleci.yml / Fixed and updated .travis.yml

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+use SLLH\StyleCIBridge\ConfigBridge;
+
+require_once __DIR__.'/vendor/autoload.php';
+
+$headerString = <<<EOF
+This file is part of the `liip/LiipImagineBundle` project.
+
+(c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+
+For the full copyright and license information, please view the LICENSE.md
+file that was distributed with this source code.
+EOF;
+
+$headerConfig = [ 'header_comment' => [ 'header' => $headerString ] ];
+
+$config = ConfigBridge::create();
+$config->setRules(array_merge($config->getRules(), $headerConfig));
+
+return $config;

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,20 @@
+---
+
 preset: symfony
+
+enabled:
+  - combine_consecutive_unsets
+  - linebreak_after_opening_tag
+  - no_short_echo_tag
+  - ordered_imports
+  - phpdoc_order
+  - php_unit_construct
+  - php_unit_dedicate_assert
+  - long_array_syntax
+
+finder :
+  name    : [ "*.php", "*.twig" ]
+  exclude : [ "vendor", "var" ]
+  path    : [ "./" ]
+
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+---
+
 language: php
 
 php:
@@ -29,13 +31,15 @@ matrix:
       env: COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:
-  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;'
-  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" && "${TRAVIS_PHP_VERSION}" != "7.0" ]; then yes "" | pecl -q install -f mongo; fi;'
-  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" && "${TRAVIS_PHP_VERSION}" != "7.0" ]; then composer require --dev doctrine/mongodb-odm:~1.0 --no-update; fi;'
-  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" && "${TRAVIS_PHP_VERSION}" >= "5.4" ]; then composer require --dev league/flysystem:~1.0 --no-update; fi;'
   - composer self-update
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
+  - if [ "${SYMFONY_VERSION:0:3}" == "2.3" ]; then composer remove --dev friendsofphp/php-cs-fixer --no-update; fi;
+  - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION}" != "5.3" ]; then composer require --dev league/flysystem:~1.0 --no-update; fi;
+  - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION}" != "7.0" ]; then composer require --dev doctrine/mongodb-odm:~1.0 --no-update; yes "" | pecl -q install -f mongo; fi;
+  - if [ "${SYMFONY_VERSION:-x}" != "x" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 
 install: composer update --prefer-source $COMPOSER_FLAGS
 
 script: ./bin/phpunit --coverage-text
+
+...

--- a/composer.json
+++ b/composer.json
@@ -18,46 +18,44 @@
     "require": {
         "php": "^5.3.9|^7.0",
         "imagine/Imagine": "^0.6.3,<0.7",
-        "symfony/finder": "~2.3|~3.0",
         "symfony/filesystem": "~2.3|~3.0",
-        "symfony/options-resolver": "~2.3|~3.0",
+        "symfony/finder": "~2.3|~3.0",
         "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/options-resolver": "~2.3|~3.0",
         "symfony/process": "~2.3|~3.0"
     },
-
     "require-dev": {
-        "phpunit/phpunit": "~4.3",
-        "symfony/browser-kit": "~2.3|~3.0",
-        "symfony/yaml": "~2.3|~3.0",
-        "symfony/form": "~2.3|~3.0",
-        "symfony/console": "~2.3|~3.0",
-        "symfony/phpunit-bridge": "~2.3|~3.0",
-        "symfony/dependency-injection": "~2.3|~3.0",
-        "doctrine/orm": "~2.3",
-        "doctrine/cache": "~1.1",
-        "twig/twig": "~1.12",
-        "aws/aws-sdk-php": "~2.4",
+        "ext-gd": "*",
         "amazonwebservices/aws-sdk-for-php": "~1.0",
+        "aws/aws-sdk-php": "~2.4",
+        "doctrine/cache": "~1.1",
+        "doctrine/orm": "~2.3",
+        "friendsofphp/php-cs-fixer": "~2.0",
+        "phpunit/phpunit": "~4.3",
         "psr/log": "~1.0",
-        "ext-gd": "*"
+        "sllh/php-cs-fixer-styleci-bridge": "~2.1",
+        "symfony/browser-kit": "~2.3|~3.0",
+        "symfony/console": "~2.3|~3.0",
+        "symfony/dependency-injection": "~2.3|~3.0",
+        "symfony/form": "~2.3|~3.0",
+        "symfony/phpunit-bridge": "~2.3|~3.0",
+        "symfony/yaml": "~2.3|~3.0",
+        "twig/twig": "~1.12"
     },
-
     "suggest": {
-        "twig/twig":                "If you'd want to use some handy twig filters, version 1.12 or greater required",
-        "aws/aws-sdk-php":          "Add it if you'd like to use aws v2 or v3 resolver",
-        "amazonwebservices/aws-sdk-for-php": "Add it if you'd like to use aws v1 resolver",
-        "monolog/monolog":          "If you'd want to write logs",
-        "league/flysystem":         "If you'd want to use Flysystem binary loader"
+        "amazonwebservices/aws-sdk-for-php": "Required to use AWS version 1 cache resolver.",
+        "aws/aws-sdk-php": "Required to use AWS version 2/3 cache resolver.",
+        "league/flysystem": "Required to use FlySystem data loader or cache resolver.",
+        "monolog/monolog": "A psr/log compatible logger is required to enable logging.",
+        "twig/twig": "Required to use the provided Twig extension. Version 1.12 or greater needed."
     },
-
     "autoload": {
         "psr-4": { "Liip\\ImagineBundle\\": "" }
     },
-
     "config": {
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "sort-packages" : true
     },
-
     "extra": {
         "branch-alias": {
             "dev-master": "1.6.x-dev"


### PR DESCRIPTION
# Description

Adds `php-cs-fixer` and `php-cs-fixer-styleci-bridge` as development dependencies, enabling automatic configuration of `bin/php-cs-fixer` using the `.styleci.yml` file.

Now, running `php-cs-fixer` is easy, which will hopefully provide incentive for regular use of [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer):

```
bin/php-cs-fixer fix ./
```

## Additional Details

The `.styleci.yml` file was updated to enable a few additional, sensible options on top of the `symfony` preset. For example, as PHP 5.3 is supported, the `long_array_syntax` rule was added. **This caught a bug in the current production code base, [seen here](https://github.com/src-run/liip-imagine-bundle-sandbox/commit/a27d221a12c7e09bf7eb10f89dd3392b8d591738#diff-741c7f1cd78fc4c24ff27bd7659a6fd7L135)**.

The other, additional rules add consistency I believe worthwhile, such as:
- ordering file imports
- ordering phpdocs

Reference [their fixer docs](https://styleci.readme.io/docs/fixers) for details about what all the new rules do and provide feedback if you disagree with any of the newly introduced rules.

## Original Commit Message

- Added "friendsofphp/php-cs-fixer:~2.0" development dep.
- Added "sllh/php-cs-fixer-styleci-bridge:~2.1" development dep to enable php-cs-fixer configuration directly from .styleci.yml config file.
- Updated "styleci.yml" file rule additions (on top of symfony preset):
  - combine_consecutive_unsets
  - linebreak_after_opening_tag
  - no_short_echo_tag
  - ordered_imports
  - phpdoc_order
  - php_unit_construct
  - php_unit_dedicate_assert
  - long_array_syntax
- Added "sort-packages" to "config" key in "composer.json"
- Updated "suggest" key descriptions in "composer.json" for clarity.