### PR TITLE
Fix absolute path

### DIFF
--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -59,7 +59,7 @@ class FileSystemLoader implements LoaderInterface
      */
     public function find($path)
     {
-        if (!($absolutePath = realpath($this->rootPath.DIRECTORY_SEPARATOR.$path))) {
+        if (!($absolutePath = realpath($this->rootPath).DIRECTORY_SEPARATOR.$path)) {
             throw new NotLoadableException(sprintf('Source image not resolvable "%s"', $path));
         }
 


### PR DESCRIPTION
There was conflict with 'assets:install --symlink', which cause the NotLoadableException. It searches in web but the realpath was returned the path in src/.../. That path was outside the defined root path (/web by default).