### PR TITLE
Bug Fixes/Deprecation Cleanup for Symfony 3.3

### DIFF
--- a/DependencyInjection/Factory/Loader/AbstractLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/AbstractLoaderFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
+
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+
+abstract class AbstractLoaderFactory implements LoaderFactoryInterface
+{
+    /**
+     * @var string
+     */
+    protected static $namePrefix = 'liip_imagine.binary.loader';
+
+    /**
+     * @return ChildDefinition|DefinitionDecorator
+     */
+    final protected function getChildLoaderDefinition()
+    {
+        $parent = sprintf('%s.prototype.%s', static::$namePrefix, $this->getName());
+
+        return class_exists('\Symfony\Component\DependencyInjection\ChildDefinition') ?
+            new ChildDefinition($parent) : new DefinitionDecorator($parent);
+    }
+
+    /**
+     * @param string           $name
+     * @param Definition       $definition
+     * @param ContainerBuilder $container
+     *
+     * @return string
+     */
+    final protected function setTaggedLoaderDefinition($name, Definition $definition, ContainerBuilder $container)
+    {
+        $definition->addTag(static::$namePrefix, array(
+            'loader' => $name,
+        ));
+
+        $container->setDefinition(
+            $id = sprintf('%s.%s', static::$namePrefix, $name),
+            $definition
+        );
+
+        return $id;
+    }
+}

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -13,25 +13,18 @@ namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
-class FileSystemLoaderFactory implements LoaderFactoryInterface
+class FileSystemLoaderFactory extends AbstractLoaderFactory
 {
     /**
      * {@inheritdoc}
      */
     public function create(ContainerBuilder $container, $loaderName, array $config)
     {
-        $loaderDefinition = new DefinitionDecorator('liip_imagine.binary.loader.prototype.filesystem');
-        $loaderDefinition->replaceArgument(2, $config['data_root']);
-        $loaderDefinition->addTag('liip_imagine.binary.loader', array(
-            'loader' => $loaderName,
-        ));
-        $loaderId = 'liip_imagine.binary.loader.'.$loaderName;
+        $definition = $this->getChildLoaderDefinition();
+        $definition->replaceArgument(2, $config['data_root']);
 
-        $container->setDefinition($loaderId, $loaderDefinition);
-
-        return $loaderId;
+        return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
     }
 
     /**

--- a/DependencyInjection/Factory/Loader/FlysystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FlysystemLoaderFactory.php
@@ -13,26 +13,19 @@ namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
-class FlysystemLoaderFactory implements LoaderFactoryInterface
+class FlysystemLoaderFactory extends AbstractLoaderFactory
 {
     /**
      * {@inheritdoc}
      */
     public function create(ContainerBuilder $container, $loaderName, array $config)
     {
-        $loaderDefinition = new DefinitionDecorator('liip_imagine.binary.loader.prototype.flysystem');
-        $loaderDefinition->replaceArgument(1, new Reference($config['filesystem_service']));
-        $loaderDefinition->addTag('liip_imagine.binary.loader', array(
-            'loader' => $loaderName,
-        ));
-        $loaderId = 'liip_imagine.binary.loader.'.$loaderName;
+        $definition = $this->getChildLoaderDefinition();
+        $definition->replaceArgument(1, new Reference($config['filesystem_service']));
 
-        $container->setDefinition($loaderId, $loaderDefinition);
-
-        return $loaderId;
+        return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
     }
 
     /**

--- a/DependencyInjection/Factory/Loader/StreamLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/StreamLoaderFactory.php
@@ -13,26 +13,19 @@ namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
-class StreamLoaderFactory implements LoaderFactoryInterface
+class StreamLoaderFactory extends AbstractLoaderFactory
 {
     /**
      * {@inheritdoc}
      */
     public function create(ContainerBuilder $container, $loaderName, array $config)
     {
-        $loaderDefinition = new DefinitionDecorator('liip_imagine.binary.loader.prototype.stream');
-        $loaderDefinition->replaceArgument(0, $config['wrapper']);
-        $loaderDefinition->replaceArgument(1, $config['context']);
-        $loaderDefinition->addTag('liip_imagine.binary.loader', array(
-            'loader' => $loaderName,
-        ));
-        $loaderId = 'liip_imagine.binary.loader.'.$loaderName;
+        $definition = $this->getChildLoaderDefinition();
+        $definition->replaceArgument(0, $config['wrapper']);
+        $definition->replaceArgument(1, $config['context']);
 
-        $container->setDefinition($loaderId, $loaderDefinition);
-
-        return $loaderId;
+        return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
     }
 
     /**

--- a/Tests/DependencyInjection/Factory/FactoryTestCase.php
+++ b/Tests/DependencyInjection/Factory/FactoryTestCase.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory;
+
+use Symfony\Component\DependencyInjection\Definition;
+
+abstract class FactoryTestCase extends \Phpunit_Framework_TestCase
+{
+    /**
+     * @param Definition $definition
+     */
+    protected function assertInstanceOfChildDefinition(Definition $definition)
+    {
+        $expected = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition') ?
+            '\Symfony\Component\DependencyInjection\ChildDefinition' :
+            '\Symfony\Component\DependencyInjection\DefinitionDecorator';
+
+        $this->assertInstanceOf($expected, $definition);
+    }
+}

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory\Loader;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory;
+use Liip\ImagineBundle\Tests\DependencyInjection\Factory\FactoryTestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -19,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory<extended>
  */
