### PR TITLE
Require components that no longer ship with Symfony FrameworkBundle 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
       env: SYMFONY_VERSION=3.1.*@dev
     - php: 7.0
       env: SYMFONY_VERSION=3.2.x-dev
+    - php: 7.1
+      env: SYMFONY_VERSION=3.2.x-dev
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ matrix:
       env: SYMFONY_VERSION=3.2.x-dev
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
-  allow_failures:
-    - php: 7.0
-      env: SYMFONY_VERSION=3.2.x-dev
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,14 @@
     "require": {
         "php": "^5.3.9|^7.0",
         "imagine/Imagine": "^0.6.3,<0.7",
+        "symfony/asset": "~2.3|~3.0",
         "symfony/filesystem": "~2.3|~3.0",
         "symfony/finder": "~2.3|~3.0",
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/options-resolver": "~2.3|~3.0",
-        "symfony/process": "~2.3|~3.0"
+        "symfony/process": "~2.3|~3.0",
+        "symfony/templating": "~2.3|~3.0",
+        "symfony/translation": "~2.3|~3.0"
     },
     "require-dev": {
         "ext-gd": "*",


### PR DESCRIPTION
Symfony 3.2 FrameworkBundle no longer requires symfony/asset, symfony/templating and symfony/translation anymore, causing several tests to fail. By requiring them explicitly the tests no longer fail.

Additionaly, this PR makes symfony 3.2 required for Travis, since symfony 3.2 is final now, and also adds PHP 7.1 to the test matrix, since that is final now as well.

This PR is an alternative to https://github.com/liip/LiipImagineBundle/pull/831, which marks the tests with missing dependencies as skipped.