### PR TITLE
[WIP] Composer Update Notice Hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_install:
   - if [ "${TRAVIS_PHP_VERSION}" == "5.3" ]; then composer remove --no-update --dev satooshi/php-coveralls; fi;
   - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
   - if [ "${SYMFONY_VERSION:0:3}" == "2.3" ]; then composer remove --dev friendsofphp/php-cs-fixer --no-update; fi;
+  - if [ "${SYMFONY_VERSION:0:3}" == "2.3" ]; then composer remove --dev composer/composer --no-update; fi;
   - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION}" != "5.3" ]; then composer require --dev league/flysystem:~1.0 --no-update; fi;
   - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION:0:1}" != "7" ]; then composer require --dev doctrine/mongodb-odm:~1.0 --no-update; yes "" | pecl -q install -f mongo; fi;
   - if [ "${SYMFONY_VERSION:-x}" != "x" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;

--- a/Tests/Utils/Composer/BufferedIO.php
+++ b/Tests/Utils/Composer/BufferedIO.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Utils\Composer;
+
+use Composer\IO\IOInterface;
+
+abstract class BufferedIO implements IOInterface
+{
+    private $buffer = array();
+
+    public function write($messages, $newline = true, $verbosity = self::NORMAL)
+    {
+        $this->buffer = array_merge($this->buffer, (array) $messages);
+    }
+
+    public function askConfirmation($question, $default = true)
+    {
+        $this->buffer[] = $question;
+    }
+
+    public function getBuffer()
+    {
+        return $this->buffer;
+    }
+}

--- a/Tests/Utils/Composer/UpgradeNoticeTest.php
+++ b/Tests/Utils/Composer/UpgradeNoticeTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Utils\Composer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Package\RootPackageInterface;
+use Composer\Script\Event;
+use Liip\ImagineBundle\Utils\Composer\UpgradeNotice;
+
+/**
+ * @covers \Liip\ImagineBundle\Utils\Composer\ConsoleIO
+ * @covers \Liip\ImagineBundle\Utils\Composer\UpgradeNotice
+ */
+class UpgradeNoticeTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        if (false === version_compare(PHP_VERSION, '5.4', '>=')
+         || false === interface_exists('\Composer\IO\IOInterface')) {
+            static::markTestSkipped('"PHP 5.4" or greater and "\Composer\IO\IOInterface" required to test this component.');
+        }
+    }
+
+    public function testWrite()
+    {
+        $io = $this->getIOMock(true);
+        $io
+            ->expects($this->atLeastOnce())
+            ->method('write');
+
+        UpgradeNotice::doWrite($this->getEventMock($io, '1.7.0'));
+        UpgradeNotice::doWrite($this->getEventMock($io = $this->getIOMock(), '1.7.0'));
+
+        $lineBuffer = $io->getBuffer();
+        $firstLine = array_shift($lineBuffer);
+
+        $this->assertTrue(count($lineBuffer) > 0);
+        $this->assertContains('Update Notice:', $firstLine);
+
+        foreach ($lineBuffer as $b) {
+            $this->assertContains('liip/imagine-bundle', $b);
+        }
+    }
+
+    public function testWriteOnUnsupportedVersion()
+    {
+        $io = $this->getIOMock(true);
+        $io
+            ->expects($this->never())
+            ->method('write');
+
+        UpgradeNotice::doWrite($this->getEventMock($io, '100.100.100'));
+        UpgradeNotice::doWrite($this->getEventMock($io = $this->getIOMock(), '100.100.100'));
+
+        $this->assertCount(0, $io->getBuffer());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|IOInterface|BufferedIO
+     */
+    private function getIOMock($mockWrite = false)
+    {
+        $io = $this->getMockBuilder('Liip\ImagineBundle\Tests\Utils\Composer\BufferedIO');
+
+        if ($mockWrite) {
+            $io->setMethods(array('write'));
+        }
+
+        return $io->getMockForAbstractClass();
+    }
+
+    /**
+     * @param IOInterface $io
+     * @param string      $version
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|Event
+     */
+    private function getEventMock(IOInterface $io, $version)
+    {
+        $composer = $this->getComposerMock($this->getPackageMock($version));
+
+        $event = $this
+            ->getMockBuilder('Composer\Script\Event')
+            ->setMethods(array('getComposer', 'getIO'))
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event
+            ->method('getComposer')
+            ->willReturn($composer);
+
+        $event
+            ->method('getIO')
+            ->willReturn($io);
+
+        return $event;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|RootPackageInterface
+     */
+    private function getPackageMock($version)
+    {
+        $package = $this
+            ->getMockBuilder('Composer\Package\RootPackageInterface')
+            ->setMethods(array('getVersion', 'getName'))
+            ->getMockForAbstractClass();
+
+        $package
+            ->method('getVersion')
+            ->willReturn($version);
+
+        $package
+            ->method('getName')
+            ->willReturn('liip/imagine-bundle');
+
+        return $package;
+    }
+
+    /**
+     * @param RootPackageInterface $package
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|Composer
+     */
+    private function getComposerMock(RootPackageInterface $package)
+    {
+        $composer = $this
+            ->getMockBuilder('Composer\Composer')
+            ->setMethods(array('getPackage'))
+            ->getMock();
+
+        $composer
+            ->method('getPackage')
+            ->willReturn($package);
+
+        return $composer;
+    }
+}
+

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,75 +1,165 @@
-Upgrade
-=======
+# Upgrade
 
-1.0.0-alpha6 to 1.0.0-alpha7
----------------
+## 1.7.x
 
-* [Configuration] `liip_imagine.controller_action` option was removed in favour of an array of actions. See `liip_imagine.controller` config
+  - __[Data Loader]__ The `FileSystemLoader` data loader performs a more robust security check against image resource
+    paths to ensure they reside within the defined data root path(s). If utilizing symbolic links, you should reference
+    the troubleshooting guide at the end of this upgrade notice.
 
-```diff
--liip_imagine:
--    controller_action: AcmeDemoBundle:Default:filterAction
-+liip_imagine:
-+    controller:
-+        filter_action: AcmeDemoBundle:Default:filterAction
-```
+  - __[Data Loader]__ The `FileSystemLoader` data loader now accepts an array of paths (as strings) for its third
+    constructor argument, enabling the loader to check multiple paths for the requested image resource.
 
-1.0.0-alpha5 to 1.0.0-alpha6
----------------
+  - __[Configuration]__ The `liip_imagine.loaders.default.filesystem.data_root` bundle configuration option now accepts
+    an array of paths (as strings) or a single scalar path ()if only one is required for your configuration), allowing
+    the `filesystem` data loader to check multiple data root paths for the requested image resource. The following YML
+    configuration shows examples for all allowed value types.
 
