### PR TITLE
Bugfix for Failing Tests Introduced in #777

### DIFF
--- a/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
@@ -18,7 +18,7 @@ class FlysystemResolverFactory implements ResolverFactoryInterface
         $resolverDefinition->replaceArgument(0, new Reference($config['filesystem_service']));
         $resolverDefinition->replaceArgument(2, $config['root_url']);
         $resolverDefinition->replaceArgument(3, $config['cache_prefix']);
-        $resolverDefinition->addArgument($config['visibility']);
+        $resolverDefinition->replaceArgument(4, $config['visibility']);
         $resolverDefinition->addTag('liip_imagine.cache.resolver', array(
             'resolver' => $resolverName,
         ));

--- a/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
@@ -52,6 +52,7 @@ class FlysystemResolverFactoryTest extends \Phpunit_Framework_TestCase
             'filesystem_service' => 'flyfilesystemservice',
             'root_url' => 'http://images.example.com',
             'cache_prefix' => 'theCachePrefix',
+            'visibility' => 'public',
         ));
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername'));
@@ -62,6 +63,7 @@ class FlysystemResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $this->assertEquals('http://images.example.com', $resolverDefinition->getArgument(2));
         $this->assertEquals('theCachePrefix', $resolverDefinition->getArgument(3));
+        $this->assertEquals('public', $resolverDefinition->getArgument(4));
     }
 
     public function testProcessCorrectlyOptionsOnAddConfiguration()
@@ -69,6 +71,7 @@ class FlysystemResolverFactoryTest extends \Phpunit_Framework_TestCase
         $expectedRootUrl = 'http://images.example.com';
         $expectedCachePrefix = 'theCachePrefix';
         $expectedFlysystemService = 'flyfilesystemservice';
+        $expectedVisibility = 'public';
 
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('flysystem', 'array');
@@ -81,6 +84,7 @@ class FlysystemResolverFactoryTest extends \Phpunit_Framework_TestCase
                 'root_url' => $expectedRootUrl,
                 'cache_prefix' => $expectedCachePrefix,
                 'filesystem_service' => $expectedFlysystemService,
+                'visibility' => 'public',
             ),
         ));
 
@@ -92,6 +96,9 @@ class FlysystemResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $this->assertArrayHasKey('cache_prefix', $config);
         $this->assertEquals($expectedCachePrefix, $config['cache_prefix']);
+
+        $this->assertArrayHasKey('visibility', $config);
+        $this->assertEquals($expectedVisibility, $config['visibility']);
     }
 
     /**


### PR DESCRIPTION
This is a bugfix for failing tests introduced in #777. Sadly, this wasn't caught because the travis config conditional to include `league/flysystem` contained an incorrect conditional that would always resolve to false ([due to this line](https://github.com/liip/LiipImagineBundle/blob/1.0/.travis.yml#L35)) which caused [all flyststem tests to be skipped](https://travis-ci.org/liip/LiipImagineBundle/jobs/158697869#L311).

So, *the tests for this pull requests don't actually test the fix* because I inadvertently already fixed the travis file in #792.

So: this special branch includes both this pull request and #792: https://travis-ci.org/src-run/liip-imagine-bundle-sandbox/builds/158721955