### PR TITLE
Set DefaultMetadataReader when ext-exif is not present

### DIFF
--- a/DependencyInjection/Compiler/MetadataReaderCompilerPass.php
+++ b/DependencyInjection/Compiler/MetadataReaderCompilerPass.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * By default, a metadata reader based on the exif php extension is used.
+ * This compiler pass checks if the extension is loaded an switches to a simpler
+ * implementation if not.
+ */
+class MetadataReaderCompilerPass implements CompilerPassInterface
+{
+    const METADATA_READER_PARAM = 'liip_imagine.meta_data.reader.class';
+
+    const DEFAULT_METADATA_READER_CLASS = 'Imagine\Image\Metadata\DefaultMetadataReader';
+
+    const EXIF_METADATA_READER_CLASS = 'Imagine\Image\Metadata\ExifMetadataReader';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$this->extExifIsAvailable() && $this->isDefaultMetadataReader($container)) {
+            $container->setParameter(self::METADATA_READER_PARAM, self::DEFAULT_METADATA_READER_CLASS);
+            $this->logMetadataReaderReplaced($container);
+        }
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     *
+     * @return bool
+     */
+    protected function isDefaultMetadataReader(ContainerBuilder $container)
+    {
+        $currentMetadataReaderParameter = $container->getParameter(self::METADATA_READER_PARAM);
+
+        return $currentMetadataReaderParameter === self::EXIF_METADATA_READER_CLASS;
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    protected function logMetadataReaderReplaced(ContainerBuilder $container)
+    {
+        $compiler = $container->getCompiler();
+        $formatter = $compiler->getLoggingFormatter();
+        $message = 'Automatically replaced Imagine ExifMetadataReader with DefaultMetadataReader; '.
+            'you might experience issues with LiipImagineBundle; reason: PHP extension "exif" is missing; solution: '.
+            'for advanced metadata extraction install the PHP extension "exif" or set a custom MetadataReader '.
+            'through the "liip_imagine.meta_data.reader.class" parameter';
+
+        $compiler->addLogMessage($formatter->format($this, $message));
+    }
+
+    /**
+     * @return bool
+     */
+    protected function extExifIsAvailable()
+    {
+        return extension_loaded('exif');
+    }
+}

--- a/LiipImagineBundle.php
+++ b/LiipImagineBundle.php
@@ -13,6 +13,7 @@ namespace Liip\ImagineBundle;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass;
+use Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\PostProcessorsCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\ResolversCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory;
@@ -38,6 +39,7 @@ class LiipImagineBundle extends Bundle
         $container->addCompilerPass(new FiltersCompilerPass());
         $container->addCompilerPass(new PostProcessorsCompilerPass());
         $container->addCompilerPass(new ResolversCompilerPass());
+        $container->addCompilerPass(new MetadataReaderCompilerPass());
 
         /** @var $extension LiipImagineExtension */
         $extension = $container->getExtension('liip_imagine');

--- a/Tests/DependencyInjection/Compiler/MetadataReaderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MetadataReaderCompilerPassTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
+
+use Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @covers Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass
+ */
+class MetadataReaderCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcessWithoutExtExifAddsDefaultReader()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter(
+            MetadataReaderCompilerPass::METADATA_READER_PARAM,
+            MetadataReaderCompilerPass::EXIF_METADATA_READER_CLASS
+        );
+
+        /** @var MetadataReaderCompilerPass $pass */
+        $pass = $this->getMock(
+            'Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass',
+            array('extExifIsAvailable'),
+            array()
+        );
+        $pass->expects($this->once())
+            ->method('extExifIsAvailable')
+            ->willReturn(false);
+
+        //guard
+        $this->assertEquals(
+            MetadataReaderCompilerPass::EXIF_METADATA_READER_CLASS,
+            $container->getParameter(MetadataReaderCompilerPass::METADATA_READER_PARAM)
+        );
+
+        $pass->process($container);
+
+        $this->assertEquals(
+            MetadataReaderCompilerPass::DEFAULT_METADATA_READER_CLASS,
+            $container->getParameter(MetadataReaderCompilerPass::METADATA_READER_PARAM)
+        );
+    }
+
+    public function testProcessWithExtExifKeepsExifReader()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter(
+            MetadataReaderCompilerPass::METADATA_READER_PARAM,
+            MetadataReaderCompilerPass::EXIF_METADATA_READER_CLASS
+        );
+
+        /** @var MetadataReaderCompilerPass $pass */
+        $pass = $this->getMock(
+            'Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass',
+            array('extExifIsAvailable'),
+            array()
+        );
+        $pass->expects($this->once())
+            ->method('extExifIsAvailable')
+            ->willReturn(true);
+
+        //guard
+        $this->assertEquals(
+            MetadataReaderCompilerPass::EXIF_METADATA_READER_CLASS,
+            $container->getParameter(MetadataReaderCompilerPass::METADATA_READER_PARAM)
+        );
+
+        $pass->process($container);
+
+        $this->assertEquals(
+            MetadataReaderCompilerPass::EXIF_METADATA_READER_CLASS,
+            $container->getParameter(MetadataReaderCompilerPass::METADATA_READER_PARAM)
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
     "suggest": {
         "amazonwebservices/aws-sdk-for-php": "Required to use AWS version 1 cache resolver.",
         "aws/aws-sdk-php": "Required to use AWS version 2/3 cache resolver.",
+        "ext-exif": "Required to read metadata from Exif information",
         "league/flysystem": "Required to use FlySystem data loader or cache resolver.",
         "monolog/monolog": "A psr/log compatible logger is required to enable logging.",
         "twig/twig": "Required to use the provided Twig extension. Version 1.12 or greater needed."


### PR DESCRIPTION
This fixes the issue where an exif reader is used, but ext-exif
is not loaded.

Closes: #501