- * [Route] `ImagineLoader` was removed. Please adjust your `app/config/routing.yml` file.
+    ```yml
 
-    ```diff
-    -_imagine:
-    -    resource: .
-    -    type:     imagine
-    +_liip_imagine:
-    +    resource: "@LiipImagineBundle/Resources/config/routing.xml"
+      # provide an array of scalar paths
+      liip_imagine:
+        loaders:
+          default:
+            filesystem:
+              data_root:
+                - /multiple/root/paths/foo
+                - /multiple/root/paths/bar
+
+      # provide an single scalar path
+      liip_imagine:
+        loaders:
+          default:
+            filesystem:
+              data_root: /single/root/path
+
     ```
+  
+  - __[Troubleshooting]__ If you are using the `filesystem` data loader and have *symbolic links* within the `data_root`
+    that point outside this path (the `data_root` option defaults to `%kernel.root_dir%/../web`) then you are *required*
+    to configure all outside resource paths as additional `data_root` paths using the following option key in your
+    application's configuration: `liip_imagine.loaders.default.filesystem.data_root`.
+    
+    The following is a list of the most common exception error messages encountered when the `data_root` option is not
+    correctly configured:
 
- * [Configuration] `liip_imagine.filter_sets.route` option and sub options were removed.
- * [Configuration] `liip_imagine.cache_prefix` option was removed.
+    - > Source image not resolvable "%s" in root path(s) "%s"
+    - > Source image invalid "%s" as it is outside of the defined root path(s) "%s"
 
-0.19.x to 1.0.0-alpha5
----------------
+## 1.0.0-alpha7
 
-* [Symfony] Required minimum symfony version was updated to 2.3.
-* [Logger] Symfony `LoggerInterface` was replaced with PSR-3 one.
-* [Cache] New `isStored` method was added.
-* [Cache] The method `ResolverInterface::getBrowserPath` was removed.
-* [Cache] The method `ResolverInterface::store` accept `BinaryInterface` as first argument.
-* [Cache] The method `ResolverInterface::store` return nothing.
-* [Cache] The method `ResolverInterface::remove` return nothing.
-* [Cache] The method `ResolverInterface::remove` takes required array of filter as first argument.
-* [Cache] The method `ResolverInterface::remove` takes optional path as second argument.
-* [Cache] The method `ResolverInterface::clean` was removed.
-* [Cache] The method `ResolverInterface::resolve` takes path and filter as arguments.
-* [Cache] The method `ResolverInterface::resolve` return absolute url of the cached image.
-* [Cache] The method `CacheManager::resolve` may throw OutOfBoundsException if required resolver does not exist.
-* [Cache] The method `CacheManager::resolve` return absolute url of the cached image.
-* [Cache] The method `CacheManager::store` accept `BinaryInterface` as first argument.
-* [Cache] The method `CacheManager::store` return nothing.
-* [Cache] The method `CacheManager::clearResolversCache` was removed.
-* [Cache] The method `CacheManager::getWebRoot` was removed.
-* [Cache] The method `CacheManager::getBrowserPath` third argument was changed, now it is `runtimeConfig`.
-* [Cache] The method `CacheManager::generateUrl` third argument was changed, now it is `runtimeConfig`.
-* [Cache] `NoCacheResolver` renamed to `NoCacheWebPathResolver`.
-* [Cache] `AbstractFilesystemResolver` was removed.
-* [Data] `LoaderInterface::find` now can return string or `BinaryInterface` instance.
-* [Data] `DataManager::find` now can return `BinaryInterface` instance only.
-* [Data] All data loaders moved to `Binary/Loader` folder.
-* [Data] Tag name `liip_imagine.data.loader` changed to `liip_imagine.binary.loader`
-* [Data] Parameter key `liip_imagine.data.loader.filesystem.class` changed to `liip_imagine.binary.loader.filesystem.class`
-* [Data] Parameter key `liip_imagine.data.loader.stream.class` changed to `liip_imagine.binary.loader.stream.class`
-* [Data] Service id `liip_imagine.data.loader.prototype.filesystem` changed to `liip_imagine.binary.loader.prototype.filesystem`
-* [Data] Service id `liip_imagine.data.loader.prototype.stream` changed to `liip_imagine.binary.loader.prototype.stream`
-* [Filter] `FilterManager::applyFilter` now return instance of `BinaryInterface`.
-* [Filter] `FilterManager::applyFilter` first argument was changed from Image instance to BinaryInterface one.
-* [Filter] `FilterManager::get` was removed.
-* [Configuration] `liip_imagine.filter_sets.path` option was removed.
-* [Configuration] `liip_imagine.filter_sets.format` option was removed.
-* [Configuration] `liip_imagine.cache_mkdir_mode` option was removed.
-* [Configuration] `liip_imagine.web_root` option was removed.
-* [Configuration] `liip_imagine.cache` default value was changed from `web_path`to `default`.
-* [Configuration] `liip_imagine.formats` option was removed.
-* [Configuration] `liip_imagine.data_root` option was removed.
+  - __[Configuration]__ `liip_imagine.controller_action` option was removed in favour of an array of actions. See 
+    `liip_imagine.controller` config
+
+      ```diff
+
+        -liip_imagine:
+        -    controller_action: AcmeDemoBundle:Default:filterAction
+        +liip_imagine:
+        +    controller:
+        +       filter_action: AcmeDemoBundle:Default:filterAction
+
+      ```
+
+## 1.0.0-alpha6
+
+  - __[Route]__ `ImagineLoader` was removed. Please adjust your `app/config/routing.yml` file.
+
+      ```diff
+      
+        -_imagine:
+        -    resource: .
+        -    type:     imagine
+        +_liip_imagine:
+        +    resource: "@LiipImagineBundle/Resources/config/routing.xml"
+      
+      ```
+
+  - __[Configuration]__ `liip_imagine.filter_sets.route` option and sub options were removed.
+
+  - __[Configuration]__ `liip_imagine.cache_prefix` option was removed.
+
+## 1.0.0-alpha5
+
+  - __[Symfony]__ Required minimum symfony version was updated to 2.3.
+
+  - __[Logger]__ Symfony `LoggerInterface` was replaced with PSR-3 one.
+
+  - __[Cache]__ New `isStored` method was added.
+
+  - __[Cache]__ The method `ResolverInterface::getBrowserPath` was removed.
+
+  - __[Cache]__ The method `ResolverInterface::store` accept `BinaryInterface` as first argument.
+
+  - __[Cache]__ The method `ResolverInterface::store` return nothing.
+
+  - __[Cache]__ The method `ResolverInterface::remove` return nothing.
+
+  - __[Cache]__ The method `ResolverInterface::remove` takes required array of filter as first argument.
+
+  - __[Cache]__ The method `ResolverInterface::remove` takes optional path as second argument.
+
+  - __[Cache]__ The method `ResolverInterface::clean` was removed.
+
+  - __[Cache]__ The method `ResolverInterface::resolve` takes path and filter as arguments.
+
+  - __[Cache]__ The method `ResolverInterface::resolve` return absolute url of the cached image.
+
+  - __[Cache]__ The method `CacheManager::resolve` may throw OutOfBoundsException if required resolver does not exist.
+
+  - __[Cache]__ The method `CacheManager::resolve` return absolute url of the cached image.
+
+  - __[Cache]__ The method `CacheManager::store` accept `BinaryInterface` as first argument.
+
+  - __[Cache]__ The method `CacheManager::store` return nothing.
+
+  - __[Cache]__ The method `CacheManager::clearResolversCache` was removed.
+
+  - __[Cache]__ The method `CacheManager::getWebRoot` was removed.
+
+  - __[Cache]__ The method `CacheManager::getBrowserPath` third argument was changed, now it is `runtimeConfig`.
+
+  - __[Cache]__ The method `CacheManager::generateUrl` third argument was changed, now it is `runtimeConfig`.
+
+  - __[Cache]__ `NoCacheResolver` renamed to `NoCacheWebPathResolver`.
+
+  - __[Cache]__ `AbstractFilesystemResolver` was removed.
+
+  - __[Data Loader]__ `LoaderInterface::find` now can return string or `BinaryInterface` instance.
+
+  - __[Data Loader]__ `DataManager::find` now can return `BinaryInterface` instance only.
+
+  - __[Data Loader]__ All data loaders moved to `Binary/Loader` folder.
+
+  - __[Data Loader]__ Tag name `liip_imagine.data.loader` changed to `liip_imagine.binary.loader`
+
+  - __[Data Loader]__ Parameter key `liip_imagine.data.loader.filesystem.class` changed to 
+    `liip_imagine.binary.loader.filesystem.class`
+
+  - __[Data Loader]__ Parameter key `liip_imagine.data.loader.stream.class` changed to 
+    `liip_imagine.binary.loader.stream.class`
+
+  - __[Data Loader]__ Service id `liip_imagine.data.loader.prototype.filesystem` changed to 
+    `liip_imagine.binary.loader.prototype.filesystem`
+
+  - __[Data Loader]__ Service id `liip_imagine.data.loader.prototype.stream` changed to 
+    `liip_imagine.binary.loader.prototype.stream`
+
+  - __[Filter]__ `FilterManager::applyFilter` now return instance of `BinaryInterface`.
+
+  - __[Filter]__ `FilterManager::applyFilter` first argument was changed from Image instance to BinaryInterface one.
+
+  - __[Filter]__ `FilterManager::get` was removed.
+
+  - __[Configuration]__ `liip_imagine.filter_sets.path` option was removed.
+
+  - __[Configuration]__ `liip_imagine.filter_sets.format` option was removed.
+
+  - __[Configuration]__ `liip_imagine.cache_mkdir_mode` option was removed.
+
+  - __[Configuration]__ `liip_imagine.web_root` option was removed.
+
+  - __[Configuration]__ `liip_imagine.cache` default value was changed from `web_path`to `default`.
+
+  - __[Configuration]__ `liip_imagine.formats` option was removed.
+
+  - __[Configuration]__ `liip_imagine.data_root` option was removed.

--- a/Utils/Composer/ConsoleIO.php
+++ b/Utils/Composer/ConsoleIO.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Utils\Composer;
+
+use Composer\IO\IOInterface;
+use Composer\Package\RootPackageInterface;
+
+final class ConsoleIO
+{
+    /**
+     * @var string
+     */
+    private static $format = '<fg=yellow>[%s]</> %s';
+
+    /**
+     * @var IOInterface
+     */
+    private $io;
+
+    /**
+     * @var RootPackageInterface
+     */
+    private $package;
+
+    /**
+     * @param IOInterface          $io
+     * @param RootPackageInterface $package
+     */
+    public function __construct(IOInterface $io, RootPackageInterface $package)
+    {
+        $this->io = $io;
+        $this->package = $package;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isInteractive()
+    {
+        return $this->io->isInteractive();
+    }
+
+    /**
+     * @param string $line
+     * @param array  $replacements
+     */
+    public function write($line, array $replacements = array())
+    {
+        $line = sprintf(static::$format, $this->package->getName(), $line);
+
+        if (count($replacements) > 0) {
+            $line = vsprintf($line, $replacements);
+        }
+
+        $this->io->write($line);
+    }
+
+    /**
+     * @param string $what
+     *
+     * @return bool
+     */
+    public function ask($what)
+    {
+        return $this->io->askConfirmation(sprintf(static::$format, $this->package->getName(), $what), true);
+    }
+}

--- a/Utils/Composer/UpgradeNotice.php
+++ b/Utils/Composer/UpgradeNotice.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Utils\Composer;
+
+use Composer\Script\Event;
+
+final class UpgradeNotice
+{
+    /**
+     * @param Event $event
+     */
+    final static public function doWrite(Event $event)
+    {
+        $package = $event->getComposer()->getPackage();
+        $version = substr($package->getVersion(), 0, 5);
+        $console = new ConsoleIO($event->getIO(), $package);
+
+        if (false === version_compare(PHP_VERSION, '5.4', '>=')
+         || false === $notice = static::getUpgradeNotice($version)) {
+            return;
+        }
+
+        $console->write('<error> Update Notice: %s </error>', array($version));
+
+        foreach ($notice as $line) {
+            $console->write($line);
+        }
+
+        if ($console->isInteractive()) {
+            $console->ask('Press [ENTER] to acknowledge the above upgrade notice...');
+        }
+    }
+
+    /**
+     * Read in updates file and parse for the passed package version.
+     *
+     * @param string $version
+     *
+     * @return string[]|false
+     */
+    final static private function getUpgradeNotice($version)
+    {
+        $lines = array_map(function ($line) {
+            return preg_replace('{^[\s]{2}}', '', rtrim($line));
+        }, static::readUpgradeFile());
+
+        $lines = array_filter($lines, function ($line) use ($version) {
+            return static::filterLine($line, $version);
+        });
+
+        array_shift($lines);
+
+        return 0 === count($lines) ? false : $lines;
+    }
+
+    /**
+     * Keep lines if header matches package version, up until the next header is reached.
+     *
+     * @param string $line
+     * @param string $version
+     *
+     * @return bool
+     */
+    final static private function filterLine($line, $version)
+    {
+        static $keepLine = false;
+
+        if (0 === strpos($line, '##')) {
+            preg_match_all('{(?<version>[0-9]+\.[0-9]+(?:\.[0-9]+)?)}', $line, $matches);
+
+            $keepLine = count(array_filter($matches['version'], function ($v) use ($version) {
+                return false !== strpos($version, $v);
+            })) > 0;
+        }
+
+        return $keepLine;
+    }
+
+    /**
+     * Attempt to read the file to an array of lines.
+     *
+     * @return string[]
+     */
+    final static private function readUpgradeFile()
+    {
+        if (false !== $lines = @file(__DIR__ . '/../../UPGRADE.md')) {
+            return $lines;
+        }
+
+        return array();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "ext-gd": "*",
         "amazonwebservices/aws-sdk-for-php": "~1.0",
         "aws/aws-sdk-php": "~2.4",
+        "composer/composer": "~1.3",
         "doctrine/cache": "~1.1",
         "doctrine/orm": "~2.3",
         "friendsofphp/php-cs-fixer": "~2.0",
@@ -45,6 +46,10 @@
         "symfony/phpunit-bridge": "~2.3|~3.0",
         "symfony/yaml": "~2.3|~3.0",
         "twig/twig": "~1.12"
+    },
+    "scripts": {
+        "post-install-cmd": "Liip\\ImagineBundle\\Utils\\Composer\\UpgradeNotice::doWrite",
+        "post-update-cmd": "Liip\\ImagineBundle\\Utils\\Composer\\UpgradeNotice::doWrite"
     },
     "suggest": {
         "amazonwebservices/aws-sdk-for-php": "Required to use AWS version 1 cache resolver.",


### PR DESCRIPTION
This is a composer update/install hook that reads in the [UPGRADE.md](https://github.com/robfrawley/LiipImagineBundle/blob/feature-composer-upgrade-notice/UPGRADE.md) file, searches for a header matching the version Composer is installing, and, if such a version exists in the file, prints out the corresponding text for the user to acknowledge. See https://github.com/liip/LiipImagineBundle/issues/846#issuecomment-272584682 for the comments where the discussion for this component began.

Here is an example of the output

![liip-imagine-composer-update-notice](https://cloud.githubusercontent.com/assets/3967713/21960847/a5e3381a-dac5-11e6-9953-872664fd4982.png)

Lastly, it is important to note that I cut off support for PHP 5.3; users using this release will simply not see any notices (it doesn't error out or anything, it is just turned off for them). This helps facilitate a sane, well-laid-out code base (PHP 5.3 doesn't properly implement closure scope).