### PR TITLE
[DependencyInjection] Container logging for compiler passes

### DIFF
--- a/DependencyInjection/Compiler/AbstractCompilerPass.php
+++ b/DependencyInjection/Compiler/AbstractCompilerPass.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+abstract class AbstractCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function log(ContainerBuilder $container, $message, array $replacements = array())
+    {
+        if (count($replacements) > 0) {
+            $message = vsprintf($message, $replacements);
+        }
+
+        if (method_exists($container, 'log')) {
+            $container->log($this, $message);
+        } else {
+            $compiler = $container->getCompiler();
+            $formatter = $compiler->getLoggingFormatter();
+            $compiler->addLogMessage($formatter->format($this, $message));
+        }
+    }
+}

--- a/DependencyInjection/Compiler/FiltersCompilerPass.php
+++ b/DependencyInjection/Compiler/FiltersCompilerPass.php
@@ -11,11 +11,10 @@
 
 namespace Liip\ImagineBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class FiltersCompilerPass implements CompilerPassInterface
+class FiltersCompilerPass extends AbstractCompilerPass
 {
     /**
      * {@inheritdoc}
@@ -29,6 +28,7 @@ class FiltersCompilerPass implements CompilerPassInterface
 
             foreach ($tags as $id => $tag) {
                 $manager->addMethodCall('addLoader', array($tag[0]['loader'], new Reference($id)));
+                $this->log($container, 'Registered imagine-bimdle filter loader: %s', array($id));
             }
         }
     }

--- a/DependencyInjection/Compiler/LoadersCompilerPass.php
+++ b/DependencyInjection/Compiler/LoadersCompilerPass.php
@@ -11,11 +11,10 @@
 
 namespace Liip\ImagineBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class LoadersCompilerPass implements CompilerPassInterface
+class LoadersCompilerPass extends AbstractCompilerPass
 {
     /**
      * {@inheritdoc}
@@ -29,6 +28,7 @@ class LoadersCompilerPass implements CompilerPassInterface
 
             foreach ($tags as $id => $tag) {
                 $manager->addMethodCall('addLoader', array($tag[0]['loader'], new Reference($id)));
+                $this->log($container, 'Registered imagine-bimdle binary loader: %s', array($id));
             }
         }
     }

--- a/DependencyInjection/Compiler/PostProcessorsCompilerPass.php
+++ b/DependencyInjection/Compiler/PostProcessorsCompilerPass.php
@@ -11,7 +11,6 @@
 
 namespace Liip\ImagineBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -20,7 +19,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Konstantin Tjuterev <kostik.lv@gmail.com>
  */
-class PostProcessorsCompilerPass implements CompilerPassInterface
+class PostProcessorsCompilerPass extends AbstractCompilerPass
 {
     /**
      * {@inheritdoc}
@@ -34,6 +33,7 @@ class PostProcessorsCompilerPass implements CompilerPassInterface
 
             foreach ($tags as $id => $tag) {
                 $manager->addMethodCall('addPostProcessor', array($tag[0]['post_processor'], new Reference($id)));
+                $this->log($container, 'Registered imagine-bimdle filter post-processor: %s', array($id));
             }
         }
     }

--- a/DependencyInjection/Compiler/ResolversCompilerPass.php
+++ b/DependencyInjection/Compiler/ResolversCompilerPass.php
@@ -11,11 +11,10 @@
 
 namespace Liip\ImagineBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ResolversCompilerPass implements CompilerPassInterface
+class ResolversCompilerPass extends AbstractCompilerPass
 {
     /**
      * {@inheritdoc}
@@ -29,6 +28,7 @@ class ResolversCompilerPass implements CompilerPassInterface
 
             foreach ($tags as $id => $tag) {
                 $manager->addMethodCall('addResolver', array($tag[0]['resolver'], new Reference($id)));
+                $this->log($container, 'Registered imagine-bimdle cache resolver: %s', array($id));
             }
         }
     }

--- a/Tests/DependencyInjection/Compiler/LoadersCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoadersCompilerPassTest.php
@@ -16,7 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * @covers Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass
+ * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
+ * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass
  */
 class LoadersCompilerPassTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/DependencyInjection/Compiler/MetadataReaderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MetadataReaderCompilerPassTest.php
@@ -15,71 +15,83 @@ use Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @covers Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass
+ * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
+ * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass
  */
 class MetadataReaderCompilerPassTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @param \ReflectionClass $r
+     * @param string           $p
+     *
+     * @return string
+     */
+    private static function getPrivateStaticProperty(\ReflectionClass $r, $p)
+    {
+        $property = $r->getProperty($p);
+        $property->setAccessible(true);
+
+        return $property->getValue();
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private static function getReaderParamAndDefaultAndExifValues()
+    {
+        $r = new \ReflectionClass('Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass');
+
+        return array(
+            static::getPrivateStaticProperty($r, 'metadataReaderParameter'),
+            static::getPrivateStaticProperty($r, 'metadataReaderExifClass'),
+            static::getPrivateStaticProperty($r, 'metadataReaderDefaultClass'),
+        );
+    }
+
+    /**
+     * @param bool $return
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|MetadataReaderCompilerPass
+     */
+    private function getMetadataReaderCompilerPass($return)
+    {
+        $mock = $this->getMockBuilder('Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass')
+            ->setMethods(array('isExifExtensionLoaded'))
+            ->getMock();
+
+        $mock
+            ->expects($this->atLeastOnce())
+            ->method('isExifExtensionLoaded')
+            ->willReturn($return);
+
+        return $mock;
+    }
+
     public function testProcessWithoutExtExifAddsDefaultReader()
     {
+        list($metadataParameter, $metadataExifClass, $metadataDefaultClass) = static::getReaderParamAndDefaultAndExifValues();
+
         $container = new ContainerBuilder();
-        $container->setParameter(
-            MetadataReaderCompilerPass::METADATA_READER_PARAM,
-            MetadataReaderCompilerPass::EXIF_METADATA_READER_CLASS
-        );
+        $container->setParameter($metadataParameter, $metadataExifClass);
 
-        /** @var MetadataReaderCompilerPass $pass */
-        $pass = $this->getMock(
-            'Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass',
-            array('extExifIsAvailable'),
-            array()
-        );
-        $pass->expects($this->once())
-            ->method('extExifIsAvailable')
-            ->willReturn(false);
-
-        //guard
-        $this->assertEquals(
-            MetadataReaderCompilerPass::EXIF_METADATA_READER_CLASS,
-            $container->getParameter(MetadataReaderCompilerPass::METADATA_READER_PARAM)
-        );
+        $pass = $this->getMetadataReaderCompilerPass(false);
+        $this->assertEquals($metadataExifClass, $container->getParameter($metadataParameter));
 
         $pass->process($container);
-
-        $this->assertEquals(
-            MetadataReaderCompilerPass::DEFAULT_METADATA_READER_CLASS,
-            $container->getParameter(MetadataReaderCompilerPass::METADATA_READER_PARAM)
-        );
+        $this->assertEquals($metadataDefaultClass, $container->getParameter($metadataParameter));
     }
 
     public function testProcessWithExtExifKeepsExifReader()
     {
+        list($metadataParameter, $metadataExifClass) = static::getReaderParamAndDefaultAndExifValues();
+
         $container = new ContainerBuilder();
-        $container->setParameter(
-            MetadataReaderCompilerPass::METADATA_READER_PARAM,
-            MetadataReaderCompilerPass::EXIF_METADATA_READER_CLASS
-        );
+        $container->setParameter($metadataParameter, $metadataExifClass);
 
-        /** @var MetadataReaderCompilerPass $pass */
-        $pass = $this->getMock(
-            'Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass',
-            array('extExifIsAvailable'),
-            array()
-        );
-        $pass->expects($this->once())
-            ->method('extExifIsAvailable')
-            ->willReturn(true);
-
-        //guard
-        $this->assertEquals(
-            MetadataReaderCompilerPass::EXIF_METADATA_READER_CLASS,
-            $container->getParameter(MetadataReaderCompilerPass::METADATA_READER_PARAM)
-        );
+        $pass = static::getMetadataReaderCompilerPass(true);
+        $this->assertEquals($metadataExifClass, $container->getParameter($metadataParameter));
 
         $pass->process($container);
-
-        $this->assertEquals(
-            MetadataReaderCompilerPass::EXIF_METADATA_READER_CLASS,
-            $container->getParameter(MetadataReaderCompilerPass::METADATA_READER_PARAM)
-        );
+        $this->assertEquals($metadataExifClass, $container->getParameter($metadataParameter));
     }
 }

--- a/Tests/DependencyInjection/Compiler/PostProcessorsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/PostProcessorsCompilerPassTest.php
@@ -11,35 +11,32 @@
 
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
-use Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass;
+use Liip\ImagineBundle\DependencyInjection\Compiler\PostProcessorsCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
- * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass
+ * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\PostProcessorsCompilerPass
  */
-class FiltersCompilerPassTest extends \PHPUnit_Framework_TestCase
+class PostProcessorsCompilerPassTest extends \PHPUnit_Framework_TestCase
 {
     public function testProcess()
     {
         $managerDefinition = new Definition();
-        $loaderDefinition = new Definition();
-        $loaderDefinition->addTag('liip_imagine.filter.loader', array(
-            'loader' => 'foo',
+        $resolverDefinition = new Definition();
+        $resolverDefinition->addTag('liip_imagine.filter.post_processor', array(
+            'post_processor' => 'foo',
         ));
 
         $container = new ContainerBuilder();
         $container->setDefinition('liip_imagine.filter.manager', $managerDefinition);
-        $container->setDefinition('a.loader', $loaderDefinition);
+        $container->setDefinition('a.post_processor', $resolverDefinition);
 
-        $pass = new FiltersCompilerPass();
+        $pass = new PostProcessorsCompilerPass();
 
-        //guard
         $this->assertCount(0, $managerDefinition->getMethodCalls());
-
         $pass->process($container);
-
         $this->assertCount(1, $managerDefinition->getMethodCalls());
     }
 }

--- a/Tests/DependencyInjection/Compiler/ResolversCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResolversCompilerPassTest.php
@@ -16,7 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * @covers Liip\ImagineBundle\DependencyInjection\Compiler\ResolversCompilerPass
+ * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
+ * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\ResolversCompilerPass
  */
 class ResolversCompilerPassTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | n/a
| License | MIT
| Doc PR | n/a

Container build logging for all compiler passes, including support for Symfony 3.3's new `log` method (`ContainerBuilder::log()`). This would be much nicer as a trait, but due to our PHP 5.3 requirement, this is not an option; as such, an abstract class is used. :-(