### PR TITLE
[Loader] [Locator] FileSystemLocator service must not be shared

### DIFF
--- a/Binary/Locator/FileSystemLocator.php
+++ b/Binary/Locator/FileSystemLocator.php
@@ -21,7 +21,7 @@ class FileSystemLocator implements LocatorInterface
     /**
      * @var string[]
      */
-    protected $roots;
+    private $roots;
 
     /**
      * @param array[] $options

--- a/Binary/Locator/FileSystemLocator.php
+++ b/Binary/Locator/FileSystemLocator.php
@@ -13,6 +13,7 @@ namespace Liip\ImagineBundle\Binary\Locator;
 
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Exception\InvalidArgumentException;
+use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FileSystemLocator implements LocatorInterface
@@ -27,9 +28,14 @@ class FileSystemLocator implements LocatorInterface
      */
     public function setOptions(array $options = array())
     {
-        $optionsResolver = new OptionsResolver();
-        $optionsResolver->setDefaults(array('roots' => array()));
-        $options = $optionsResolver->resolve($options);
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(array('roots' => array()));
+
+        try {
+            $options = $resolver->resolve($options);
+        } catch (ExceptionInterface $e) {
+            throw new InvalidArgumentException(sprintf('Invalid options provided to %s()', __METHOD__), null, $e);
+        }
 
         $this->roots = array_map(array($this, 'sanitizeRootPath'), (array) $options['roots']);
     }
@@ -71,7 +77,7 @@ class FileSystemLocator implements LocatorInterface
      *
      * @return string
      */
-    protected function sanitizeRootPath($root)
+    private function sanitizeRootPath($root)
     {
         if (!empty($root) && false !== $realRoot = realpath($root)) {
             return $realRoot;

--- a/DependencyInjection/Compiler/AbstractCompilerPass.php
+++ b/DependencyInjection/Compiler/AbstractCompilerPass.php
@@ -11,13 +11,17 @@
 
 namespace Liip\ImagineBundle\DependencyInjection\Compiler;
 
+use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
 abstract class AbstractCompilerPass implements CompilerPassInterface
 {
     /**
-     * {@inheritdoc}
+     * @param ContainerBuilder $container
+     * @param string           $message
+     * @param mixed[]          $replacements
      */
     protected function log(ContainerBuilder $container, $message, array $replacements = array())
     {
@@ -25,12 +29,24 @@ abstract class AbstractCompilerPass implements CompilerPassInterface
             $message = vsprintf($message, $replacements);
         }
 
-        if (method_exists($container, 'log')) {
+        if (SymfonyFramework::hasDirectContainerBuilderLogging()) {
             $container->log($this, $message);
         } else {
             $compiler = $container->getCompiler();
-            $formatter = $compiler->getLoggingFormatter();
-            $compiler->addLogMessage($formatter->format($this, $message));
+            $compiler->addLogMessage($compiler->getLoggingFormatter()->format($this, $message));
+        }
+    }
+
+    /**
+     * @param Definition $definition
+     * @param bool       $enable
+     */
+    protected function setDefinitionSharing(Definition $definition, $enable)
+    {
+        if (SymfonyFramework::hasDefinitionSharing()) {
+            $definition->setShared($enable);
+        } else {
+            $definition->setScope($enable ? 'container' : 'prototype');
         }
     }
 }

--- a/DependencyInjection/Compiler/LocatorsCompilerPass.php
+++ b/DependencyInjection/Compiler/LocatorsCompilerPass.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\DependencyInjection\Compiler;
+
+use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class LocatorsCompilerPass extends AbstractCompilerPass
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach (array_keys($container->findTaggedServiceIds('liip_imagine.binary.locator')) as $id) {
+            $this->disableSharedDefinition($container->getDefinition($id));
+        }
+    }
+
+    /**
+     * @param Definition $definition
+     */
+    private function disableSharedDefinition(Definition $definition)
+    {
+        if (SymfonyFramework::hasDefinitionSharedToggle()) {
+            $definition->setShared(false);
+        } else {
+            $definition->setScope('prototype');
+        }
+    }
+}

--- a/DependencyInjection/Compiler/LocatorsCompilerPass.php
+++ b/DependencyInjection/Compiler/LocatorsCompilerPass.php
@@ -11,9 +11,7 @@
 
 namespace Liip\ImagineBundle\DependencyInjection\Compiler;
 
