### PR TITLE
Update Source to Newly Merged Style Rule Additions

### DIFF
--- a/Binary/BinaryInterface.php
+++ b/Binary/BinaryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Binary;
 
 interface BinaryInterface

--- a/Binary/FileBinaryInterface.php
+++ b/Binary/FileBinaryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Binary;
 
 interface FileBinaryInterface extends BinaryInterface

--- a/Binary/Loader/AbstractDoctrineLoader.php
+++ b/Binary/Loader/AbstractDoctrineLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Binary\Loader;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -1,12 +1,21 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Binary\Loader;
 
+use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Exception\InvalidArgumentException;
 use Liip\ImagineBundle\Model\FileBinary;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
-use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 
 class FileSystemLoader implements LoaderInterface
 {

--- a/Binary/Loader/FlysystemLoader.php
+++ b/Binary/Loader/FlysystemLoader.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Binary\Loader;
 
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
-use Liip\ImagineBundle\Model\Binary;
-use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use League\Flysystem\FilesystemInterface;
+use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
+use Liip\ImagineBundle\Model\Binary;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
 
 class FlysystemLoader implements LoaderInterface
 {

--- a/Binary/Loader/GridFSLoader.php
+++ b/Binary/Loader/GridFSLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Binary\Loader;
 
 use Doctrine\ODM\MongoDB\DocumentManager;

--- a/Binary/Loader/LoaderInterface.php
+++ b/Binary/Loader/LoaderInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Binary\Loader;
 
 interface LoaderInterface

--- a/Binary/Loader/StreamLoader.php
+++ b/Binary/Loader/StreamLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Binary\Loader;
 
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;

--- a/Binary/MimeTypeGuesserInterface.php
+++ b/Binary/MimeTypeGuesserInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Binary;
 
 interface MimeTypeGuesserInterface

--- a/Binary/SimpleMimeTypeGuesser.php
+++ b/Binary/SimpleMimeTypeGuesser.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Binary;
 
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface as SymfonyMimeTypeGuesserInterface;

--- a/Command/RemoveCacheCommand.php
+++ b/Command/RemoveCacheCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Command;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;

--- a/Command/ResolveCacheCommand.php
+++ b/Command/ResolveCacheCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Command;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;

--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -1,14 +1,23 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Controller;
 
 use Imagine\Exception\RuntimeException;
+use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Exception\Imagine\Filter\NonExistingFilterException;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Liip\ImagineBundle\Imagine\Cache\SignerInterface;
 use Liip\ImagineBundle\Imagine\Data\DataManager;
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
-use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
-use Liip\ImagineBundle\Imagine\Cache\SignerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;

--- a/DependencyInjection/Compiler/FiltersCompilerPass.php
+++ b/DependencyInjection/Compiler/FiltersCompilerPass.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/DependencyInjection/Compiler/LoadersCompilerPass.php
+++ b/DependencyInjection/Compiler/LoadersCompilerPass.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/DependencyInjection/Compiler/PostProcessorsCompilerPass.php
+++ b/DependencyInjection/Compiler/PostProcessorsCompilerPass.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/DependencyInjection/Compiler/ResolversCompilerPass.php
+++ b/DependencyInjection/Compiler/ResolversCompilerPass.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface;

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;

--- a/DependencyInjection/Factory/Loader/FlysystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FlysystemLoaderFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;

--- a/DependencyInjection/Factory/Loader/LoaderFactoryInterface.php
+++ b/DependencyInjection/Factory/Loader/LoaderFactoryInterface.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 interface LoaderFactoryInterface
 {

--- a/DependencyInjection/Factory/Loader/StreamLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/StreamLoaderFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;

--- a/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Factory\Resolver;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;

--- a/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Factory\Resolver;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;

--- a/DependencyInjection/Factory/Resolver/ResolverFactoryInterface.php
+++ b/DependencyInjection/Factory/Resolver/ResolverFactoryInterface.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Factory\Resolver;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 interface ResolverFactoryInterface
 {

--- a/DependencyInjection/Factory/Resolver/WebPathResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/WebPathResolverFactory.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection\Factory\Resolver;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
 class WebPathResolverFactory implements ResolverFactoryInterface

--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\DependencyInjection;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface;

--- a/Events/CacheResolveEvent.php
+++ b/Events/CacheResolveEvent.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Events;
 
 use Symfony\Component\EventDispatcher\Event;

--- a/Exception/Binary/Loader/NotLoadableException.php
+++ b/Exception/Binary/Loader/NotLoadableException.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Exception\Binary\Loader;
 
 use Liip\ImagineBundle\Exception\ExceptionInterface;

--- a/Exception/ExceptionInterface.php
+++ b/Exception/ExceptionInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Exception;
 
 interface ExceptionInterface

--- a/Exception/Imagine/Cache/Resolver/NotResolvableException.php
+++ b/Exception/Imagine/Cache/Resolver/NotResolvableException.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Exception\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Exception\ExceptionInterface;

--- a/Exception/Imagine/Cache/Resolver/NotStorableException.php
+++ b/Exception/Imagine/Cache/Resolver/NotStorableException.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Exception\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Exception\ExceptionInterface;

--- a/Exception/Imagine/Filter/NonExistingFilterException.php
+++ b/Exception/Imagine/Filter/NonExistingFilterException.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Exception\Imagine\Filter;
 
 use Liip\ImagineBundle\Exception\ExceptionInterface;

--- a/Exception/InvalidArgumentException.php
+++ b/Exception/InvalidArgumentException.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;

--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -1,16 +1,25 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;
+use Liip\ImagineBundle\Events\CacheResolveEvent;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+use Liip\ImagineBundle\ImagineEvents;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Liip\ImagineBundle\ImagineEvents;
-use Liip\ImagineBundle\Events\CacheResolveEvent;
 
 class CacheManager
 {
@@ -90,9 +99,9 @@ class CacheManager
      * @param string $filter
      * @param string $resolver
      *
-     * @return ResolverInterface
-     *
      * @throws \OutOfBoundsException If neither a specific nor a default resolver is available
+     *
+     * @return ResolverInterface
      */
     protected function getResolver($filter, $resolver)
     {
@@ -211,9 +220,9 @@ class CacheManager
      * @param string $filter
      * @param string $resolver
      *
-     * @return string The url of resolved image
-     *
      * @throws NotFoundHttpException if the path can not be resolved
+     *
+     * @return string The url of resolved image
      */
     public function resolve($path, $filter, $resolver = null)
     {

--- a/Imagine/Cache/CacheManagerAwareInterface.php
+++ b/Imagine/Cache/CacheManagerAwareInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache;
 
 interface CacheManagerAwareInterface

--- a/Imagine/Cache/CacheManagerAwareTrait.php
+++ b/Imagine/Cache/CacheManagerAwareTrait.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache;
 
 trait CacheManagerAwareTrait

--- a/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
+++ b/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;
@@ -136,9 +145,9 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
     }
 
     /**
-     * @return Request
-     *
      * @throws \LogicException
+     *
+     * @return Request
      */
     protected function getRequest()
     {
@@ -171,10 +180,11 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
     /**
      * Return the local filepath.
      *
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      *
      * @param string $path   The resource path to convert
      * @param string $filter The name of the imagine filter
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      *
      * @return string
      */

--- a/Imagine/Cache/Resolver/AmazonS3Resolver.php
+++ b/Imagine/Cache/Resolver/AmazonS3Resolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Imagine/Cache/Resolver/AwsS3Resolver.php
+++ b/Imagine/Cache/Resolver/AwsS3Resolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
 use Aws\S3\S3Client;

--- a/Imagine/Cache/Resolver/CacheResolver.php
+++ b/Imagine/Cache/Resolver/CacheResolver.php
@@ -1,12 +1,21 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
 use Doctrine\Common\Cache\Cache;
 use Liip\ImagineBundle\Binary\BinaryInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\HttpKernel\Kernel;
 
 class CacheResolver implements ResolverInterface
 {

--- a/Imagine/Cache/Resolver/FlysystemResolver.php
+++ b/Imagine/Cache/Resolver/FlysystemResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
 use League\Flysystem\AdapterInterface;
@@ -107,9 +116,9 @@ class FlysystemResolver implements ResolverInterface
      * @param string $path   The path where the original file is expected to be
      * @param string $filter The name of the imagine filter in effect
      *
-     * @return string The absolute URL of the cached image
-     *
      * @throws NotResolvableException
+     *
+     * @return string The absolute URL of the cached image
      */
     public function resolve($path, $filter)
     {
@@ -132,7 +141,7 @@ class FlysystemResolver implements ResolverInterface
         $this->flysystem->put(
             $this->getFilePath($path, $filter),
             $binary->getContent(),
-            ['visibility' => $this->visibility]
+            array('visibility' => $this->visibility)
         );
     }
 

--- a/Imagine/Cache/Resolver/NoCacheWebPathResolver.php
+++ b/Imagine/Cache/Resolver/NoCacheWebPathResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Imagine/Cache/Resolver/ProxyResolver.php
+++ b/Imagine/Cache/Resolver/ProxyResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Imagine/Cache/Resolver/ResolverInterface.php
+++ b/Imagine/Cache/Resolver/ResolverInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;
@@ -23,9 +32,9 @@ interface ResolverInterface
      * @param string $path   The path where the original file is expected to be
      * @param string $filter The name of the imagine filter in effect
      *
-     * @return string The absolute URL of the cached image
-     *
      * @throws NotResolvableException
+     *
+     * @return string The absolute URL of the cached image
      */
     public function resolve($path, $filter);
 

--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Imagine/Cache/Signer.php
+++ b/Imagine/Cache/Signer.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache;
 
 class Signer implements SignerInterface

--- a/Imagine/Cache/SignerInterface.php
+++ b/Imagine/Cache/SignerInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Cache;
 
 interface SignerInterface

--- a/Imagine/Data/DataManager.php
+++ b/Imagine/Data/DataManager.php
@@ -1,12 +1,21 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Data;
 
-use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
-use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
-use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
-use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Binary\BinaryInterface;
+use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
+use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+use Liip\ImagineBundle\Model\Binary;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
 
 class DataManager

--- a/Imagine/Data/Transformer/TransformerInterface.php
+++ b/Imagine/Data/Transformer/TransformerInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Data\Transformer;
 
 /**

--- a/Imagine/Filter/FilterConfiguration.php
+++ b/Imagine/Filter/FilterConfiguration.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter;
 
 use Liip\ImagineBundle\Exception\Imagine\Filter\NonExistingFilterException;
@@ -24,9 +33,9 @@ class FilterConfiguration
      *
      * @param string $filter
      *
-     * @return array
-     *
      * @throws NonExistingFilterException
+     *
+     * @return array
      */
     public function get($filter)
     {

--- a/Imagine/Filter/FilterManager.php
+++ b/Imagine/Filter/FilterManager.php
@@ -1,14 +1,23 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter;
 
 use Imagine\Image\ImagineInterface;
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Binary\FileBinaryInterface;
 use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
-use Liip\ImagineBundle\Imagine\Filter\PostProcessor\PostProcessorInterface;
-use Liip\ImagineBundle\Imagine\Filter\PostProcessor\ConfigurablePostProcessorInterface;
 use Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface;
+use Liip\ImagineBundle\Imagine\Filter\PostProcessor\ConfigurablePostProcessorInterface;
+use Liip\ImagineBundle\Imagine\Filter\PostProcessor\PostProcessorInterface;
 use Liip\ImagineBundle\Model\Binary;
 
 class FilterManager

--- a/Imagine/Filter/Loader/AutoRotateFilterLoader.php
+++ b/Imagine/Filter/Loader/AutoRotateFilterLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Image\ImageInterface;

--- a/Imagine/Filter/Loader/BackgroundFilterLoader.php
+++ b/Imagine/Filter/Loader/BackgroundFilterLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Image\Box;

--- a/Imagine/Filter/Loader/CropFilterLoader.php
+++ b/Imagine/Filter/Loader/CropFilterLoader.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Filter\Basic\Crop;
 use Imagine\Image\Box;
-use Imagine\Image\Point;
 use Imagine\Image\ImageInterface;
+use Imagine\Image\Point;
 
 class CropFilterLoader implements LoaderInterface
 {

--- a/Imagine/Filter/Loader/DownscaleFilterLoader.php
+++ b/Imagine/Filter/Loader/DownscaleFilterLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 /**

--- a/Imagine/Filter/Loader/GrayscaleFilterLoader.php
+++ b/Imagine/Filter/Loader/GrayscaleFilterLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Filter\Advanced\Grayscale;

--- a/Imagine/Filter/Loader/InterlaceFilterLoader.php
+++ b/Imagine/Filter/Loader/InterlaceFilterLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Image\ImageInterface;

--- a/Imagine/Filter/Loader/LoaderInterface.php
+++ b/Imagine/Filter/Loader/LoaderInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Image\ImageInterface;

--- a/Imagine/Filter/Loader/PasteFilterLoader.php
+++ b/Imagine/Filter/Loader/PasteFilterLoader.php
@@ -1,10 +1,19 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
-use Imagine\Image\Point;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
+use Imagine\Image\Point;
 
 class PasteFilterLoader implements LoaderInterface
 {

--- a/Imagine/Filter/Loader/RelativeResizeFilterLoader.php
+++ b/Imagine/Filter/Loader/RelativeResizeFilterLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Exception\InvalidArgumentException;

--- a/Imagine/Filter/Loader/ResizeFilterLoader.php
+++ b/Imagine/Filter/Loader/ResizeFilterLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Filter\Basic\Resize;

--- a/Imagine/Filter/Loader/RotateFilterLoader.php
+++ b/Imagine/Filter/Loader/RotateFilterLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Image\ImageInterface;

--- a/Imagine/Filter/Loader/ScaleFilterLoader.php
+++ b/Imagine/Filter/Loader/ScaleFilterLoader.php
@@ -1,10 +1,19 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Filter\Basic\Resize;
-use Imagine\Image\ImageInterface;
 use Imagine\Image\Box;
+use Imagine\Image\ImageInterface;
 
 /**
  * Scale filter.

--- a/Imagine/Filter/Loader/StripFilterLoader.php
+++ b/Imagine/Filter/Loader/StripFilterLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Filter\Basic\Strip;

--- a/Imagine/Filter/Loader/ThumbnailFilterLoader.php
+++ b/Imagine/Filter/Loader/ThumbnailFilterLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Filter\Basic\Thumbnail;

--- a/Imagine/Filter/Loader/UpscaleFilterLoader.php
+++ b/Imagine/Filter/Loader/UpscaleFilterLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 /**

--- a/Imagine/Filter/Loader/WatermarkFilterLoader.php
+++ b/Imagine/Filter/Loader/WatermarkFilterLoader.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Image\Box;
-use Imagine\Image\Point;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
+use Imagine\Image\Point;
 
 class WatermarkFilterLoader implements LoaderInterface
 {

--- a/Imagine/Filter/PostProcessor/ConfigurablePostProcessorInterface.php
+++ b/Imagine/Filter/PostProcessor/ConfigurablePostProcessorInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Imagine/Filter/PostProcessor/MozJpegPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/MozJpegPostProcessor.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Imagine/Filter/PostProcessor/PngquantPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/PngquantPostProcessor.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Imagine/Filter/PostProcessor/PostProcessorInterface.php
+++ b/Imagine/Filter/PostProcessor/PostProcessorInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Imagine/Filter/RelativeResize.php
+++ b/Imagine/Filter/RelativeResize.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter;
 
 use Imagine\Exception\InvalidArgumentException;

--- a/ImagineEvents.php
+++ b/ImagineEvents.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle;
 
 interface ImagineEvents

--- a/LiipImagineBundle.php
+++ b/LiipImagineBundle.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass;
@@ -7,8 +16,8 @@ use Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\PostProcessorsCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\ResolversCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory;
-use Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory;
+use Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\FlysystemResolverFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory;

--- a/Model/Binary.php
+++ b/Model/Binary.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Model;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Model/FileBinary.php
+++ b/Model/FileBinary.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Model;
 
 use Liip\ImagineBundle\Binary\FileBinaryInterface;

--- a/Templating/Helper/ImagineHelper.php
+++ b/Templating/Helper/ImagineHelper.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Templating\Helper;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;

--- a/Templating/ImagineExtension.php
+++ b/Templating/ImagineExtension.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Templating;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests;
 
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;

--- a/Tests/Binary/Loader/AbstractDoctrineLoaderTest.php
+++ b/Tests/Binary/Loader/AbstractDoctrineLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Binary\Loader;
 
 use Doctrine\Common\Persistence\ObjectRepository;

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Binary\Loader;
 
 use Liip\ImagineBundle\Binary\Loader\FileSystemLoader;

--- a/Tests/Binary/Loader/FlysystemLoaderTest.php
+++ b/Tests/Binary/Loader/FlysystemLoaderTest.php
@@ -1,10 +1,19 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Binary\Loader;
 
 use Liip\ImagineBundle\Binary\Loader\FlysystemLoader;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 use Liip\ImagineBundle\Tests\AbstractTest;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 
 /**
  * @requires PHP 5.4

--- a/Tests/Binary/Loader/GridFSLoaderTest.php
+++ b/Tests/Binary/Loader/GridFSLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Binary\Loader;
 
 use Doctrine\MongoDB\GridFSFile;

--- a/Tests/Binary/Loader/StreamLoaderTest.php
+++ b/Tests/Binary/Loader/StreamLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Binary\Loader;
 
 use Liip\ImagineBundle\Binary\Loader\StreamLoader;

--- a/Tests/Binary/SimpleMimeTypeGuesserTest.php
+++ b/Tests/Binary/SimpleMimeTypeGuesserTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Binary;
 
 use Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser;

--- a/Tests/Controller/ImagineControllerTest.php
+++ b/Tests/Controller/ImagineControllerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Controller;
 
 use Liip\ImagineBundle\Controller\ImagineController;

--- a/Tests/DependencyInjection/Compiler/FiltersCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FiltersCompilerPassTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass;

--- a/Tests/DependencyInjection/Compiler/LoadersCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoadersCompilerPassTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass;

--- a/Tests/DependencyInjection/Compiler/ResolversCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResolversCompilerPassTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\ResolversCompilerPass;

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\DependencyInjection;
 
 use Liip\ImagineBundle\DependencyInjection\Configuration;

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory\Loader;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory;

--- a/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory\Loader;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory;

--- a/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory\Loader;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory;

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory\Resolver;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory;

--- a/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory\Resolver;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\FlysystemResolverFactory;

--- a/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory\Resolver;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory;

--- a/Tests/DependencyInjection/LiipImagineExtensionTest.php
+++ b/Tests/DependencyInjection/LiipImagineExtensionTest.php
@@ -1,16 +1,25 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\DependencyInjection;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory;
-use Liip\ImagineBundle\Tests\AbstractTest;
 use Liip\ImagineBundle\DependencyInjection\LiipImagineExtension;
+use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Yaml\Parser;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Yaml\Parser;
 
 /**
  * @covers Liip\ImagineBundle\DependencyInjection\Configuration

--- a/Tests/Events/CacheResolveEventTest.php
+++ b/Tests/Events/CacheResolveEventTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Events;
 
 use Liip\ImagineBundle\Events\CacheResolveEvent;

--- a/Tests/Exception/Imagine/Cache/Resolver/NotResolvableExceptionTest.php
+++ b/Tests/Exception/Imagine/Cache/Resolver/NotResolvableExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Exception\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;

--- a/Tests/Exception/Imagine/Cache/Resolver/NotStorableExceptionTest.php
+++ b/Tests/Exception/Imagine/Cache/Resolver/NotStorableExceptionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Exception\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotStorableException;

--- a/Tests/Fixtures/CacheManagerAwareResolver.php
+++ b/Tests/Fixtures/CacheManagerAwareResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Fixtures;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManagerAwareInterface;

--- a/Tests/Fixtures/Model.php
+++ b/Tests/Fixtures/Model.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Guzzle\Service\Resource;
 
 class Model

--- a/Tests/Form/Type/ImageTypeTest.php
+++ b/Tests/Form/Type/ImageTypeTest.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Form\Type;
 
 use Liip\ImagineBundle\Form\Type\ImageType;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @covers Liip\ImagineBundle\Form\Type\ImageType

--- a/Tests/Functional/Binary/SimpleMimeTypeGuesserTest.php
+++ b/Tests/Functional/Binary/SimpleMimeTypeGuesserTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\Binary;
 
 use Liip\ImagineBundle\Tests\Functional\WebTestCase;

--- a/Tests/Functional/Command/RemoveCacheTest.php
+++ b/Tests/Functional/Command/RemoveCacheTest.php
@@ -1,14 +1,23 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\Command;
 
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
 use Liip\ImagineBundle\Command\RemoveCacheCommand;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Console\Command\Command;
+use Liip\ImagineBundle\Tests\Functional\WebTestCase;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @covers Liip\ImagineBundle\Command\RemoveCacheCommand

--- a/Tests/Functional/Command/ResolveCacheTest.php
+++ b/Tests/Functional/Command/ResolveCacheTest.php
@@ -1,14 +1,23 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\Command;
 
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
 use Liip\ImagineBundle\Command\ResolveCacheCommand;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Console\Command\Command;
+use Liip\ImagineBundle\Tests\Functional\WebTestCase;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @covers Liip\ImagineBundle\Command\ResolveCacheCommand

--- a/Tests/Functional/Controller/ImagineControllerTest.php
+++ b/Tests/Functional/Controller/ImagineControllerTest.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\Controller;
 
+use Liip\ImagineBundle\Imagine\Cache\Signer;
 use Liip\ImagineBundle\Tests\Functional\WebTestCase;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\Filesystem\Filesystem;
-use Liip\ImagineBundle\Imagine\Cache\Signer;
 
 /**
  * @covers Liip\ImagineBundle\Controller\ImagineController

--- a/Tests/Functional/ExtensionGuesserTest.php
+++ b/Tests/Functional/ExtensionGuesserTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional;
 
 class ExtensionGuesserTest extends WebTestCase

--- a/Tests/Functional/Imagine/Cache/Resolver/NoCacheWebPathResolverTest.php
+++ b/Tests/Functional/Imagine/Cache/Resolver/NoCacheWebPathResolverTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Tests\Functional\WebTestCase;

--- a/Tests/Functional/Imagine/Data/DataManagerTest.php
+++ b/Tests/Functional/Imagine/Data/DataManagerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Data;
 
 use Liip\ImagineBundle\Tests\Functional\WebTestCase;

--- a/Tests/Functional/Imagine/Filter/FilterManagerTest.php
+++ b/Tests/Functional/Imagine/Filter/FilterManagerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter;
 
 use Liip\ImagineBundle\Tests\Functional\WebTestCase;

--- a/Tests/Functional/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
+++ b/Tests/Functional/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter\Loader;
 
 use Liip\ImagineBundle\Tests\Functional\WebTestCase;

--- a/Tests/Functional/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
+++ b/Tests/Functional/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter\Loader;
 
 use Liip\ImagineBundle\Tests\Functional\WebTestCase;

--- a/Tests/Functional/Imagine/Filter/Loader/InterlaceFilterLoaderTest.php
+++ b/Tests/Functional/Imagine/Filter/Loader/InterlaceFilterLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter\Loader;
 
 use Liip\ImagineBundle\Tests\Functional\WebTestCase;

--- a/Tests/Functional/Imagine/Filter/Loader/RotateFilterLoaderTest.php
+++ b/Tests/Functional/Imagine/Filter/Loader/RotateFilterLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter\Loader;
 
 use Liip\ImagineBundle\Tests\Functional\WebTestCase;

--- a/Tests/Functional/MimeTypeGuesserTest.php
+++ b/Tests/Functional/MimeTypeGuesserTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional;
 
 class MimeTypeGuesserTest extends WebTestCase

--- a/Tests/Functional/SignerTest.php
+++ b/Tests/Functional/SignerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional;
 
 class SignerTest extends WebTestCase

--- a/Tests/Functional/WebTestCase.php
+++ b/Tests/Functional/WebTestCase.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Functional\app;
 
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
 {

--- a/Tests/Imagine/Cache/CacheManagerTest.php
+++ b/Tests/Imagine/Cache/CacheManagerTest.php
@@ -1,13 +1,22 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Cache;
 
+use Liip\ImagineBundle\Events\CacheResolveEvent;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
-use Liip\ImagineBundle\Model\Binary;
-use Liip\ImagineBundle\Tests\AbstractTest;
 use Liip\ImagineBundle\Imagine\Cache\Signer;
 use Liip\ImagineBundle\ImagineEvents;
-use Liip\ImagineBundle\Events\CacheResolveEvent;
+use Liip\ImagineBundle\Model\Binary;
+use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**

--- a/Tests/Imagine/Cache/Resolver/AmazonS3ResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/AmazonS3ResolverTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Imagine\Cache\Resolver\AmazonS3Resolver;

--- a/Tests/Imagine/Cache/Resolver/AwsS3ResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/AwsS3ResolverTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Imagine\Cache\Resolver\AwsS3Resolver;

--- a/Tests/Imagine/Cache/Resolver/CacheResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/CacheResolverTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Cache\Resolver;
 
 use Doctrine\Common\Cache\ArrayCache;

--- a/Tests/Imagine/Cache/Resolver/FlysystemResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/FlysystemResolverTest.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Cache\Resolver;
 
+use League\Flysystem\Filesystem;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\FlysystemResolver;
 use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Tests\AbstractTest;
-use League\Flysystem\Filesystem;
 use Symfony\Component\Routing\RequestContext;
 
 /**

--- a/Tests/Imagine/Cache/Resolver/NoCacheWebPathResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/NoCacheWebPathResolverTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Imagine\Cache\Resolver\NoCacheWebPathResolver;

--- a/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ProxyResolver;

--- a/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Cache\Resolver;
 
 use Liip\ImagineBundle\Imagine\Cache\Resolver\WebPathResolver;

--- a/Tests/Imagine/Cache/SignerTest.php
+++ b/Tests/Imagine/Cache/SignerTest.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Cache;
 
-use Liip\ImagineBundle\Tests\AbstractTest;
 use Liip\ImagineBundle\Imagine\Cache\Signer;
+use Liip\ImagineBundle\Tests\AbstractTest;
 
 class SignerTest extends AbstractTest
 {

--- a/Tests/Imagine/Data/DataManagerTest.php
+++ b/Tests/Imagine/Data/DataManagerTest.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Data;
 
-use Liip\ImagineBundle\Imagine\Data\DataManager;
 use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
+use Liip\ImagineBundle\Imagine\Data\DataManager;
 use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Tests\AbstractTest;
 

--- a/Tests/Imagine/Filter/FilterConfigurationTest.php
+++ b/Tests/Imagine/Filter/FilterConfigurationTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;

--- a/Tests/Imagine/Filter/FilterManagerTest.php
+++ b/Tests/Imagine/Filter/FilterManagerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;

--- a/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
 use Liip\ImagineBundle\Imagine\Filter\Loader\AutoRotateFilterLoader;

--- a/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
-use Liip\ImagineBundle\Imagine\Filter\Loader\CropFilterLoader;
-use Liip\ImagineBundle\Tests\AbstractTest;
 use Imagine\Image\Box;
 use Imagine\Image\Point;
+use Liip\ImagineBundle\Imagine\Filter\Loader\CropFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
  * Test cases for CropFilterLoader class.

--- a/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
 use Imagine\Image\Box;

--- a/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundDownscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundDownscaleFilterLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
 use Imagine\Gd\Imagine;

--- a/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundUpscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundUpscaleFilterLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
 use Imagine\Gd\Imagine;

--- a/Tests/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
+use Imagine\Gd\Imagine;
 use Imagine\Image\Box;
 use Imagine\Image\Palette\RGB;
 use Imagine\Image\Point;
-use Imagine\Gd\Imagine;
 use Liip\ImagineBundle\Imagine\Filter\Loader\GrayscaleFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 

--- a/Tests/Imagine/Filter/Loader/InterlaceFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/InterlaceFilterLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
 use Liip\ImagineBundle\Imagine\Filter\Loader\InterlaceFilterLoader;

--- a/Tests/Imagine/Filter/Loader/PasteFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/PasteFilterLoaderTest.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
-use Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader;
-use Liip\ImagineBundle\Tests\AbstractTest;
 use Imagine\Image\Box;
 use Imagine\Image\Point;
+use Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
  * Test cases for PasteFilterLoader class.

--- a/Tests/Imagine/Filter/Loader/ResizeFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ResizeFilterLoaderTest.php
@@ -1,10 +1,19 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
+use Imagine\Image\Box;
 use Liip\ImagineBundle\Imagine\Filter\Loader\ResizeFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
-use Imagine\Image\Box;
 
 /**
  * Test cases for ResizeFilterLoader class.

--- a/Tests/Imagine/Filter/Loader/RotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/RotateFilterLoaderTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
 use Liip\ImagineBundle\Imagine\Filter\Loader\RotateFilterLoader;

--- a/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
@@ -1,10 +1,19 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
+use Imagine\Image\Box;
 use Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
-use Imagine\Image\Box;
 
 /**
  * Test cases for ScaleFilterLoader class.

--- a/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
@@ -1,10 +1,19 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Filter;
 
+use Imagine\Image\Box;
 use Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
-use Imagine\Image\Box;
 
 /**
  * Test cases for ThumbnailFilterLoader class.

--- a/Tests/LiipImagineBundleTest.php
+++ b/Tests/LiipImagineBundleTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests;
 
 use Liip\ImagineBundle\LiipImagineBundle;

--- a/Tests/Model/BinaryTest.php
+++ b/Tests/Model/BinaryTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Model;
 
 use Liip\ImagineBundle\Model\Binary;

--- a/Tests/Templating/Helper/ImagineHelperTest.php
+++ b/Tests/Templating/Helper/ImagineHelperTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Templating\Helper;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;

--- a/Tests/Templating/ImagineExtensionTest.php
+++ b/Tests/Templating/ImagineExtensionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Templating\Helper;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace {
     if (!$loader = @include __DIR__.'/../vendor/autoload.php') {
         echo <<<'EOM'


### PR DESCRIPTION
This replaces #791 (which was done prior to the new "style rules" and "php-cs-fixer bridge" additions using a hand crafted regex of mine - I feel more comfortable having a real code tokenizer/lexer do it instead, heh).

**So, this is simple a PHP CS Fixer run using our new default rule set.**

While the change set is substantial in size, its actually quite simple. All the changes relate to one of the following three rules:
- Ensure all files have the proper file-level doc block.
- Ensure all class/method/etc doc blocks use consistent ordering of tags.
- Ensure all imports are ordered.

The only, singular exception to my above assertion is a [short-array to long-array syntax fix](https://github.com/liip/LiipImagineBundle/compare/master...src-run:bugfix-phpcsfixer-run?expand=1#diff-741c7f1cd78fc4c24ff27bd7659a6fd7L135) caught the fixer.

Hopefully people run this more often now! Remember, it's as easy as this now:

```
bin/php-cs-fixer fix
```