### PR TITLE
Add visibility argument to service definition

### DIFF
--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -265,6 +265,7 @@
             <argument type="service" id="router.request_context" />
             <argument><!-- will be injected by a ResolverFactory --></argument>
             <argument><!-- will be injected by a ResolverFactory --></argument>
+            <argument><!-- will be injected by a ResolverFactory --></argument>
         </service>
 
         <service id="liip_imagine.cache.resolver.prototype.proxy" class="%liip_imagine.cache.resolver.proxy.class%" public="true" abstract="true">


### PR DESCRIPTION
That's a fix for the fix in #793 and equally important.

The service definition missed the visibility argument since I at first added it dynamically (which was fixed in #793 - thx for that!). This patch simply adds the argument to the static definition so the 5th argument can now be set correctly.

Without the patch the container cannot be build and fatals with Symfony 3.2-dev

```
[Symfony\Component\DependencyInjection\Exception\OutOfBoundsException]                               
  Service "liip_imagine.cache.resolver.flysystem_resolver": The index "4" is not in the range [0, 3].
``` 