-use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 
 class LocatorsCompilerPass extends AbstractCompilerPass
 {
@@ -22,20 +20,10 @@ class LocatorsCompilerPass extends AbstractCompilerPass
      */
     public function process(ContainerBuilder $container)
     {
-        foreach (array_keys($container->findTaggedServiceIds('liip_imagine.binary.locator')) as $id) {
-            $this->disableSharedDefinition($container->getDefinition($id));
-        }
-    }
-
-    /**
-     * @param Definition $definition
-     */
-    private function disableSharedDefinition(Definition $definition)
-    {
-        if (SymfonyFramework::hasDefinitionSharedToggle()) {
-            $definition->setShared(false);
-        } else {
-            $definition->setScope('prototype');
+        foreach ($container->findTaggedServiceIds('liip_imagine.binary.locator') as $id => $tags) {
+            if (isset($tags[0]['shared'])) {
+                $this->setDefinitionSharing($container->getDefinition($id), $tags[0]['shared']);
+            }
         }
     }
 }

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -11,8 +11,10 @@
 
 namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
 
+use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 class FileSystemLoaderFactory extends AbstractLoaderFactory
@@ -24,7 +26,7 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
     {
         $definition = $this->getChildLoaderDefinition();
         $definition->replaceArgument(2, $config['data_root']);
-        $definition->replaceArgument(3, new Reference(sprintf('liip_imagine.binary.locator.%s', $config['locator'])));
+        $definition->replaceArgument(3, $this->createLocatorReference($config['locator']));
 
         return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
     }
@@ -60,5 +62,19 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
                     ->end()
                 ->end()
             ->end();
+    }
+
+    /**
+     * @param string $reference
+     *
+     * @return Reference
+     */
+    private function createLocatorReference($reference)
+    {
+        return new Reference(
+            sprintf('liip_imagine.binary.locator.%s', $reference),
+            ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
+            SymfonyFramework::hasDefinitionSharedToggle()
+        );
     }
 }

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -73,7 +73,7 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
     {
         $name = sprintf('liip_imagine.binary.locator.%s', $reference);
 
-        if (SymfonyFramework::hasDefinitionSharedToggle()) {
+        if (SymfonyFramework::hasDefinitionSharing()) {
             return new Reference($name);
         }
 

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -71,10 +71,12 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
      */
     private function createLocatorReference($reference)
     {
-        return new Reference(
-            sprintf('liip_imagine.binary.locator.%s', $reference),
-            ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
-            SymfonyFramework::hasDefinitionSharedToggle()
-        );
+        $name = sprintf('liip_imagine.binary.locator.%s', $reference);
+
+        if (SymfonyFramework::hasDefinitionSharedToggle()) {
+            return new Reference($name);
+        }
+
+        return new Reference($name, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false);
     }
 }

--- a/LiipImagineBundle.php
+++ b/LiipImagineBundle.php
@@ -13,6 +13,7 @@ namespace Liip\ImagineBundle;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass;
+use Liip\ImagineBundle\DependencyInjection\Compiler\LocatorsCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\PostProcessorsCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\ResolversCompilerPass;
@@ -35,6 +36,7 @@ class LiipImagineBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new LocatorsCompilerPass());
         $container->addCompilerPass(new LoadersCompilerPass());
         $container->addCompilerPass(new FiltersCompilerPass());
         $container->addCompilerPass(new PostProcessorsCompilerPass());

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -247,9 +247,11 @@
         <!-- Data loader locators -->
 
         <service id="liip_imagine.binary.locator.filesystem" class="%liip_imagine.binary.locator.filesystem.class%" public="false">
+            <tag name="liip_imagine.binary.locator" />
         </service>
 
         <service id="liip_imagine.binary.locator.filesystem_insecure" class="%liip_imagine.binary.locator.filesystem_insecure.class%" public="false">
+            <tag name="liip_imagine.binary.locator" />
         </service>
 
         <!-- Cache resolver -->

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -247,11 +247,11 @@
         <!-- Data loader locators -->
 
         <service id="liip_imagine.binary.locator.filesystem" class="%liip_imagine.binary.locator.filesystem.class%" public="false">
-            <tag name="liip_imagine.binary.locator" />
+            <tag name="liip_imagine.binary.locator" shared="false" />
         </service>
 
         <service id="liip_imagine.binary.locator.filesystem_insecure" class="%liip_imagine.binary.locator.filesystem_insecure.class%" public="false">
-            <tag name="liip_imagine.binary.locator" />
+            <tag name="liip_imagine.binary.locator" shared="false" />
         </service>
 
         <!-- Cache resolver -->

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -110,6 +110,22 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         return $this->getMockBuilder('Imagine\Image\ImagineInterface')->getMock();
     }
 
+    /**
+     * @param object $object
+     * @param string $name
+     *
+     * @return \ReflectionMethod
+     */
+    protected function getVisibilityRestrictedMethod($object, $name)
+    {
+        $r = new \ReflectionObject($object);
+
+        $m = $r->getMethod($name);
+        $m->setAccessible(true);
+
+        return $m;
+    }
+
     protected function tearDown()
     {
         if (!$this->filesystem) {

--- a/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
@@ -74,4 +74,15 @@ abstract class AbstractFileSystemLocatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertNotNull($this->getLocator($rootDirs)->locate($path));
     }
+
+    public function testThrowsExceptionOnInvalidOptions()
+    {
+        $this->setExpectedException(
+            'Liip\ImagineBundle\Exception\InvalidArgumentException',
+            'Invalid options provided to'
+        );
+
+        $locator = $this->getLocator(__DIR__);
+        $locator->setOptions(array('foo' => 'bar'));
+    }
 }