-class FileSystemLoaderFactoryTest extends \Phpunit_Framework_TestCase
+class FileSystemLoaderFactoryTest extends FactoryTestCase
 {
     public function testImplementsLoaderFactoryInterface()
     {
@@ -46,14 +47,15 @@ class FileSystemLoaderFactoryTest extends \Phpunit_Framework_TestCase
 
         $loader = new FileSystemLoaderFactory();
 
-        $loader->create($container, 'theLoaderName', array(
+        $loader->create($container, 'the_loader_name', array(
             'data_root' => 'theDataRoot',
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.binary.loader.theloadername'));
+        $this->assertTrue($container->hasDefinition('liip_imagine.binary.loader.the_loader_name'));
 
-        $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.theloadername');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $loaderDefinition);
+        $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.the_loader_name');
+
+        $this->assertInstanceOfChildDefinition($loaderDefinition);
         $this->assertEquals('liip_imagine.binary.loader.prototype.filesystem', $loaderDefinition->getParent());
 
         $this->assertEquals('theDataRoot', $loaderDefinition->getArgument(2));

--- a/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
@@ -58,13 +58,13 @@ class FlysystemLoaderFactoryTest extends \Phpunit_Framework_TestCase
 
         $loader = new FlysystemLoaderFactory();
 
-        $loader->create($container, 'theLoaderName', array(
+        $loader->create($container, 'the_loader_name', array(
             'filesystem_service' => 'flyfilesystemservice',
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.binary.loader.theloadername'));
+        $this->assertTrue($container->hasDefinition('liip_imagine.binary.loader.the_loader_name'));
 
-        $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.theloadername');
+        $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.the_loader_name');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $loaderDefinition);
         $this->assertEquals('liip_imagine.binary.loader.prototype.flysystem', $loaderDefinition->getParent());
 

--- a/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
@@ -46,14 +46,14 @@ class StreamLoaderFactoryTest extends \Phpunit_Framework_TestCase
 
         $loader = new StreamLoaderFactory();
 
-        $loader->create($container, 'theLoaderName', array(
+        $loader->create($container, 'the_loader_name', array(
             'wrapper' => 'theWrapper',
             'context' => 'theContext',
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.binary.loader.theloadername'));
+        $this->assertTrue($container->hasDefinition('liip_imagine.binary.loader.the_loader_name'));
 
-        $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.theloadername');
+        $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.the_loader_name');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $loaderDefinition);
         $this->assertEquals('liip_imagine.binary.loader.prototype.stream', $loaderDefinition->getParent());
 

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -47,7 +47,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'client_config' => array(),
             'bucket' => 'theBucket',
             'acl' => 'theAcl',
@@ -58,14 +58,14 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
             'proxies' => array(),
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername'));
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
 
-        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername');
+        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $resolverDefinition->getParent());
 
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(0));
-        $this->assertEquals('liip_imagine.cache.resolver.theresolvername.client', $resolverDefinition->getArgument(0));
+        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.client', $resolverDefinition->getArgument(0));
 
         $this->assertEquals('theBucket', $resolverDefinition->getArgument(1));
         $this->assertEquals('theAcl', $resolverDefinition->getArgument(2));
@@ -79,7 +79,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'client_config' => array(),
             'bucket' => 'theBucket',
             'acl' => 'theAcl',
@@ -90,9 +90,9 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
             'proxies' => array(),
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername'));
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
 
-        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername');
+        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertEquals(array('fooKey' => 'fooVal_overridden', 'barKey' => 'barVal'), $resolverDefinition->getArgument(3));
     }
 
@@ -102,7 +102,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'client_config' => array('theClientConfigKey' => 'theClientConfigVal'),
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
@@ -113,9 +113,9 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
             'proxies' => array(),
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername.client'));
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.client'));
 
-        $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername.client');
+        $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.client');
         $this->assertEquals('Aws\S3\S3Client', $clientDefinition->getClass());
         $this->assertEquals(array('theClientConfigKey' => 'theClientConfigVal'), $clientDefinition->getArgument(0));
     }
@@ -130,7 +130,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'client_config' => array('theClientConfigKey' => 'theClientConfigVal'),
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
@@ -141,7 +141,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
             'proxies' => array(),
         ));
 
-        $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername.client');
+        $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.client');
         $this->assertEquals(array('Aws\S3\S3Client', 'factory'), $clientDefinition->getFactory());
     }
 
@@ -155,7 +155,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'client_config' => array('theClientConfigKey' => 'theClientConfigVal'),
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
@@ -166,7 +166,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
             'proxies' => array(),
         ));
 
-        $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername.client');
+        $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.client');
         $this->assertEquals('Aws\S3\S3Client', $clientDefinition->getFactoryClass());
         $this->assertEquals('factory', $clientDefinition->getFactoryMethod());
     }
@@ -177,7 +177,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'client_config' => array(),
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
@@ -188,20 +188,20 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
             'proxies' => array('foo'),
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername.proxied'));
-        $proxiedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername.proxied');
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
+        $proxiedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $proxiedResolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $proxiedResolverDefinition->getParent());
 
-        $this->assertFalse($container->hasDefinition('liip_imagine.cache.resolver.theresolvername.cached'));
+        $this->assertFalse($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername'));
-        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername');
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
+        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.proxy', $resolverDefinition->getParent());
 
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(0));
-        $this->assertEquals('liip_imagine.cache.resolver.theresolvername.proxied', $resolverDefinition->getArgument(0));
+        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.proxied', $resolverDefinition->getArgument(0));
 
         $this->assertEquals(array('foo'), $resolverDefinition->getArgument(1));
     }
@@ -212,34 +212,34 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'client_config' => array(),
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
             'url_options' => array(),
             'get_options' => array(),
             'put_options' => array(),
-            'cache' => 'theCacheServiceId',
+            'cache' => 'the_cache_service_id',
             'proxies' => array(),
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername.cached'));
-        $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername.cached');
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
+        $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.cached');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $cachedResolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $cachedResolverDefinition->getParent());
 
-        $this->assertFalse($container->hasDefinition('liip_imagine.cache.resolver.theresolvername.proxied'));
+        $this->assertFalse($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername'));
-        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername');
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
+        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.cache', $resolverDefinition->getParent());
 
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(0));
-        $this->assertEquals('thecacheserviceid', $resolverDefinition->getArgument(0));
+        $this->assertEquals('the_cache_service_id', $resolverDefinition->getArgument(0));
 
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(1));
-        $this->assertEquals('liip_imagine.cache.resolver.theresolvername.cached', $resolverDefinition->getArgument(1));
+        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.cached', $resolverDefinition->getArgument(1));
     }
 
     public function testWrapResolverWithProxyAndCacheOnCreate()
