### PR TITLE
Add github issue and pr templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.github/issue_template.md export-ignore
+.github/pull_request_template.md export-ignore

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,15 @@
+| Q | A
+| --- | ---
+| Bug Report? | yes/no
+| Feature Request? | yes/no
+| BC Break Report? | yes/no
+| RFC? | yes/no
+| Imagine Bundle Version | x.y.z
+
+<!--
+- Please take a moment to complete the template above by answering
+- yes or no to the given questions and providing the bundle version.
+-
+- Afterward, replace this comment with the description of your issue,
+- including the steps required to reproduce your issue.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+| Q | A
+| --- | ---
+| Branch? | 1.0 or 2.0 <!--choose version number-->
+| Bug fix? | yes/no
+| New feature? | yes/no
+| BC breaks? | yes/no
+| Deprecations? | yes/no
+| Tests pass? | yes/no
+| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
+| License | MIT
+| Doc PR | <!--highly recommended for new features-->
+
+<!--
+- Please take a moment to complete the template above by answering
+- yes or no to the given questions and providing the bundle version.
+-
+- Afterward, replace this comment with the description of your PR.
+-->


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | n/a
| Fixed tickets | #859 
| License | MIT
| Doc PR | 

Thanks to @cedricziel, we now know Github issue and PR templates can be added via file, instead of relying on the Github settings pages. Do @antoligy or @cedricziel have any alterations to these templates they'd suggest?