--- a/Tests/DependencyInjection/Compiler/AbstractCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AbstractCompilerPassTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
+
+use Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass;
+use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
+use Symfony\Component\DependencyInjection\Compiler\Compiler;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
+ */
+class AbstractCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    /**
+     * @param string[] $methods
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|AbstractCompilerPass
+     */
+    private function createAbstractCompilerPassMock(array $methods = array())
+    {
+        return $this
+            ->getMockBuilder('\Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass')
+            ->setMethods($methods)
+            ->getMock();
+    }
+
+    /**
+     * @param string[] $methods
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|ContainerBuilder
+     */
+    private function createContainerBuilderMock(array $methods = array())
+    {
+        return $this
+            ->getMockBuilder('\Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods($methods)
+            ->getMock();
+    }
+
+    /**
+     * @param string[] $methods
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|Compiler
+     */
+    private function createCompilerMock(array $methods = array())
+    {
+        return $this
+            ->getMockBuilder('\Symfony\Component\DependencyInjection\Compiler\Compiler')
+            ->setMethods($methods)
+            ->getMock();
+    }
+
+    /**
+     * @param string[] $methods
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|Compiler
+     */
+    private function createLoggingFormatterMock(array $methods = array())
+    {
+        return $this
+            ->getMockBuilder('\Symfony\Component\DependencyInjection\Compiler\LoggingFormatter')
+            ->setMethods($methods)
+            ->getMock();
+    }
+
+    /**
+     * @param string[] $methods
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|Definition
+     */
+    private function createDefinitionMock(array $methods = array())
+    {
+        return $this
+            ->getMockBuilder('\Symfony\Component\DependencyInjection\Definition')
+            ->setMethods($methods)
+            ->getMock();
+    }
+
+    public function testCompilerLogging()
+    {
+        $pass = $this->createAbstractCompilerPassMock();
+
+        $message = 'Compiler log: %d %s message';
+        $messageReplaces = array(1, 'foo-bar');
+        $messageCompiled = vsprintf($message, $messageReplaces);
+
+        if (SymfonyFramework::hasDirectContainerBuilderLogging()) {
+            $container = $this->createContainerBuilderMock();
+            $container
+                ->expects($this->atLeastOnce())
+                ->method('log')
+                ->with($pass, $messageCompiled);
+        } else {
+            $container = $this->createContainerBuilderMock(array('getCompiler'));
+            $formatter = $this->createLoggingFormatterMock(array('format'));
+            $formatter
+                ->expects($this->atLeastOnce())
+                ->method('format')
+                ->with($pass, $messageCompiled);
+
+            $compiler = $this->createCompilerMock(array('addLogMessage', 'getLoggingFormatter'));
+            $compiler
+                ->expects($this->atLeastOnce())
+                ->method('addLogMessage');
+            $compiler
+                ->expects($this->atLeastOnce())
+                ->method('getLoggingFormatter')
+                ->willReturn($formatter);
+
+            $container
+                ->expects($this->atLeastOnce())
+                ->method('getCompiler')
+                ->willReturn($compiler);
+        }
+
+        $log = $this->getVisibilityRestrictedMethod($pass, 'log');
+        $log->invoke($pass, $container, $message, $messageReplaces);
+    }
+
+    public function testSetDefinitionSharing()
+    {
+        $p = $this->createAbstractCompilerPassMock();
+        $m = $this->getVisibilityRestrictedMethod($p, 'setDefinitionSharing');
+
+        if (SymfonyFramework::hasDefinitionSharing()) {
+            $definition = $this->createDefinitionMock(array('setShared'));
+            $definition
+                ->expects($this->atLeastOnce())
+                ->method('setShared')
+                ->with(false);
+        } else {
+            $definition = $this->createDefinitionMock(array('setScope'));
+            $definition
+                ->expects($this->atLeastOnce())
+                ->method('setScope')
+                ->with('prototype');
+        }
+
+        $m->invoke($p, $definition, false);
+
+        if (SymfonyFramework::hasDefinitionSharing()) {
+            $definition = $this->createDefinitionMock(array('setShared'));
+            $definition
+                ->expects($this->atLeastOnce())
+                ->method('setShared')
+                ->with(true);
+        } else {
+            $definition = $this->createDefinitionMock(array('setScope'));
+            $definition
+                ->expects($this->atLeastOnce())
+                ->method('setScope')
+                ->with('container');
+        }
+
+        $m->invoke($p, $definition, true);
+    }
+}

--- a/Tests/DependencyInjection/Compiler/AbstractCompilerPassTestCase.php
+++ b/Tests/DependencyInjection/Compiler/AbstractCompilerPassTestCase.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
+
+use Liip\ImagineBundle\Tests\AbstractTest;
+use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class AbstractCompilerPassTestCase extends AbstractTest
+{
+    /**
+     * @param array $tags
+     *
+     * @return Definition
+     */
+    protected function createDefinition(array $tags = array())
+    {
+        $definition = new Definition();
+
+        foreach ($tags as $name => $attributes) {
+            $definition->addTag($name, $attributes);
+        }
+
+        return $definition;
+    }
+
+    /**
+     * @param array $definitions
+     *
+     * @return ContainerBuilder
+     */
+    protected function createContainerBuilder(array $definitions = array())
+    {
+        $container = new ContainerBuilder();
+
+        foreach ($definitions as $name => $object) {
+            $container->setDefinition($name, $object);
+        }
+
+        return $container;
+    }
+
+    /**
+     * @param Definition  $definition
+     * @param string|null $message
+     */
+    protected function assertDefinitionSharingEnabled(Definition $definition, $message = null)
+    {
+        if (SymfonyFramework::hasDefinitionSharing()) {
+            $this->assertTrue($definition->isShared(), $message);
+        } elseif (SymfonyFramework::hasDefinitionScoping()) {
+            $this->assertSame('container', $definition->getScope(), $message);
+        } else {
+            $this->fail(sprintf('Neither sharing or scoping is available for assertion: %s',
+                $message ?: var_export($definition)));
+        }
+    }
+
+    /**
+     * @param Definition  $definition
+     * @param string|null $message
+     */
+    protected function assertDefinitionSharingDisabled(Definition $definition, $message = null)
+    {
+        if (SymfonyFramework::hasDefinitionSharing()) {
+            $this->assertFalse($definition->isShared(), $message);
+        } elseif (SymfonyFramework::hasDefinitionScoping()) {
+            $this->assertSame('prototype', $definition->getScope(), $message);
+        } else {
+            $this->fail(sprintf('Neither sharing or scoping is available for assertion: %s',
+                $message ?: var_export($definition)));
+        }
+    }
+
+    /**
+     * @param Definition  $definition
+     * @param string|null $message
+     */
+    protected function assertDefinitionMethodCallsNone(Definition $definition, $message = null)
+    {
+        $this->assertDefinitionMethodCallCount(0, $definition, $message);
+    }
+
+    /**
+     * @param int         $expect
+     * @param Definition  $definition
+     * @param string|null $message
+     */
+    protected function assertDefinitionMethodCallCount($expect, Definition $definition, $message = null)
+    {
+        $this->assertCount($expect, $definition->getMethodCalls(), $message);
+    }
+}

