### PR TITLE
Fix travis build definition for conditional dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ matrix:
       env: COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:
-  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;'
-  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" && "${TRAVIS_PHP_VERSION}" != "7.0" ]; then yes "" | pecl -q install -f mongo; fi;'
-  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" && "${TRAVIS_PHP_VERSION}" != "7.0" ]; then composer require --dev doctrine/mongodb-odm:~1.0 --no-update; fi;'
-  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" && "${TRAVIS_PHP_VERSION}" >= "5.4" ]; then composer require --dev league/flysystem:~1.0 --no-update; fi;'
+  - if [[ "${TRAVIS_PHP_VERSION}" != "hhvm" ]]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
+  - if [[ "${TRAVIS_PHP_VERSION}" != "hhvm" && "${TRAVIS_PHP_VERSION}" != "7.0" ]]; then yes "" | pecl -q install -f mongo; fi;
+  - if [[ "${TRAVIS_PHP_VERSION}" != "hhvm" && "${TRAVIS_PHP_VERSION}" != "7.0" ]]; then composer require --dev doctrine/mongodb-odm:~1.0 --no-update; fi;
+  - if [[ "${TRAVIS_PHP_VERSION}" != "hhvm" && "${TRAVIS_PHP_VERSION}" != "5.3" ]]; then composer require --dev league/flysystem:~1.0 --no-update; fi
   - composer self-update
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi
 
 install: composer update --prefer-source $COMPOSER_FLAGS
 


### PR DESCRIPTION
This change adjusts the before_install section to correctly install the optional dependencies.

Before this commit, the if statements silently failed (you can see that in the older build-logs), and the corresponding tests were skipped.

The patch ensures that the dependencies for `ext-mongo`, the `odm` and `flysystem` are installed so that the tests aren't skipped anymore.