### PR TITLE
[Travis] Enable mongo unit tests on PHP7 using "mongo" => "mongodb" extension adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,17 +45,17 @@ matrix:
       env: SYMFONY_VERSION=dev-master
 
 before_install:
-  - composer self-update
-  - if [ "${TRAVIS_PHP_VERSION}" == "5.3" ]; then composer remove --no-update --dev satooshi/php-coveralls; fi;
   - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
-  - if [ "${SYMFONY_VERSION:0:3}" == "2.3" ]; then composer remove --dev friendsofphp/php-cs-fixer --no-update; fi;
-  - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION}" != "5.3" ]; then composer require --dev league/flysystem:~1.0 --no-update; fi;
-  - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION:0:1}" != "7" ]; then composer require --dev doctrine/mongodb-odm:~1.0 --no-update; yes "" | pecl -q install -f mongo; fi;
-  - if [ "${SYMFONY_VERSION:-x}" != "x" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - cp ./.composer/config.json ~/.composer; composer global require "hirak/prestissimo:^0.3"
+  - if [ "${TRAVIS_PHP_VERSION}" == "5.3" ]; then composer remove --no-update --dev satooshi/php-coveralls; fi;
+  - if [ "${SYMFONY_VERSION:0:3}" == "2.3" ]; then composer remove --no-update --dev friendsofphp/php-cs-fixer; fi;
+  - if [ "${SYMFONY_VERSION:-x}" != "x" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION:0:3}" != "5.3" ]; then composer require --no-update --dev league/flysystem:~1.0; fi;
+  - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION:0:1}" != "7" ]; then yes "" | pecl -q install -f mongo; composer require --no-update --dev doctrine/mongodb-odm:~1.0; fi;
+  - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION:0:1}" == "7" ]; then yes "" | pecl -q install -f mongodb; travis_retry composer require --dev alcaeus/mongo-php-adapter:~1.0; composer require --no-update --dev doctrine/mongodb-odm:~1.0; fi
 
 install:
-  - composer update $COMPOSER_FLAGS
+  - travis_retry composer update $COMPOSER_FLAGS
 
 script:
   - SYMFONY_DEPRECATIONS_HELPER=weak ./bin/phpunit -vvv

--- a/composer.json
+++ b/composer.json
@@ -1,19 +1,21 @@
 {
     "name": "liip/imagine-bundle",
     "type": "symfony-bundle",
-    "description": "This Bundle assists in imagine manipulation using the imagine library",
-    "keywords": ["imagine", "image"],
+    "description": "This bundle provides an image manipulation abstraction toolkit for Symfony-based projects.",
+    "keywords": [ "imagine", "image", "manipulation", "pictures", "photos", "transformation", "bundle", "symfony", "liip" ],
     "homepage": "http://liip.ch",
     "license": "MIT",
-    "minimum-stability": "dev",
     "authors": [
         {
             "name": "Liip and other contributors",
             "homepage": "https://github.com/liip/LiipImagineBundle/contributors"
         }
     ],
-    "archive": {
-        "exclude": ["/Tests"]
+    "autoload": {
+        "psr-4": {
+            "Liip\\ImagineBundle\\": ""
+        },
+        "exclude-from-classmap": [ "/Tests/" ]
     },
     "require": {
         "php": "^5.3.9|^7.0",
@@ -28,11 +30,11 @@
         "symfony/translation": "~2.3|~3.0"
     },
     "require-dev": {
-        "ext-gd": "*",
         "amazonwebservices/aws-sdk-for-php": "~1.0",
         "aws/aws-sdk-php": "~2.4",
         "doctrine/cache": "~1.1",
         "doctrine/orm": "~2.3",
+        "ext-gd": "*",
         "friendsofphp/php-cs-fixer": "~2.0",
         "phpunit/phpunit": "~4.3",
         "psr/log": "~1.0",
@@ -43,25 +45,29 @@
         "symfony/dependency-injection": "~2.3|~3.0",
         "symfony/form": "~2.3|~3.0",
         "symfony/phpunit-bridge": "~2.3|~3.0",
-        "symfony/yaml": "~2.3|~3.0",
         "symfony/validator": "~2.3|~3.0",
-        "twig/twig": "~1.12"
+        "symfony/yaml": "~2.3|~3.0",
+        "twig/twig": "~1.12|~2.0"
     },
     "suggest": {
-        "amazonwebservices/aws-sdk-for-php": "Required to use AWS version 1 cache resolver.",
-        "aws/aws-sdk-php": "Required to use AWS version 2/3 cache resolver.",
-        "ext-exif": "Required to read metadata from Exif information",
-        "league/flysystem": "Required to use FlySystem data loader or cache resolver.",
-        "monolog/monolog": "A psr/log compatible logger is required to enable logging.",
-        "twig/twig": "Required to use the provided Twig extension. Version 1.12 or greater needed."
+        "alcaeus/mongo-php-adapter": "required on PHP >= 7.0 to use mongo components with mongodb extension",
+        "amazonwebservices/aws-sdk-for-php": "required to use AWS version 1 cache resolver",
+        "aws/aws-sdk-php": "required to use AWS version 2/3 cache resolver",
+        "doctrine/mongodb-odm": "required to use mongodb-backed doctrine components",
+        "ext-exif": "required to read EXIF metadata from images",
+        "ext-gd": "required to use gd driver",
+        "ext-gmagick": "required to use gmagick driver",
+        "ext-imagick": "required to use imagick driver",
+        "ext-mongo": "required for mongodb components on PHP <7.0",
+        "ext-mongodb": "required for mongodb components on PHP >=7.0",
+        "league/flysystem": "required to use FlySystem data loader or cache resolver",
+        "monolog/monolog": "A psr/log compatible logger is required to enable logging",
+        "twig/twig": "required to use the provided Twig extension. Version 1.12 or greater needed"
     },
-    "autoload": {
-        "psr-4": { "Liip\\ImagineBundle\\": "" },
-        "exclude-from-classmap": ["/Tests/"]
-    },
+    "minimum-stability": "dev",
     "config": {
         "bin-dir": "bin",
-        "sort-packages" : true
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | 
| License | MIT
| Doc PR | 

Use the [alcaeus/mongo-php-adapter](https://github.com/alcaeus/mongo-php-adapter) package during Travis builds to provide an adapter for the `mongo` extension (_not_ compatible with PHP7) that proxies calls to the new `mongodb` extension (compatible with PHP7), allowing for MongoDB-related code to be properly tested on all PHP engines. Also included is general cleanup of the `composer.json` file.