--- a/Tests/DependencyInjection/Compiler/FiltersCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FiltersCompilerPassTest.php
@@ -12,34 +12,28 @@
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
  * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass
  */
-class FiltersCompilerPassTest extends \PHPUnit_Framework_TestCase
+class FiltersCompilerPassTest extends AbstractCompilerPassTestCase
 {
     public function testProcess()
     {
-        $managerDefinition = new Definition();
-        $loaderDefinition = new Definition();
-        $loaderDefinition->addTag('liip_imagine.filter.loader', array(
-            'loader' => 'foo',
-        ));
+        $m = $this->createDefinition();
+        $l = $this->createDefinition(array('liip_imagine.filter.loader' => array(
+            'loader' => 'foobar',
+        )));
 
-        $container = new ContainerBuilder();
-        $container->setDefinition('liip_imagine.filter.manager', $managerDefinition);
-        $container->setDefinition('a.loader', $loaderDefinition);
+        $container = $this->createContainerBuilder(array(
+            'filter.loader.foobar' => $l,
+            'liip_imagine.filter.manager' => $m,
+        ));
 
         $pass = new FiltersCompilerPass();
 
-        //guard
-        $this->assertCount(0, $managerDefinition->getMethodCalls());
-
+        $this->assertDefinitionMethodCallsNone($m);
         $pass->process($container);
-
-        $this->assertCount(1, $managerDefinition->getMethodCalls());
+        $this->assertDefinitionMethodCallCount(1, $m);
     }
 }

--- a/Tests/DependencyInjection/Compiler/LoadersCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoadersCompilerPassTest.php
@@ -12,34 +12,28 @@
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
  * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass
  */
-class LoadersCompilerPassTest extends \PHPUnit_Framework_TestCase
+class LoadersCompilerPassTest extends AbstractCompilerPassTestCase
 {
     public function testProcess()
     {
-        $managerDefinition = new Definition();
-        $loaderDefinition = new Definition();
-        $loaderDefinition->addTag('liip_imagine.binary.loader', array(
-            'loader' => 'foo',
-        ));
+        $m = $this->createDefinition();
+        $l = $this->createDefinition(array('liip_imagine.binary.loader' => array(
+            'loader' => 'foobar',
+        )));
 
-        $container = new ContainerBuilder();
-        $container->setDefinition('liip_imagine.data.manager', $managerDefinition);
-        $container->setDefinition('a.binary.loader', $loaderDefinition);
+        $container = $this->createContainerBuilder(array(
+            'binary.loader.foobar' => $l,
+            'liip_imagine.data.manager' => $m,
+        ));
 
         $pass = new LoadersCompilerPass();
 
-        //guard
-        $this->assertCount(0, $managerDefinition->getMethodCalls());
-
+        $this->assertDefinitionMethodCallsNone($m);
         $pass->process($container);
-
-        $this->assertCount(1, $managerDefinition->getMethodCalls());
+        $this->assertDefinitionMethodCallCount(1, $m);
     }
 }

--- a/Tests/DependencyInjection/Compiler/LocatorsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LocatorsCompilerPassTest.php
@@ -12,40 +12,26 @@
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\LocatorsCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
  * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\LocatorsCompilerPass
  */