@@ -248,42 +248,42 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'client_config' => array(),
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
             'url_options' => array(),
             'get_options' => array(),
             'put_options' => array(),
-            'cache' => 'theCacheServiceId',
+            'cache' => 'the_cache_service_id',
             'proxies' => array('foo'),
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername.proxied'));
-        $proxiedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername.proxied');
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
+        $proxiedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $proxiedResolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $proxiedResolverDefinition->getParent());
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername.cached'));
-        $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername.cached');
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
+        $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.cached');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $cachedResolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.proxy', $cachedResolverDefinition->getParent());
 
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $cachedResolverDefinition->getArgument(0));
-        $this->assertEquals('liip_imagine.cache.resolver.theresolvername.proxied', $cachedResolverDefinition->getArgument(0));
+        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.proxied', $cachedResolverDefinition->getArgument(0));
 
         $this->assertEquals(array('foo'), $cachedResolverDefinition->getArgument(1));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername'));
-        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername');
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
+        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.cache', $resolverDefinition->getParent());
 
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(0));
-        $this->assertEquals('thecacheserviceid', $resolverDefinition->getArgument(0));
+        $this->assertEquals('the_cache_service_id', $resolverDefinition->getArgument(0));
 
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(1));
-        $this->assertEquals('liip_imagine.cache.resolver.theresolvername.cached', $resolverDefinition->getArgument(1));
+        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.cached', $resolverDefinition->getArgument(1));
     }
 
     public function testWrapResolverWithProxyMatchReplaceStrategyOnCreate()
