### PR TITLE
Skip tests with dependencies that are not installed by default

### DIFF
--- a/Tests/Functional/WebTestCase.php
+++ b/Tests/Functional/WebTestCase.php
@@ -15,6 +15,17 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 
 abstract class WebTestCase extends BaseWebTestCase
 {
+    public function setUp()
+    {
+        if (!class_exists('Symfony\Component\Asset\Package')) {
+            $this->markTestSkipped('The symfony/asset PHP library is not available.');
+        }
+        if (!class_exists('Symfony\Component\Translation\Translator')) {
+            $this->markTestSkipped('The symfony/translation PHP library is not installed.');
+        }
+        parent::setUp();
+    }
+
     /**
      * @return string
      */

--- a/Tests/Templating/Helper/ImagineHelperTest.php
+++ b/Tests/Templating/Helper/ImagineHelperTest.php
@@ -19,6 +19,13 @@ use Liip\ImagineBundle\Templating\Helper\ImagineHelper;
  */
 class ImagineHelperTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        if (!class_exists('Symfony\Component\Templating\Helper\Helper')) {
+            $this->markTestSkipped('The symfony/templating PHP library is not available.');
+        }
+    }
+
     public function testSubClassOfHelper()
     {
         $rc = new \ReflectionClass('Liip\ImagineBundle\Templating\Helper\ImagineHelper');


### PR DESCRIPTION
I just checked out the repository for the first time, ran phpunit, and got a bunch of fails, one of which was a fatal PHP error that stopped the tests because symfony templating was not installed (`PHP Fatal error:  Class 'Symfony\Component\Templating\Helper\Helper' not found`).
By skipping the tests that require components that are not installed by default at least all the tests run out of the box.
Alternatively the missing dependencies could be added to the dev dependencies but I did not want to be presumptuous and just add them.