-class LocatorsCompilerPassTest extends \PHPUnit_Framework_TestCase
+class LocatorsCompilerPassTest extends AbstractCompilerPassTestCase
 {
     public function testProcess()
     {
-        $locatorDefinition = new Definition();
-        $locatorDefinition->addTag('liip_imagine.binary.locator', array(
-            'shared' => true,
+        $l = $this->createDefinition(array('liip_imagine.binary.locator' => array(
+            'shared' => false,
+        )));
+
+        $container = $this->createContainerBuilder(array(
+            'liip_imagine.binary.locator.foo' => $l,
         ));
 
-        $container = new ContainerBuilder();
-        $container->setDefinition('liip_imagine.binary.locator.foo', $locatorDefinition);
-
         $pass = new LocatorsCompilerPass();
-
-        //guard
-        if (method_exists($locatorDefinition, 'isShared')) {
-            $this->assertTrue($locatorDefinition->isShared());
-        } else {
-            $this->assertSame('container', $locatorDefinition->getScope());
-        }
+        $this->assertDefinitionSharingEnabled($l);
 
         $pass->process($container);
-
-        if (method_exists($locatorDefinition, 'isShared')) {
-            $this->assertFalse($locatorDefinition->isShared());
-        } else {
-            $this->assertSame('prototype', $locatorDefinition->getScope());
-        }
+        $this->assertDefinitionSharingDisabled($l);
     }
 }

--- a/Tests/DependencyInjection/Compiler/LocatorsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LocatorsCompilerPassTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
+
+use Liip\ImagineBundle\DependencyInjection\Compiler\LocatorsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
+ * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\LocatorsCompilerPass
+ */
+class LocatorsCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcess()
+    {
+        $locatorDefinition = new Definition();
+        $locatorDefinition->addTag('liip_imagine.binary.locator', array(
+            'shared' => true,
+        ));
+
+        $container = new ContainerBuilder();
+        $container->setDefinition('liip_imagine.binary.locator.foo', $locatorDefinition);
+
+        $pass = new LocatorsCompilerPass();
+
+        //guard
+        if (method_exists($locatorDefinition, 'isShared')) {
+            $this->assertTrue($locatorDefinition->isShared());
+        } else {
+            $this->assertSame('container', $locatorDefinition->getScope());
+        }
+
+        $pass->process($container);
+
+        if (method_exists($locatorDefinition, 'isShared')) {
+            $this->assertFalse($locatorDefinition->isShared());
+        } else {
+            $this->assertSame('prototype', $locatorDefinition->getScope());
+        }
+    }
+}

--- a/Tests/DependencyInjection/Compiler/MetadataReaderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MetadataReaderCompilerPassTest.php
@@ -15,7 +15,6 @@ use Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
  * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass
  */
 class MetadataReaderCompilerPassTest extends \PHPUnit_Framework_TestCase
@@ -26,7 +25,7 @@ class MetadataReaderCompilerPassTest extends \PHPUnit_Framework_TestCase
      *
      * @return string
      */
-    private static function getPrivateStaticProperty(\ReflectionClass $r, $p)
+    private static function getVisibilityRestrictedStaticProperty(\ReflectionClass $r, $p)
     {
         $property = $r->getProperty($p);
         $property->setAccessible(true);
@@ -42,9 +41,9 @@ class MetadataReaderCompilerPassTest extends \PHPUnit_Framework_TestCase
         $r = new \ReflectionClass('Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass');
 
         return array(
-            static::getPrivateStaticProperty($r, 'metadataReaderParameter'),
-            static::getPrivateStaticProperty($r, 'metadataReaderExifClass'),
-            static::getPrivateStaticProperty($r, 'metadataReaderDefaultClass'),
+            static::getVisibilityRestrictedStaticProperty($r, 'metadataReaderParameter'),
+            static::getVisibilityRestrictedStaticProperty($r, 'metadataReaderExifClass'),
+            static::getVisibilityRestrictedStaticProperty($r, 'metadataReaderDefaultClass'),
         );
     }
 

--- a/Tests/DependencyInjection/Compiler/PostProcessorsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/PostProcessorsCompilerPassTest.php
@@ -12,31 +12,28 @@
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\PostProcessorsCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
  * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\PostProcessorsCompilerPass
  */
-class PostProcessorsCompilerPassTest extends \PHPUnit_Framework_TestCase
+class PostProcessorsCompilerPassTest extends AbstractCompilerPassTestCase
 {
     public function testProcess()
     {
-        $managerDefinition = new Definition();
-        $resolverDefinition = new Definition();
-        $resolverDefinition->addTag('liip_imagine.filter.post_processor', array(
-            'post_processor' => 'foo',
-        ));
+        $m = $this->createDefinition();
+        $l = $this->createDefinition(array('liip_imagine.filter.post_processor' => array(
+            'post_processor' => 'foobar',
+        )));
 
-        $container = new ContainerBuilder();
-        $container->setDefinition('liip_imagine.filter.manager', $managerDefinition);
-        $container->setDefinition('a.post_processor', $resolverDefinition);
+        $container = $this->createContainerBuilder(array(
+            'post_processor.foobar' => $l,
+            'liip_imagine.filter.manager' => $m,
+        ));
 
         $pass = new PostProcessorsCompilerPass();
 
-        $this->assertCount(0, $managerDefinition->getMethodCalls());
+        $this->assertDefinitionMethodCallsNone($m);
         $pass->process($container);
-        $this->assertCount(1, $managerDefinition->getMethodCalls());
+        $this->assertDefinitionMethodCallCount(1, $m);
     }
 }

--- a/Tests/DependencyInjection/Compiler/ResolversCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResolversCompilerPassTest.php
@@ -12,34 +12,28 @@
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\ResolversCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
  * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\ResolversCompilerPass
  */
-class ResolversCompilerPassTest extends \PHPUnit_Framework_TestCase
+class ResolversCompilerPassTest extends AbstractCompilerPassTestCase
 {
     public function testProcess()
     {
-        $managerDefinition = new Definition();
-        $resolverDefinition = new Definition();
-        $resolverDefinition->addTag('liip_imagine.cache.resolver', array(
-            'resolver' => 'foo',
-        ));
+        $m = $this->createDefinition();
+        $l = $this->createDefinition(array('liip_imagine.cache.resolver' => array(
+            'resolver' => 'foobar',
+        )));
 
-        $container = new ContainerBuilder();
-        $container->setDefinition('liip_imagine.cache.manager', $managerDefinition);
-        $container->setDefinition('a.resolver', $resolverDefinition);
+        $container = $this->createContainerBuilder(array(
+            'resolver.foobar' => $l,
+            'liip_imagine.cache.manager' => $m,
+        ));
 
         $pass = new ResolversCompilerPass();
 
-        //guard
-        $this->assertCount(0, $managerDefinition->getMethodCalls());
-
+        $this->assertDefinitionMethodCallsNone($m);
         $pass->process($container);
-
-        $this->assertCount(1, $managerDefinition->getMethodCalls());
+        $this->assertDefinitionMethodCallCount(1, $m);
     }
 }

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -12,13 +12,13 @@
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory\Resolver;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory;
+use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
- * @covers Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory<extended>
+ * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory<extended>
  */
 class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 {
@@ -122,7 +122,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
     public function testCreateS3ClientDefinitionWithFactoryOnCreate()
     {
-        if (version_compare(Kernel::VERSION_ID, '20600') < 0) {
+        if (SymfonyFramework::isKernelLessThan(2, 6)) {
             $this->markTestSkipped('No need to test on symfony < 2.6');
         }
 
@@ -147,7 +147,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
     public function testLegacyCreateS3ClientDefinitionWithFactoryOnCreate()
     {
-        if (version_compare(Kernel::VERSION_ID, '20600') >= 0) {
+        if (SymfonyFramework::isKernelGreaterThanOrEqualTo(2, 6)) {
             $this->markTestSkipped('No need to test on symfony >= 2.6');
         }
 

--- a/Tests/Form/Type/ImageTypeTest.php
+++ b/Tests/Form/Type/ImageTypeTest.php
@@ -12,12 +12,12 @@
 namespace Liip\ImagineBundle\Tests\Form\Type;
 
 use Liip\ImagineBundle\Form\Type\ImageType;
+use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * @covers Liip\ImagineBundle\Form\Type\ImageType
+ * @covers \Liip\ImagineBundle\Form\Type\ImageType
  */
 class ImageTypeTest extends \PHPUnit_Framework_TestCase
 {
@@ -37,7 +37,7 @@ class ImageTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testConfigureOptions()
     {
-        if (version_compare(Kernel::VERSION_ID, '20600') < 0) {
+        if (SymfonyFramework::isKernelLessThan(2, 6)) {
             $this->markTestSkipped('No need to test on symfony < 2.6');
         }
 
@@ -57,7 +57,7 @@ class ImageTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testLegacySetDefaultOptions()
     {
-        if (version_compare(Kernel::VERSION_ID, '20600') >= 0) {
+        if (SymfonyFramework::isKernelGreaterThanOrEqualTo(2, 6)) {
             $this->markTestSkipped('No need to test on symfony >= 2.6');
         }
 

--- a/Tests/Functional/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Functional/Binary/Loader/FileSystemLoaderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Functional\Binary\Loader;
+
+use Liip\ImagineBundle\Binary\Loader\FileSystemLoader;
+use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+
+/**
+ * @covers \Liip\ImagineBundle\Binary\Loader\FileSystemLoader
+ */
+class FileSystemLoaderTest extends WebTestCase
+{
+    /**
+     * @param string $name
+     *
+     * @return FileSystemLoader|object
+     */
+    private function getLoader($name)
+    {
+        return $this->getService(sprintf('liip_imagine.binary.loader.%s', $name));
+    }
+
+    private function getPrivateProperty($object, $name)
+    {
+        $r = new \ReflectionObject($object);
+
+        $p = $r->getProperty($name);
+        $p->setAccessible(true);
+
+        return $p->getValue($object);
+    }
+
+    public function testMultipleLoadersContainIndependentLocators()
+    {
+        $fooLoader = $this->getLoader('foo');
+        $barLoader = $this->getLoader('bar');
+
+        $fooLocator = $this->getPrivateProperty($fooLoader, 'locator');
+        $barLocator = $this->getPrivateProperty($barLoader, 'locator');
+
+        $this->assertNotSame($fooLocator, $barLocator);
+
+        $fooRoots = $this->getPrivateProperty($fooLocator, 'roots');
+        $barRoots = $this->getPrivateProperty($barLocator, 'roots');
+
+        $this->assertNotSame($fooRoots, $barRoots);
+
+        $this->assertStringEndsWith('root-01', $fooRoots[0]);
+        $this->assertStringEndsWith('root-02', $barRoots[0]);
+    }
+}

--- a/Tests/Functional/WebTestCase.php
+++ b/Tests/Functional/WebTestCase.php
@@ -24,4 +24,32 @@ abstract class WebTestCase extends BaseWebTestCase
 
         return 'Liip\ImagineBundle\Tests\Functional\app\AppKernel';
     }
+
+    /**
+     * @param string $name
+     *
+     * @return object
+     */
+    protected function getService($name)
+    {
+        if (!static::$kernel) {
+            $this->createClient();
+        }
+
+        return static::$kernel->getContainer()->get($name);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return mixed
+     */
+    protected function getParameter($name)
+    {
+        if (!static::$kernel) {
+            $this->createClient();
+        }
+
+        return static::$kernel->getContainer()->getParameter($name);
+    }
 }

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -19,6 +19,12 @@ liip_imagine:
         default:
             filesystem:
                 data_root: "%kernel.root_dir%/web"
+        foo:
+            filesystem:
+                data_root: "%kernel.root_dir%/../../Fixtures/FileSystemLocator/root-01"
+        bar:
+            filesystem:
+                data_root: "%kernel.root_dir%/../../Fixtures/FileSystemLocator/root-02"
     resolvers:
         default:
             web_path:

--- a/Tests/LiipImagineBundleTest.php
+++ b/Tests/LiipImagineBundleTest.php
@@ -12,16 +12,32 @@
 namespace Liip\ImagineBundle\Tests;
 
 use Liip\ImagineBundle\LiipImagineBundle;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @covers Liip\ImagineBundle\LiipImagineBundle
+ * @covers \Liip\ImagineBundle\LiipImagineBundle
  */
 class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
 {
     public function testSubClassOfBundle()
     {
         $this->assertInstanceOf('Symfony\Component\HttpKernel\Bundle\Bundle', new LiipImagineBundle());
+    }
+
+    public function testLocatorsCompilerPassOnBuild()
+    {
+        $containerMock = $this->createContainerBuilderMock();
+        $containerMock
+            ->expects($this->atLeastOnce())
+            ->method('getExtension')
+            ->with('liip_imagine')
+            ->will($this->returnValue($this->createExtensionMock()));
+        $containerMock
+            ->expects($this->at(0))
+            ->method('addCompilerPass')
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Compiler\LocatorsCompilerPass'));
+
+        $bundle = new LiipImagineBundle();
+        $bundle->build($containerMock);
     }
 
     public function testAddLoadersCompilerPassOnBuild()
@@ -31,18 +47,13 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createExtensionMock()))
-        ;
+            ->will($this->returnValue($this->createExtensionMock()));
         $containerMock
-            ->expects($this->at(0))
+            ->expects($this->at(1))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass'))
-        ;
-
-        $container = new ContainerBuilder();
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass'));
 
         $bundle = new LiipImagineBundle();
-
         $bundle->build($containerMock);
     }
 
@@ -53,16 +64,13 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createExtensionMock()))
-        ;
+            ->will($this->returnValue($this->createExtensionMock()));
         $containerMock
-            ->expects($this->at(1))
+            ->expects($this->at(2))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass'))
-        ;
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass'));
 
         $bundle = new LiipImagineBundle();
-
         $bundle->build($containerMock);
     }
 
@@ -73,16 +81,13 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createExtensionMock()))
-        ;
+            ->will($this->returnValue($this->createExtensionMock()));
         $containerMock
-            ->expects($this->at(2))
+            ->expects($this->at(3))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Compiler\PostProcessorsCompilerPass'))
-        ;
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Compiler\PostProcessorsCompilerPass'));
 
         $bundle = new LiipImagineBundle();
-
         $bundle->build($containerMock);
     }
 
@@ -93,16 +98,13 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createExtensionMock()))
-        ;
+            ->will($this->returnValue($this->createExtensionMock()));
         $containerMock
