### PR TITLE
Let the client pick the scheme

### DIFF
--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -158,8 +158,7 @@ class WebPathResolver implements ResolverInterface
         }
         $baseUrl = rtrim($baseUrl, '/\\');
 
-        return sprintf('%s://%s%s%s',
-            $this->requestContext->getScheme(),
+        return sprintf('//%s%s%s',
             $this->requestContext->getHost(),
             $port,
             $baseUrl

--- a/Tests/Functional/Command/ResolveCacheTest.php
+++ b/Tests/Functional/Command/ResolveCacheTest.php
@@ -58,7 +58,7 @@ class ResolveCacheTest extends WebTestCase
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_default/images/cats.jpeg');
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
     }
 
     public function testShouldResolveWithCacheExists()
@@ -77,7 +77,7 @@ class ResolveCacheTest extends WebTestCase
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_default/images/cats.jpeg');
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
     }
 
     public function testShouldResolveWithFewPathsAndSingleFilter()
@@ -89,8 +89,8 @@ class ResolveCacheTest extends WebTestCase
                 '--filters' => array('thumbnail_web_path'), )
         );
 
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
     }
 
     public function testShouldResolveWithFewPathsSingleFilterAndPartiallyFullCache()
@@ -112,8 +112,8 @@ class ResolveCacheTest extends WebTestCase
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_default/images/cats.jpeg');
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats2.jpeg');
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
     }
 
     public function testShouldResolveWithFewPathsAndFewFilters()
@@ -125,10 +125,10 @@ class ResolveCacheTest extends WebTestCase
                 '--filters' => array('thumbnail_web_path', 'thumbnail_default'), )
         );
 
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_default/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_default/images/cats2.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_default/images/cats.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_default/images/cats2.jpeg', $output);
     }
 
     public function testShouldResolveWithFewPathsAndWithoutFilters()
@@ -138,10 +138,10 @@ class ResolveCacheTest extends WebTestCase
             array('paths' => array('images/cats.jpeg', 'images/cats2.jpeg'))
         );
 
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_default/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_default/images/cats2.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_default/images/cats.jpeg', $output);
+        $this->assertContains('//localhost/media/cache/thumbnail_default/images/cats2.jpeg', $output);
     }
 
     /**

--- a/Tests/Functional/Controller/ImagineControllerTest.php
+++ b/Tests/Functional/Controller/ImagineControllerTest.php
@@ -66,7 +66,7 @@ class ImagineControllerTest extends WebTestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
+        $this->assertEquals('//localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
     }
@@ -84,7 +84,7 @@ class ImagineControllerTest extends WebTestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
+        $this->assertEquals('//localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
     }
@@ -160,7 +160,7 @@ class ImagineControllerTest extends WebTestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/media/cache/'.$expectedCachePath, $response->getTargetUrl());
+        $this->assertEquals('//localhost/media/cache/'.$expectedCachePath, $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/'.$expectedCachePath);
     }
@@ -195,7 +195,7 @@ class ImagineControllerTest extends WebTestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/media/cache'.'/'.$expectedCachePath, $response->getTargetUrl());
+        $this->assertEquals('//localhost/media/cache'.'/'.$expectedCachePath, $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/'.$expectedCachePath);
     }
@@ -215,7 +215,7 @@ class ImagineControllerTest extends WebTestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/foo bar.jpeg', $response->getTargetUrl());
+        $this->assertEquals('//localhost/media/cache/thumbnail_web_path/images/foo bar.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/foo bar.jpeg');
     }

--- a/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
@@ -160,10 +160,9 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($resolver->isStored('', 'aFilter'));
     }
 
-    public function testComposeSchemaHostAndFileUrlOnResolve()
+    public function testComposeHostAndFileUrlOnResolve()
     {
         $requestContext = new RequestContext();
-        $requestContext->setScheme('theSchema');
         $requestContext->setHost('thehost');
 
         $resolver = new WebPathResolver(
@@ -174,15 +173,14 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            'theschema://thehost/aCachePrefix/aFilter/aPath',
+            '//thehost/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
     }
 
-    public function testComposeSchemaHostAndBasePathWithPhpFileAndFileUrlOnResolve()
+    public function testComposeHostAndBasePathWithPhpFileAndFileUrlOnResolve()
     {
         $requestContext = new RequestContext();
-        $requestContext->setScheme('theSchema');
         $requestContext->setHost('thehost');
         $requestContext->setBaseUrl('/theBasePath/app.php');
 
@@ -194,15 +192,14 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            'theschema://thehost/theBasePath/aCachePrefix/aFilter/aPath',
+            '//thehost/theBasePath/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
     }
 
-    public function testComposeSchemaHostAndBasePathWithDirsOnlyAndFileUrlOnResolve()
+    public function testComposeHostAndBasePathWithDirsOnlyAndFileUrlOnResolve()
     {
         $requestContext = new RequestContext();
-        $requestContext->setScheme('theSchema');
         $requestContext->setHost('thehost');
         $requestContext->setBaseUrl('/theBasePath/theSubBasePath');
 
@@ -214,12 +211,12 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            'theschema://thehost/theBasePath/theSubBasePath/aCachePrefix/aFilter/aPath',
+            '//thehost/theBasePath/theSubBasePath/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
     }
 
-    public function testComposeSchemaHostAndBasePathWithBackSplashOnResolve()
+    public function testComposeHostAndBasePathWithBackSplashOnResolve()
     {
         $requestContext = new RequestContext();
         $requestContext->setScheme('theSchema');
@@ -234,12 +231,12 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            'theschema://thehost/aCachePrefix/aFilter/aPath',
+            '//thehost/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
     }
 
-    public function testComposeSchemaHttpAndCustomPortAndFileUrlOnResolve()
+    public function testComposeCustomHttpPortAndFileUrlOnResolve()
     {
         $requestContext = new RequestContext();
         $requestContext->setScheme('http');
@@ -254,12 +251,12 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            'http://thehost:88/aCachePrefix/aFilter/aPath',
+            '//thehost:88/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
     }
 
-    public function testComposeSchemaHttpsAndCustomPortAndFileUrlOnResolve()
+    public function testComposeCustomHttpsPortAndFileUrlOnResolve()
     {
         $requestContext = new RequestContext();
         $requestContext->setScheme('https');
@@ -274,7 +271,7 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            'https://thehost:444/aCachePrefix/aFilter/aPath',
+            '//thehost:444/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
     }


### PR DESCRIPTION
I can't figure out why my templates still output `http` schemes when my page is in https, I have configured trusted proxies, and even tried harcoding the request context scheme. The request context scheme is http when arriving in the the web path resolver.

I propose this alternative, that fixes my bug with less code : let's use '//' urls everywhere, and let the client figure out which scheme should be used.