### PR TITLE
Allow multiple root paths for FileSystemLoader

### DIFF
--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -49,8 +49,16 @@ class FileSystemLoaderFactory implements LoaderFactoryInterface
     {
         $builder
             ->children()
-                ->scalarNode('data_root')->defaultValue('%kernel.root_dir%/../web')->cannotBeEmpty()->end()
-            ->end()
-        ;
+                ->arrayNode('data_root')
+                    ->beforeNormalization()
+                    ->ifString()
+                        ->then(function ($value) { return array($value); })
+                    ->end()
+                    ->defaultValue(array('%kernel.root_dir%/../web'))
+                    ->prototype('scalar')
+                        ->cannotBeEmpty()
+                    ->end()
+                ->end()
+            ->end();
     }
 }

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -16,24 +16,10 @@ use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 
 /**
- * @covers Liip\ImagineBundle\Binary\Loader\FileSystemLoader
+ * @covers \Liip\ImagineBundle\Binary\Loader\FileSystemLoader
  */
 class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    public static function provideLoadCases()
-    {
-        $fileName = pathinfo(__FILE__, PATHINFO_BASENAME);
-
-        return array(
-            array(__DIR__, $fileName),
-            array(__DIR__.'/', $fileName),
-            array(__DIR__, '/'.$fileName),
-            array(__DIR__.'/../../Binary/Loader', '/'.$fileName),
-            array(realpath(__DIR__.'/..'), 'Loader/'.$fileName),
-            array(__DIR__.'/../', '/Loader/../../Binary/Loader/'.$fileName),
-        );
-    }
-
     public function testShouldImplementLoaderInterface()
     {
         $rc = new \ReflectionClass('Liip\ImagineBundle\Binary\Loader\FileSystemLoader');
@@ -47,6 +33,20 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
             MimeTypeGuesser::getInstance(),
             ExtensionGuesser::getInstance(),
             __DIR__
+        );
+    }
+
+    public function testThrowExceptionIfNoRootPathsProvided()
+    {
+        $this->setExpectedException(
+            'Liip\ImagineBundle\Exception\InvalidArgumentException',
+            'One or more data root paths must be specified.'
+        );
+
+        new FileSystemLoader(
+            MimeTypeGuesser::getInstance(),
+            ExtensionGuesser::getInstance(),
+            array()
         );
     }
 
@@ -137,6 +137,20 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->find('fileNotExist');
     }
 
+    public static function provideLoadCases()
+    {
+        $fileName = pathinfo(__FILE__, PATHINFO_BASENAME);
+
+        return array(
+            array(__DIR__, $fileName),
+            array(__DIR__.'/', $fileName),
+            array(__DIR__, '/'.$fileName),
+            array(__DIR__.'/../../Binary/Loader', '/'.$fileName),
+            array(realpath(__DIR__.'/..'), 'Loader/'.$fileName),
+            array(__DIR__.'/../', '/Loader/../../Binary/Loader/'.$fileName),
+        );
+    }
+
     /**
      * @dataProvider provideLoadCases
      */
@@ -146,6 +160,36 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
             MimeTypeGuesser::getInstance(),
             ExtensionGuesser::getInstance(),
             $rootDir
+        );
+
+        $binary = $loader->find($path);
+
+        $this->assertInstanceOf('Liip\ImagineBundle\Model\FileBinary', $binary);
+        $this->assertStringStartsWith('text/', $binary->getMimeType());
+    }
+
+    public static function provideMultipleRootLoadCases()
+    {
+        $prepend = array(
+            realpath(__DIR__.'/../'),
+            realpath(__DIR__.'/../../'),
+            realpath(__DIR__.'/../../../'),
+        );
+
+        return array_map(function ($params) use ($prepend) {
+            return array(array($prepend[mt_rand(0, count($prepend) - 1)], $params[0]), $params[1]);
+        }, static::provideLoadCases());
+    }
+
+    /**
+     * @dataProvider provideMultipleRootLoadCases
+     */
+    public function testMultipleRootLoadCases($rootDirs, $path)
+    {
+        $loader = new FileSystemLoader(
+            MimeTypeGuesser::getInstance(),
+            ExtensionGuesser::getInstance(),
+            $rootDirs
         );
 
         $binary = $loader->find($path);

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @covers Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory<extended>
+ * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory<extended>
  */
 class FileSystemLoaderFactoryTest extends \Phpunit_Framework_TestCase
 {
@@ -61,7 +61,7 @@ class FileSystemLoaderFactoryTest extends \Phpunit_Framework_TestCase
 
     public function testProcessCorrectlyOptionsOnAddConfiguration()
     {
-        $expectedDataRoot = 'theDataRoot';
+        $expectedDataRoot = array('theDataRoot');
 
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('filesystem', 'array');
@@ -81,7 +81,7 @@ class FileSystemLoaderFactoryTest extends \Phpunit_Framework_TestCase
 
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
     {
-        $expectedDataRoot = '%kernel.root_dir%/../web';
+        $expectedDataRoot = array('%kernel.root_dir%/../web');
 
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('filesystem', 'array');
@@ -91,6 +91,26 @@ class FileSystemLoaderFactoryTest extends \Phpunit_Framework_TestCase
 
         $config = $this->processConfigTree($treeBuilder, array(
             'filesystem' => array(),
+        ));
+
+        $this->assertArrayHasKey('data_root', $config);
+        $this->assertEquals($expectedDataRoot, $config['data_root']);
+    }
+
+    public function testAddAsScalarExpectingArrayNormalizationOfConfiguration()
+    {
+        $expectedDataRoot = array('%kernel.root_dir%/../web');
+
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('filesystem', 'array');
+
+        $loader = new FileSystemLoaderFactory();
+        $loader->addConfiguration($rootNode);
+
+        $config = $this->processConfigTree($treeBuilder, array(
+            'filesystem' => array(
+                'data_root' => $expectedDataRoot[0],
+            ),
         ));
 
         $this->assertArrayHasKey('data_root', $config);


### PR DESCRIPTION
Allow multiple data roots for file system loader as a possible approach to resolve #846. Includes `beforeNormalization` step in configuration tree-builder to allow prior string values for `data_root` bundle configuration to be seamlessly converted into an array. For example, both of the following are now valid configurations:
```yml
liip_imagine:
  loaders:
    default:
      filesystem:
        data_root: "/your/data/root"
```
```yml
liip_imagine:
  loaders:
    default:
      filesystem:
        data_root: 
          - "/your/data/root/a"
          - "/your/data/root/b"
```
This also adds a "feature" in that we can look in multiple locations using the same file system loader now, which I suspect could be beneficial for some use-cases. Most importantly, though, this implementation doesn't break any prior unit tests (but it *does* add a few unit tests to cover the new cases introduced).