-            ->expects($this->at(3))
+            ->expects($this->at(4))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Compiler\ResolversCompilerPass'))
-        ;
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Compiler\ResolversCompilerPass'));
 
         $bundle = new LiipImagineBundle();
-
         $bundle->build($containerMock);
     }
 
@@ -112,19 +114,16 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
         $extensionMock
             ->expects($this->at(0))
             ->method('addResolverFactory')
-            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory'))
-        ;
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory'));
 
         $containerMock = $this->createContainerBuilderMock();
         $containerMock
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock))
-        ;
+            ->will($this->returnValue($extensionMock));
 
         $bundle = new LiipImagineBundle();
-
         $bundle->build($containerMock);
     }
 
@@ -134,19 +133,16 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
         $extensionMock
             ->expects($this->at(1))
             ->method('addResolverFactory')
-            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory'))
-        ;
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory'));
 
         $containerMock = $this->createContainerBuilderMock();
         $containerMock
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock))
-        ;
+            ->will($this->returnValue($extensionMock));
 
         $bundle = new LiipImagineBundle();
-
         $bundle->build($containerMock);
     }
 
@@ -156,19 +152,16 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
         $extensionMock
             ->expects($this->at(2))
             ->method('addResolverFactory')
-            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\FlysystemResolverFactory'))
-        ;
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\FlysystemResolverFactory'));
 
         $containerMock = $this->createContainerBuilderMock();
         $containerMock
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock))
-        ;
+            ->will($this->returnValue($extensionMock));
 
         $bundle = new LiipImagineBundle();