@@ -292,29 +292,29 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'client_config' => array(),
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
             'url_options' => array(),
             'get_options' => array(),
             'put_options' => array(),
-            'cache' => 'theCacheServiceId',
+            'cache' => 'the_cache_service_id',
             'proxies' => array('foo' => 'bar'),
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername.proxied'));
-        $proxiedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername.proxied');
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
+        $proxiedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $proxiedResolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $proxiedResolverDefinition->getParent());
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername.cached'));
-        $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername.cached');
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
+        $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.cached');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $cachedResolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.proxy', $cachedResolverDefinition->getParent());
 
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $cachedResolverDefinition->getArgument(0));
-        $this->assertEquals('liip_imagine.cache.resolver.theresolvername.proxied', $cachedResolverDefinition->getArgument(0));
+        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.proxied', $cachedResolverDefinition->getArgument(0));
 
         $this->assertEquals(array('foo' => 'bar'), $cachedResolverDefinition->getArgument(1));
     }
@@ -325,7 +325,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'client_config' => array(),
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
@@ -337,8 +337,8 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
             'proxies' => array(),
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername'));
-        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername');
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
+        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
 
         $methodCalls = $resolverDefinition->getMethodCalls();
 

--- a/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
@@ -57,16 +57,16 @@ class FlysystemResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new FlysystemResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'filesystem_service' => 'flyfilesystemservice',
             'root_url' => 'http://images.example.com',
             'cache_prefix' => 'theCachePrefix',
             'visibility' => 'public',
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername'));
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
 
-        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername');
+        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.flysystem', $resolverDefinition->getParent());
 

--- a/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
@@ -46,14 +46,14 @@ class WebPathResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $resolver = new WebPathResolverFactory();
 
-        $resolver->create($container, 'theResolverName', array(
+        $resolver->create($container, 'the_resolver_name', array(
             'web_root' => 'theWebRoot',
             'cache_prefix' => 'theCachePrefix',
         ));
 
-        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.theresolvername'));
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
 
-        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.theresolvername');
+        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.web_path', $resolverDefinition->getParent());
 

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -12,6 +12,7 @@ framework:
     secret:          "%secret%"
     router:          { resource: "%kernel.root_dir%/config/routing.yml" }
     default_locale:  "%locale%"
+    translator:      ~
 
 liip_imagine:
     loaders:


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #858 
| License | MIT
| Doc PR | 

Changes to support Symfony `3.3`, as well as remove deprecations generated from `3.3`.

- Fix broken behavior of Symfony BC layer for `DefinitionDecorator` (now `ChildDefinition`)
  https://github.com/liip/LiipImagineBundle/pull/860/files#diff-f6a2b0a892ed32df68cab49a06e21455R29
- Fix deprecated use of `camelCaseNamed` services in our test suite (deprecated in `3.3`)
  https://github.com/liip/LiipImagineBundle/pull/860/files#diff-aa0a2d419bdf6d37e236ae7d365106c6R50 
  [...and more...]
- Include `translator: ~` in functional test config file, as Symfony `3.3` requires this to enable the `translator` service, without which our functional tests brake
  https://github.com/liip/LiipImagineBundle/pull/860/files#diff-f9e984040c72fa157de966cc3cda08c9R15
- Some general cleanup
  https://github.com/liip/LiipImagineBundle/pull/860/files#diff-c863fd2e9ed73e8612993baa710cea85R24
  [...and more...]