### PR TITLE
Add Symfony Framework 3.1.x and 3.2-dev to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,15 @@ matrix:
       env: SYMFONY_VERSION=2.8.*@dev
     - php: 5.6
       env: SYMFONY_VERSION=3.0.*@dev
+    - php: 5.6
+      env: SYMFONY_VERSION=3.1.*@dev
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.0
+      env: SYMFONY_VERSION=3.2.x-dev
+  allow_failures:
+    - php: 7.0
+      env: SYMFONY_VERSION=3.2.x-dev
 
 before_install:
   - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;'


### PR DESCRIPTION
Since #793 and therefore #795 seem (to me) to relate to a lack of testing with the current Symfony development state, I thought it might be a good idea to enhance the build matrix with Symfony 3.1 and the development state of 3.2.

Since 3.2 is still in development, it was added with the allowance to fail. This should be changed upon release.