-
         $bundle->build($containerMock);
     }
 
@@ -178,19 +171,16 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
         $extensionMock
             ->expects($this->at(3))
             ->method('addLoaderFactory')
-            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory'))
-        ;
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory'));
 
         $containerMock = $this->createContainerBuilderMock();
         $containerMock
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock))
-        ;
+            ->will($this->returnValue($extensionMock));
 
         $bundle = new LiipImagineBundle();
-
         $bundle->build($containerMock);
     }
 
@@ -200,19 +190,16 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
         $extensionMock
             ->expects($this->at(4))
             ->method('addLoaderFactory')
-            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Loader\FilesystemLoaderFactory'))
-        ;
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Loader\FilesystemLoaderFactory'));
 
         $containerMock = $this->createContainerBuilderMock();
         $containerMock
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock))
-        ;
+            ->will($this->returnValue($extensionMock));
 
         $bundle = new LiipImagineBundle();
-
         $bundle->build($containerMock);
     }
 
@@ -222,19 +209,16 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
         $extensionMock
             ->expects($this->at(5))
             ->method('addLoaderFactory')
-            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory'))
-        ;
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory'));
 
         $containerMock = $this->createContainerBuilderMock();
         $containerMock
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock))
-        ;
+            ->will($this->returnValue($extensionMock));
 
         $bundle = new LiipImagineBundle();
-
         $bundle->build($containerMock);
     }
 
@@ -246,7 +230,9 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
     protected function createExtensionMock()
     {
         $methods = array(
-            'getNamespace', 'addResolverFactory', 'addLoaderFactory',
+            'getNamespace',
+            'addResolverFactory',
+            'addLoaderFactory',
         );
 
         return $this->getMock('Liip\ImagineBundle\DependencyInjection\LiipImagineExtension', $methods, array(), '', false);

--- a/Tests/Utility/Framework/SymfonyFrameworkTest.php
+++ b/Tests/Utility/Framework/SymfonyFrameworkTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Utility\Framework;
+
+use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
+
+/**
+ * @covers \Liip\ImagineBundle\Utility\Framework\SymfonyFramework
+ */
+class SymfonyFrameworkTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHasDefinitionSharing()
+    {
+        if (SymfonyFramework::isKernelGreaterThanOrEqualTo(2, 8)) {
+            $this->assertTrue(SymfonyFramework::hasDefinitionSharing());
+        } else {
+            $this->assertFalse(SymfonyFramework::hasDefinitionSharing());
+        }
+    }
+
+    public function testHasDefinitionScoping()
+    {
+        if (SymfonyFramework::isKernelGreaterThanOrEqualTo(3, 0)) {
+            $this->assertFalse(SymfonyFramework::hasDefinitionScoping());
+        } else {
+            $this->assertTrue(SymfonyFramework::hasDefinitionScoping());
+        }
+    }
+
+    public function testHasDirectContainerBuilderLogging()
+    {
+        if (SymfonyFramework::isKernelGreaterThanOrEqualTo(3, 3)) {
+            $this->assertTrue(SymfonyFramework::hasDirectContainerBuilderLogging());
+        } else {
+            $this->assertFalse(SymfonyFramework::hasDirectContainerBuilderLogging());
+        }
+    }
+
+    public function testIsKernelGreaterThanOrEqualToOrLessThan()
+    {
+        if (false === $v = getenv('SYMFONY_VERSION')) {
+            $this->markTestSkipped('Requires SYMFONY_VERSION environment variable.');
+        }
+
+        if (1 !== preg_match('{(?<major>[0-9]+)\.(?<minor>[0-9]+)\.x(?:-dev)?}', $v, $matches)) {
+            $this->markTestSkipped('Requires SYMFONY_VERSION in format x.x.x[-dev]');
+        }
+
+        $this->assertTrue(SymfonyFramework::isKernelGreaterThanOrEqualTo($matches['major'], $matches['minor']));
+        $this->assertFalse(SymfonyFramework::isKernelLessThan($matches['major'], $matches['minor']));
+    }
+
+    public function testIsKernelLessThan()
+    {
+        $this->assertTrue(SymfonyFramework::isKernelLessThan(100, 100, 100));
+        $this->assertFalse(SymfonyFramework::isKernelLessThan(1, 1, 1));
+    }
+}

--- a/Utility/Framework/SymfonyFramework.php
+++ b/Utility/Framework/SymfonyFramework.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Utility\Framework;
+
+use Symfony\Component\HttpKernel\Kernel;
+
+class SymfonyFramework
+{
+    /**
+     * @return bool
+     */
+    public static function hasDefinitionSharedToggle()
+    {
+        return method_exists('\Symfony\Component\DependencyInjection\Definition', 'setShared');
+    }
+
+    /**
+     * @param int      $major
+     * @param int|null $minor
+     * @param int|null $patch
+     *
+     * @return bool
+     */
+    public static function isKernelGreaterThanOrEqualTo($major, $minor = null, $patch = null)
+    {
+        return static::kernelVersionCompare('>=', $major, $minor, $patch);
+    }
+
+    /**
+     * @param int      $major
+     * @param int|null $minor
+     * @param int|null $patch
+     *
+     * @return bool
+     */
+    public static function isKernelLessThan($major, $minor = null, $patch = null)
+    {
+        return static::kernelVersionCompare('<', $major, $minor, $patch);
+    }
+
+    /**
+     * @param string   $operator
+     * @param int      $major
+     * @param int|null $minor
+     * @param int|null $patch
+     *
+     * @return bool
+     */
+    private static function kernelVersionCompare($operator, $major, $minor = null, $patch = null)
+    {
+        $vernum = $major;
+        $kernel = Kernel::MAJOR_VERSION;
+
+        if ($minor) {
+            $vernum .= '.'.$minor;
+            $kernel .= '.'.Kernel::MINOR_VERSION;
+
+            if ($patch) {
+                $vernum .= '.'.$patch;
+                $kernel .= '.'.Kernel::RELEASE_VERSION;
+            }
+        }
+
+        return version_compare($kernel, $vernum, $operator);
+    }
+}

--- a/Utility/Framework/SymfonyFramework.php
+++ b/Utility/Framework/SymfonyFramework.php
@@ -18,9 +18,27 @@ class SymfonyFramework
     /**
      * @return bool
      */
-    public static function hasDefinitionSharedToggle()
+    public static function hasDefinitionSharing()
     {
-        return method_exists('\Symfony\Component\DependencyInjection\Definition', 'setShared');
+        return method_exists('\Symfony\Component\DependencyInjection\Definition', 'setShared')
+            && method_exists('\Symfony\Component\DependencyInjection\Definition', 'isShared');
+    }
+
+    /**
+     * @return bool
+     */
+    public static function hasDefinitionScoping()
+    {
+        return method_exists('\Symfony\Component\DependencyInjection\Definition', 'setScope')
+            && method_exists('\Symfony\Component\DependencyInjection\Definition', 'getScope');
+    }
+
+    /**
+     * @return bool
+     */
+    public static function hasDirectContainerBuilderLogging()
+    {
+        return method_exists('\Symfony\Component\DependencyInjection\ContainerBuilder', 'log');
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #874
| License | MIT

This PR adds a compiler pass that gathers the `Locator` services and makes them __not shared__, causing the Symfony container to instantiate new objects each time they are requested (instead of the default behavior of re-using the first instance created).

This solves a bug introduced in `1.7.2` that causes those who use multiple `FileSystemLoader` definitions to only have their last path registered. Functional tests have been added to ensure a similar regression does not occur in the future.

Additionally, when the `*Locator` classes were implemented, exceptions originating from Symfony's `OptionsResolver` were ignored; this PR adds a try/catch block to the `FileSystemLocator::setOptions()` method and throws an exception originating from the `Liip` namespace so users don't have to worry about catching external dependencies' exceptions.

---

__Note:__ This PR should _not_ be merged into the `2.0` branch. The special handling seen in this PR is only required because the `1.0` branch supports both Symfony `<2.8` _and_ `>=2.8`. These versions require different mechanisms for achieving non-shared services (with `<2.8` requiring "prototype" scoping and `>=2.8` allowing the service to be simply defined as "not shared"). The `2.0` branch can achieve the same intent of this PR by simpy adding `shared="false"` to the locator service definitions.

```xml
<service shared="false" id="liip_imagine.binary.locator.filesystem" class="%liip_imagine.binary.locator.filesystem.class%" public="false"></service>
<service shared="false" id="liip_imagine.binary.locator.filesystem_insecure" class="%liip_imagine.binary.locator.filesystem_insecure.class%" public="false"></service>
```