### PR TITLE
[Loader] Add bundle resources to safe path when requested

### DIFF
--- a/Binary/Locator/FileSystemInsecureLocator.php
+++ b/Binary/Locator/FileSystemInsecureLocator.php
@@ -21,10 +21,12 @@ class FileSystemInsecureLocator extends FileSystemLocator
      */
     protected function generateAbsolutePath($root, $path)
     {
-        if (false !== strpos($path, '..'.DIRECTORY_SEPARATOR)) {
+        if (false !== strpos($path, '..'.DIRECTORY_SEPARATOR) ||
+            false !== strpos($path, DIRECTORY_SEPARATOR.'..') ||
+            false === file_exists($absolute = $root.DIRECTORY_SEPARATOR.$path)) {
             return false;
         }
 
-        return file_exists($absolute = $root.DIRECTORY_SEPARATOR.$path) ? $absolute : false;
+        return $absolute;
     }
 }

--- a/Binary/Locator/FileSystemLocator.php
+++ b/Binary/Locator/FileSystemLocator.php
@@ -49,14 +49,51 @@ class FileSystemLocator implements LocatorInterface
      */
     public function locate($path)
     {
-        foreach ($this->roots as $root) {
-            if (false !== $absolute = $this->generateAbsolutePath($root, $path)) {
-                return $this->sanitizeAbsolutePath($absolute);
-            }
+        if (false !== $absolute = $this->locateUsingRootPlaceholder($path)) {
+            return $this->sanitizeAbsolutePath($absolute);
+        }
+
+        if (false !== $absolute = $this->locateUsingRootPathsSearch($path)) {
+            return $this->sanitizeAbsolutePath($absolute);
         }
 
         throw new NotLoadableException(sprintf('Source image not resolvable "%s" in root path(s) "%s"',
             $path, implode(':', $this->roots)));
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return bool|string
+     */
+    private function locateUsingRootPathsSearch($path)
+    {
+        foreach ($this->roots as $root) {
+            if (false !== $absolute = $this->generateAbsolutePath($root, $path)) {
+                return $absolute;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return bool|string
+     */
+    private function locateUsingRootPlaceholder($path)
+    {
+        if (0 !== strpos($path, '@') || 1 !== preg_match('{@(?<name>[^:]+):(?<path>.+)}', $path, $matches)) {
+            return false;
+        }
+
+        if (isset($this->roots[$matches['name']])) {
+            return $this->generateAbsolutePath($this->roots[$matches['name']], $matches['path']);
+        }
+
+        throw new NotLoadableException(sprintf('Invalid root placeholder "%s" for path "%s"',
+            $matches['name'], $matches['path']));
     }
 
     /**

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -11,6 +11,7 @@
 
 namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
 
+use Liip\ImagineBundle\Exception\InvalidArgumentException;
 use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -24,22 +25,8 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
      */
     public function create(ContainerBuilder $container, $loaderName, array $config)
     {
-        $dataRoots = $config['data_root'];
-        
-        // Load bundle resources if requested
-        if ($config['bundle_resources']) {
-            foreach ($container->getParameter('kernel.bundles') as $bundle) {
-                $refClass = new \ReflectionClass($bundle);
-                $bundlePath = dirname($refClass->getFileName());
-                if (!is_dir($originDir = $bundlePath . '/Resources/public')) {
-                    continue;
-                }
-                $dataRoots[] = realpath($originDir);
-            }
-        }
-        
         $definition = $this->getChildLoaderDefinition();
-        $definition->replaceArgument(2, $dataRoots);
+        $definition->replaceArgument(2, $this->resolveDataRoots($config['data_root'], $config['bundle_resources'], $container));
         $definition->replaceArgument(3, $this->createLocatorReference($config['locator']));
 
         return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
@@ -60,9 +47,6 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
     {
         $builder
             ->children()
-                ->booleanNode('bundle_resources')
-                  ->defaultFalse()
-                ->end()
                 ->enumNode('locator')
                     ->values(array('filesystem', 'filesystem_insecure'))
                     ->info('Using the "filesystem_insecure" locator is not recommended due to a less secure resolver mechanism, but is provided for those using heavily symlinked projects.')
@@ -73,12 +57,110 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
                     ->ifString()
                         ->then(function ($value) { return array($value); })
                     ->end()
+                    ->treatNullLike(array())
+                    ->treatFalseLike(array())
                     ->defaultValue(array('%kernel.root_dir%/../web'))
                     ->prototype('scalar')
                         ->cannotBeEmpty()
                     ->end()
                 ->end()
+                ->arrayNode('bundle_resources')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')
+                            ->defaultFalse()
+                        ->end()
+                        ->enumNode('access_control_type')
+                            ->values(array('blacklist', 'whitelist'))
+                            ->info('Sets the access control method applied to bundle names in "access_control_list" into a blacklist or whitelist.')
+                            ->defaultValue('blacklist')
+                        ->end()
+                        ->arrayNode('access_control_list')
+                            ->defaultValue(array())
+                            ->prototype('scalar')
+                                ->cannotBeEmpty()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
+    }
+
+
+    /*
+     * @param string[]         $staticPaths
+     * @param array            $config
+     * @param ContainerBuilder $container
+     *
+     * @return string[]
+     */
+    private function resolveDataRoots(array $staticPaths, array $config, ContainerBuilder $container)
+    {
+        if (false === $config['enabled']) {
+            return $staticPaths;
+        }
+
+        $resourcePaths = array();
+
+        foreach ($this->getBundleResourcePaths($container) as $name => $path) {
+            if (('whitelist' === $config['access_control_type']) === in_array($name, $config['access_control_list']) && is_dir($path)) {
+                $resourcePaths[$name] = $path;
+            }
+        }
+
+        return array_merge($staticPaths, $resourcePaths);
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     *
+     * @return string[]
+     */
+    private function getBundleResourcePaths(ContainerBuilder $container)
+    {
+        if ($container->hasParameter('kernel.bundles_metadata')) {
+            $paths = $this->getBundlePathsUsingMetadata($container->getParameter('kernel.bundles_metadata'));
+        } else {
+            $paths = $this->getBundlePathsUsingNamedObj($container->getParameter('kernel.bundles'));
+        }
+
+        return array_map(function ($path) {
+            return $path.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'public';
+        }, $paths);
+    }
+
+    /**
+     * @param array[] $metadata
+     *
+     * @return string[]
+     */
+    private function getBundlePathsUsingMetadata(array $metadata)
+    {
+        return array_combine(array_keys($metadata), array_map(function ($data) {
+            return $data['path'];
+        }, $metadata));
+    }
+
+    /**
+     * @param string[] $classes
+     *
+     * @return string[]
+     */
+    private function getBundlePathsUsingNamedObj(array $classes)
+    {
+        $paths = array();
+
+        foreach ($classes as $c) {
+            try {
+                $r = new \ReflectionClass($c);
+            } catch (\ReflectionException $exception) {
+                throw new InvalidArgumentException(sprintf('Unable to resolve bundle "%s" while auto-registering bundle resource paths.', $c), null, $exception);
+            }
+
+            $paths[$r->getShortName()] = dirname($r->getFileName());
+        }
+
+        return $paths;
     }
 
     /**

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -24,8 +24,22 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
      */
     public function create(ContainerBuilder $container, $loaderName, array $config)
     {
+        $dataRoots = $config['data_root'];
+        
+        // Load bundle resources if requested
+        if ($config['bundle_resources']) {
+            foreach ($container->getParameter('kernel.bundles') as $bundle) {
+                $refClass = new \ReflectionClass($bundle);
+                $bundlePath = dirname($refClass->getFileName());
+                if (!is_dir($originDir = $bundlePath . '/Resources/public')) {
+                    continue;
+                }
+                $dataRoots[] = realpath($originDir);
+            }
+        }
+        
         $definition = $this->getChildLoaderDefinition();
-        $definition->replaceArgument(2, $config['data_root']);
+        $definition->replaceArgument(2, $dataRoots);
         $definition->replaceArgument(3, $this->createLocatorReference($config['locator']));
 
         return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
@@ -46,6 +60,9 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
     {
         $builder
             ->children()
+                ->booleanNode('bundle_resources')
+                  ->defaultFalse()
+                ->end()
                 ->enumNode('locator')
                     ->values(array('filesystem', 'filesystem_insecure'))
                     ->info('Using the "filesystem_insecure" locator is not recommended due to a less secure resolver mechanism, but is provided for those using heavily symlinked projects.')

--- a/README.md
+++ b/README.md
@@ -367,12 +367,12 @@ $response = $imagine
 ```
 
 
-## Images Outside Data Root
+## Data Roots
 
-When your setup requires your source images reside outside the web root,
-you have to set your loader's `data_root` parameter in your configuration 
-(often `app/config/config.yml`) with the absolute path to your source image 
-location.
+By default, Symfony's `web/` directory is registered as a data root to load
+assets from. For many installations this will be sufficient, but sometime you
+may need to load images from other locations. To do this, you must set the
+`data_root` parameter in your configuration (often located at `app/config/config.yml`).
 
 ```yml
 liip_imagine:
@@ -382,14 +382,68 @@ liip_imagine:
                 data_root: /path/to/source/images/dir
 ```
 
-When you need assets from bundles which have a `Resources/public`-folder, you can automatically add them to the `data_root` by setting the `bundle_resources` parameter to `true`.
+As of version `1.7.2` you can register multiple data root paths, and the 
+file locator will search each for the requested file.
+
 ```yml
 liip_imagine:
     loaders:
         default:
             filesystem:
-                bundle_resources: true
+                data_root:
+                    - /path/foo
+                    - /path/bar
 ```
+
+As of version `1.7.3` you ask for the public resource paths from all registered bundles
+to be auto-registered as data roots. This allows you to load assets from the
+`Resources/public` folders that reside within the loaded bundles. To enable this
+feature, set the `bundle_resources.enabled` configuration option to `true`.
+
+```yml
+liip_imagine:
+    loaders:
+        default:
+            filesystem:
+                bundle_resources:
+                    enabled: true
+```
+
+If you want to register some of the `Resource/public` folders, but not all, you can do
+so by blacklisting the bundles you don't want registered or whitelisting the bundles you
+do want registered. For example, to blacklist (not register) the bundles "FooBundle" and
+"BarBundle", you would use the following configuration.
+
+```yml
+liip_imagine:
+    loaders:
+        default:
+            filesystem:
+                bundle_resources:
+                    enabled: true
+                    access_control_type: blacklist
+                    access_control_list:
+                        - FooBundle
+                        - BarBundle
+```
+
+Alternatively, if you want to whitelist (only register) the bundles "FooBundle" and "BarBundle",
+you would use the following configuration.
+
+```yml
+liip_imagine:
+    loaders:
+        default:
+            filesystem:
+                bundle_resources:
+                    enabled: true
+                    access_control_type: whitelist
+                    access_control_list:
+                        - FooBundle
+                        - BarBundle
+```
+
+### Permissions
 
 Image locations must be readable by your web server. On a system that supports 
 `setfacl` (such as Linux/BSD), use

--- a/README.md
+++ b/README.md
@@ -382,7 +382,16 @@ liip_imagine:
                 data_root: /path/to/source/images/dir
 ```
 
-This location must be readable by your web server. On a system that supports 
+When you need assets from bundles which have a `Resources/public`-folder, you can automatically add them to the `data_root` by setting the `bundle_resources` parameter to `true`.
+```yml
+liip_imagine:
+    loaders:
+        default:
+            filesystem:
+                bundle_resources: true
+```
+
+Image locations must be readable by your web server. On a system that supports 
 `setfacl` (such as Linux/BSD), use
 
 ```sh

--- a/Resources/doc/data-loader/filesystem.rst
+++ b/Resources/doc/data-loader/filesystem.rst
@@ -36,3 +36,17 @@ You can configure the ``data_root``, used as the root path to search for images:
             profile_photos:
                 filesystem:
                     data_root: "%kernel.root_dir%/../web"
+
+You can automatically load bundle resources in their ``Resources/public`` by enabling
+the ``bundle_resources`` parameter. This will automatically add those directories to the
+root path.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        loaders:
+            profile_photos:
+                filesystem:
+                    bundle_resources: true

--- a/Resources/doc/data-loader/filesystem.rst
+++ b/Resources/doc/data-loader/filesystem.rst
@@ -25,7 +25,10 @@ To set this loader for a specific context called ``profile_photos``, use:
             profile_photos:
                 filesystem: ~
 
-You can configure the ``data_root``, used as the root path to search for images:
+By default, Symfony's ``web/`` directory is registered as a data root to load
+assets from. For many installations this will be sufficient, but sometime you
+may need to load images from other locations. To do this, you must set the
+``data_root`` parameter.
 
 .. code-block:: yaml
 
@@ -33,13 +36,13 @@ You can configure the ``data_root``, used as the root path to search for images:
 
     liip_imagine:
         loaders:
-            profile_photos:
+            default:
                 filesystem:
-                    data_root: "%kernel.root_dir%/../web"
+                    data_root: /path/to/source/images/dir
 
-You can automatically load bundle resources in their ``Resources/public`` by enabling
-the ``bundle_resources`` parameter. This will automatically add those directories to the
-root path.
+
+As of version ``1.7.2`` you can register multiple data roots and the file locator
+will search each for the requested file.
 
 .. code-block:: yaml
 
@@ -47,6 +50,83 @@ root path.
 
     liip_imagine:
         loaders:
-            profile_photos:
+            default:
                 filesystem:
-                    bundle_resources: true
+                    data_root:
+                        - /path/foo
+                        - /path/bar
+
+As of version ``1.7.3`` you ask for the public resource paths from all registered bundles
+to be auto-registered as data roots. This allows you to load assets from the
+``Resources/public`` folders that reside within the loaded bundles. To enable this
+feature, set the ``bundle_resources.enabled`` configuration option to ``true``.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        loaders:
+            default:
+                filesystem:
+                    bundle_resources:
+                        enabled: true
+
+If you want to register some of the ``Resource/public`` folders, but not all, you can do
+so by blacklisting the bundles you don't want registered or whitelisting the bundles you
+do want registered. For example, to blacklist (not register) the bundles "FooBundle" and
+"BarBundle", you would use the following configuration.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        loaders:
+            default:
+                filesystem:
+                    bundle_resources:
+                        enabled: true
+                        access_control_type: blacklist
+                        access_control_list:
+                            - FooBundle
+                            - BarBundle
+
+Alternatively, if you want to whitelist (only register) the bundles "FooBundle" and "BarBundle",
+you would use the following configuration.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        loaders:
+            default:
+                filesystem:
+                    bundle_resources:
+                        enabled: true
+                        access_control_type: whitelist
+                        access_control_list:
+                            - FooBundle
+                            - BarBundle
+
+Lastly, as of version `1.7.3`, you can name your data roots and reference them when calling resources.
+This can be useful for a number of reasons, such as wanting to be explicit, but it most useful when
+you have multiple data roots paths that both contain a file of the same name. In this situation, you
+can name your data root paths by providing an index in the `data_root` configuration array (note that
+auto-registered bundle resource paths have indices defined of the bundle's short class name).
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        loaders:
+            default:
+                filesystem:
+                    data_root:
+                        foo: /a/foo/path
+                        bar: /a/bar/path
+
+Given the above configuration, you can explicitly request a root path using the format ``@index:path/to/file.ext``.
+For example, to request the file ``/a/foo/path/with/file.ext`` you can pass ``@foo:with/file.ext`` as the filename.

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -13,6 +13,8 @@ namespace Liip\ImagineBundle\Tests\Binary\Loader;
 
 use Liip\ImagineBundle\Binary\Loader\FileSystemLoader;
 use Liip\ImagineBundle\Binary\Locator\FileSystemLocator;
+use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
+use Liip\ImagineBundle\Model\FileBinary;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 
@@ -21,228 +23,224 @@ use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
  */
 class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
 {
+    public function testImplementsLoaderInterface()
+    {
+        $r = new \ReflectionClass('Liip\ImagineBundle\Binary\Loader\FileSystemLoader');
+
+        $this->assertTrue($r->implementsInterface('Liip\ImagineBundle\Binary\Loader\LoaderInterface'));
+    }
+
+    public function testConstruction()
+    {
+        $this->getFileSystemLoader();
+    }
+
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|FileSystemLocator
+     * @return array[]
      */
-    private function getLocator()
-    {
-        return new FileSystemLocator();
-    }
-
-    public function testShouldImplementLoaderInterface()
-    {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\Binary\Loader\FileSystemLoader');
-
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\Binary\Loader\LoaderInterface'));
-    }
-
-    public function testCouldBeConstructedWithExpectedArguments()
-    {
-        new FileSystemLoader(
-            MimeTypeGuesser::getInstance(),
-            ExtensionGuesser::getInstance(),
-            __DIR__,
-            $this->getLocator()
-        );
-    }
-
-    public function testThrowExceptionIfNoRootPathsProvided()
-    {
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\InvalidArgumentException',
-            'One or more data root paths must be specified.'
-        );
-
-        new FileSystemLoader(
-            MimeTypeGuesser::getInstance(),
-            ExtensionGuesser::getInstance(),
-            array(),
-            $this->getLocator()
-        );
-    }
-
-    public function testThrowExceptionIfRootPathIsEmpty()
-    {
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\InvalidArgumentException',
-            'Root image path not resolvable'
-        );
-
-        new FileSystemLoader(
-            MimeTypeGuesser::getInstance(),
-            ExtensionGuesser::getInstance(),
-            '',
-            $this->getLocator()
-        );
-    }
-
-    public function testThrowExceptionIfRootPathDoesNotExist()
-    {
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\InvalidArgumentException',
-            'Root image path not resolvable'
-        );
-
-        new FileSystemLoader(
-            MimeTypeGuesser::getInstance(),
-            ExtensionGuesser::getInstance(),
-            '/a/bad/root/path',
-            $this->getLocator()
-        );
-    }
-
-    public function testThrowExceptionIfRealPathIsOutsideRootPath1()
-    {
-        $loader = new FileSystemLoader(
-            MimeTypeGuesser::getInstance(),
-            ExtensionGuesser::getInstance(),
-            __DIR__,
-            $this->getLocator()
-        );
-
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException',
-            'Source image invalid'
-        );
-
-        $loader->find('../Loader/../../Binary/Loader/../../../Resources/config/routing.xml');
-    }
-
-    public function testThrowExceptionIfRealPathIsOutsideRootPath2()
-    {
-        $loader = new FileSystemLoader(
-            MimeTypeGuesser::getInstance(),
-            ExtensionGuesser::getInstance(),
-            __DIR__,
-            $this->getLocator()
-        );
-
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException',
-            'Source image invalid'
-        );
-
-        $loader->find('../../Binary/');
-    }
-
-    public function testThrowExceptionIfPathHasDoublePointSlashInTheMiddle()
-    {
-        $loader = new FileSystemLoader(
-            MimeTypeGuesser::getInstance(),
-            ExtensionGuesser::getInstance(),
-            __DIR__,
-            $this->getLocator()
-        );
-
-        $loader->find('/../../Binary/Loader/'.pathinfo(__FILE__, PATHINFO_BASENAME));
-    }
-
-    public function testThrowExceptionIfFileNotExist()
-    {
-        $loader = new FileSystemLoader(
-            MimeTypeGuesser::getInstance(),
-            ExtensionGuesser::getInstance(),
-            __DIR__,
-            $this->getLocator()
-        );
-
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException',
-            'Source image not resolvable'
-        );
-
-        $loader->find('fileNotExist');
-    }
-
     public static function provideLoadCases()
     {
-        $fileName = pathinfo(__FILE__, PATHINFO_BASENAME);
+        $file = pathinfo(__FILE__, PATHINFO_BASENAME);
 
         return array(
-            array(__DIR__, $fileName),
-            array(__DIR__.'/', $fileName),
-            array(__DIR__, '/'.$fileName),
-            array(__DIR__.'/../../Binary/Loader', '/'.$fileName),
-            array(realpath(__DIR__.'/..'), 'Loader/'.$fileName),
-            array(__DIR__.'/../', '/Loader/../../Binary/Loader/'.$fileName),
+            array(
+                __DIR__,
+                $file,
+            ),
+            array(
+                __DIR__.'/',
+                $file,
+            ),
+            array(
+                __DIR__, '/'.
+                $file,
+            ),
+            array(
+                __DIR__.'/../../Binary/Loader',
+                '/'.$file,
+            ),
+            array(
+                realpath(__DIR__.'/..'),
+                'Loader/'.$file,
+            ),
+            array(
+                __DIR__.'/../',
+                '/Loader/../../Binary/Loader/'.$file,
+            ),
         );
     }
 
     /**
      * @dataProvider provideLoadCases
+     *
+     * @param string $root
+     * @param string $path
      */
-    public function testLoad($rootDir, $path)
+    public function testLoad($root, $path)
     {
-        $loader = new FileSystemLoader(
-            MimeTypeGuesser::getInstance(),
-            ExtensionGuesser::getInstance(),
-            $rootDir,
-            $this->getLocator()
-        );
-
-        $binary = $loader->find($path);
-
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\FileBinary', $binary);
-        $this->assertStringStartsWith('text/', $binary->getMimeType());
+        $this->assertValidLoaderFindReturn($this->getFileSystemLoader(array($root))->find($path));
     }
 
     /**
      * @dataProvider provideLoadCases
+     *
+     * @param string $root
+     * @param string $path
      */
-    public function testLoadUsingDeprecatedConstruction($rootDir, $path)
+    public function testDeprecatedConstruction($root, $path)
     {
         $loader = new FileSystemLoader(
             MimeTypeGuesser::getInstance(),
             ExtensionGuesser::getInstance(),
-            $rootDir
+            array($root)
         );
 
-        $binary = $loader->find($path);
-
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\FileBinary', $binary);
-        $this->assertStringStartsWith('text/', $binary->getMimeType());
+        $this->assertValidLoaderFindReturn($loader->find($path));
     }
 
-    public function testThrowsExceptionWhenFourthConstructorArgumentNotLoaderInterface()
-    {
-        $this->setExpectedExceptionRegExp('\InvalidArgumentException', '{Method .+ expects a LocatorInterface for the forth argument}');
-
-        new FileSystemLoader(
-            MimeTypeGuesser::getInstance(),
-            ExtensionGuesser::getInstance(),
-            __DIR__,
-            null
-        );
-    }
-
+    /**
+     * @return array[]
+     */
     public static function provideMultipleRootLoadCases()
     {
-        $prepend = array(
+        $pathsPrepended = array(
             realpath(__DIR__.'/../'),
             realpath(__DIR__.'/../../'),
             realpath(__DIR__.'/../../../'),
         );
 
-        return array_map(function ($params) use ($prepend) {
-            return array(array($prepend[mt_rand(0, count($prepend) - 1)], $params[0]), $params[1]);
+        return array_map(function ($parameters) use ($pathsPrepended) {
+            return array(array($pathsPrepended[mt_rand(0, count($pathsPrepended) - 1)], $parameters[0]), $parameters[1]);
         }, static::provideLoadCases());
     }
 
     /**
      * @dataProvider provideMultipleRootLoadCases
+     *
+     * @param string $root
+     * @param string $path
      */
-    public function testMultipleRootLoadCases($rootDirs, $path)
+    public function testMultipleRootLoadCases($root, $path)
     {
-        $loader = new FileSystemLoader(
+        $this->assertValidLoaderFindReturn($this->getFileSystemLoader($root)->find($path));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp {Method .+ expects a LocatorInterface for the forth argument}
+     */
+    public function testThrowsIfConstructionArgumentsInvalid()
+    {
+        new FileSystemLoader(
             MimeTypeGuesser::getInstance(),
             ExtensionGuesser::getInstance(),
-            $rootDirs,
-            $this->getLocator()
+            array(__DIR__),
+            'not-instance-of-locator'
         );
+    }
 
-        $binary = $loader->find($path);
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
+     * @expectedExceptionMessage One or more data root paths must be specified
+     */
+    public function testThrowsIfZeroCountRootPathArray()
+    {
+        $this->getFileSystemLoader(array());
+    }
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\FileBinary', $binary);
-        $this->assertStringStartsWith('text/', $binary->getMimeType());
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Root image path not resolvable
+     */
+    public function testThrowsIfEmptyRootPath()
+    {
+        $this->getFileSystemLoader('');
+    }
+
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Root image path not resolvable
+     */
+    public function testThrowsIfRootPathDoesNotExist()
+    {
+        $this->getFileSystemLoader('/a/bad/root/path');
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideOutsideRootPathsData()
+    {
+        return array(
+            array('../Loader/../../Binary/Loader/../../../Resources/config/routing.xml'),
+            array('../../Binary/'),
+        );
+    }
+
+    /**
+     * @dataProvider provideOutsideRootPathsData
+     *
+     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
+     * @expectedExceptionMessage Source image invalid
+     */
+    public function testThrowsIfRealPathOutsideRootPath($path)
+    {
+        $this->getFileSystemLoader()->find($path);
+    }
+
+    public function testPathWithDoublePeriodBackStep()
+    {
+        $this->assertValidLoaderFindReturn($this->getFileSystemLoader()->find('/../../Binary/Loader/'.pathinfo(__FILE__, PATHINFO_BASENAME)));
+    }
+
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
+     * @expectedExceptionMessage Source image not resolvable
+     */
+    public function testThrowsIfFileDoesNotExist()
+    {
+        $this->getFileSystemLoader()->find('fileNotExist');
+    }
+
+    /**
+     * @return FileSystemLocator
+     */
+    private function getFileSystemLocator()
+    {
+        return new FileSystemLocator();
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getDefaultDataRoots()
+    {
+        return array(__DIR__);
+    }
+
+    /**
+     * @param string|array|null     $root
+     * @param LocatorInterface|null $locator
+     *
+     * @return FileSystemLoader
+     */
+    private function getFileSystemLoader($root = null, LocatorInterface $locator = null)
+    {
+        return new FileSystemLoader(
+            MimeTypeGuesser::getInstance(),
+            ExtensionGuesser::getInstance(),
+            null !== $root ? $root : $this->getDefaultDataRoots(),
+            null !== $locator ? $locator : $this->getFileSystemLocator()
+        );
+    }
+
+    /**
+     * @param FileBinary|mixed $return
+     * @param string|null      $message
+     */
+    private function assertValidLoaderFindReturn($return, $message = null)
+    {
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\FileBinary', $return, $message);
+        $this->assertStringStartsWith('text/', $return->getMimeType(), $message);
     }
 }

--- a/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
@@ -75,14 +75,23 @@ abstract class AbstractFileSystemLocatorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($this->getLocator($rootDirs)->locate($path));
     }
 
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid options provided to
+     */
     public function testThrowsExceptionOnInvalidOptions()
     {
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\InvalidArgumentException',
-            'Invalid options provided to'
-        );
-
         $locator = $this->getLocator(__DIR__);
         $locator->setOptions(array('foo' => 'bar'));
+    }
+
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
+     * @expectedExceptionMessage Invalid root placeholder "invalid-placeholder" for path
+     */
+    public function testThrowsExceptionOnInvalidNamedLoadCase()
+    {
+        $loader = $this->getLocator(__DIR__);
+        $loader->locate('@invalid-placeholder:file.ext');
     }
 }

--- a/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
@@ -94,4 +94,18 @@ class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
             return array(array($prepend[mt_rand(0, count($prepend) - 1)], $params[0]), $params[1]);
         }, static::provideLoadCases());
     }
+
+    public function testNamedLoadCases()
+    {
+        $root01 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-01');
+        $root02 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02');
+
+        $loader = $this->getLocator(array(
+            'root-01' => $root01,
+            'root-02' => $root02,
+        ));
+
+        $this->assertStringStartsWith($root01, $loader->locate('@root-01:file.ext'));
+        $this->assertStringStartsWith($root02, $loader->locate('@root-02:root-01/file.ext'));
+    }
 }

--- a/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
@@ -22,7 +22,7 @@ class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
     /**
      * @return LocatorInterface
      */
-    protected function getLocator($paths)
+    protected function getFileSystemLocator($paths)
     {
         $locator = new FileSystemInsecureLocator();
         $locator->setOptions(array('roots' => (array) $paths));
@@ -30,45 +30,38 @@ class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
         return $locator;
     }
 
-    public function testThrowExceptionIfRealPathIsOutsideRootPath1()
-    {
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException',
-            'Source image not resolvable'
-        );
-
-        $locator = $this->getLocator(__DIR__);
-        $locator->locate('../Loader/../../Binary/Loader/../../../Resources/config/routing.xml');
-    }
-
-    public function testThrowExceptionIfRealPathIsOutsideRootPath2()
-    {
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException',
-            'Source image not resolvable'
-        );
-
-        $loader = $this->getLocator(__DIR__);
-        $loader->locate('../../Binary/');
-    }
-
     public function testLoadsOnSymbolicLinks()
     {
-        $loader = $this->getLocator($root = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02'));
+        $loader = $this->getFileSystemLocator($root = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02'));
         $this->assertStringStartsWith(realpath($root), $loader->locate('root-01/file.ext'));
     }
 
-    public function testThrowsOnUpDirectoryInPaths()
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
+     * @expectedExceptionMessage Source image not resolvable
+     */
+    public function testThrowsIfPathHasDoublePeriodBackStep()
     {
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException',
-            'Source image not resolvable'
-        );
-
-        $loader = $this->getLocator($root = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02'));
-        $this->assertStringStartsWith(realpath($root), $loader->locate('/../root-01/file.ext'));
+        $this->getFileSystemLocator(realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02'))->locate('/../root-01/file.ext');
     }
 
+    public function testRootPlaceholders()
+    {
+        $root01 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-01');
+        $root02 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02');
+
+        $loader = $this->getFileSystemLocator(array(
+            'root-01' => $root01,
+            'root-02' => $root02,
+        ));
+
+        $this->assertStringStartsWith($root01, $loader->locate('@root-01:file.ext'));
+        $this->assertStringStartsWith($root02, $loader->locate('@root-02:root-01/file.ext'));
+    }
+
+    /**
+     * @return array[]
+     */
     public static function provideLoadCases()
     {
         $fileName = pathinfo(__FILE__, PATHINFO_BASENAME);
@@ -82,6 +75,9 @@ class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
         );
     }
 
+    /**
+     * @return array[]
+     */
     public static function provideMultipleRootLoadCases()
     {
         $prepend = array(
@@ -93,19 +89,5 @@ class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
         return array_map(function ($params) use ($prepend) {
             return array(array($prepend[mt_rand(0, count($prepend) - 1)], $params[0]), $params[1]);
         }, static::provideLoadCases());
-    }
-
-    public function testNamedLoadCases()
-    {
-        $root01 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-01');
-        $root02 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02');
-
-        $loader = $this->getLocator(array(
-            'root-01' => $root01,
-            'root-02' => $root02,
-        ));
-
-        $this->assertStringStartsWith($root01, $loader->locate('@root-01:file.ext'));
-        $this->assertStringStartsWith($root02, $loader->locate('@root-02:root-01/file.ext'));
     }
 }

--- a/Tests/Binary/Locator/FileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemLocatorTest.php
@@ -89,4 +89,18 @@ class FileSystemLocatorTest extends AbstractFileSystemLocatorTest
             return array(array($prepend[mt_rand(0, count($prepend) - 1)], $params[0]), $params[1]);
         }, static::provideLoadCases());
     }
+
+    public function testNamedLoadCases()
+    {
+        $root01 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-01');
+        $root02 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02');
+
+        $loader = $this->getLocator(array(
+            'root-01' => $root01,
+            'root-02' => $root02,
+        ));
+
+        $this->assertStringStartsWith($root01, $loader->locate('@root-01:file.ext'));
+        $this->assertStringStartsWith($root01, $loader->locate('@root-02:root-01/file.ext'));
+    }
 }

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -48,7 +48,8 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $loader = new FileSystemLoaderFactory();
 
         $loader->create($container, 'the_loader_name', array(
-            'data_root' => 'theDataRoot',
+            'bundle_resources' => false,
+            'data_root' => array('theDataRoot'),
             'locator' => 'filesystem',
         ));
 
@@ -59,7 +60,27 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $this->assertInstanceOfChildDefinition($loaderDefinition);
         $this->assertEquals('liip_imagine.binary.loader.prototype.filesystem', $loaderDefinition->getParent());
 
-        $this->assertEquals('theDataRoot', $loaderDefinition->getArgument(2));
+        $this->assertEquals(array('theDataRoot'), $loaderDefinition->getArgument(2));
+    }
+
+    public function testCreateLoaderDefinitionOnCreateWithBundlesEnabled()
+    {
+        $container = new ContainerBuilder();
+
+        // We need at least an empty bundle parameter
+        $container->setParameter('kernel.bundles', array());
+
+        $loader = new FileSystemLoaderFactory();
+
+        $loader->create($container, 'the_loader_name', array(
+            'bundle_resources' => true,
+            'data_root' => array('theDataRoot'),
+            'locator' => 'filesystem',
+        ));
+
+        $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.the_loader_name');
+
+        $this->assertEquals(array('theDataRoot'), $loaderDefinition->getArgument(2));
     }
 
     public function testProcessCorrectlyOptionsOnAddConfiguration()

--- a/Tests/Functional/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Functional/Binary/Loader/FileSystemLoaderTest.php
@@ -29,18 +29,10 @@ class FileSystemLoaderTest extends WebTestCase
         return $this->getService(sprintf('liip_imagine.binary.loader.%s', $name));
     }
 
-    private function getPrivateProperty($object, $name)
-    {
-        $r = new \ReflectionObject($object);
-
-        $p = $r->getProperty($name);
-        $p->setAccessible(true);
-
-        return $p->getValue($object);
-    }
-
     public function testMultipleLoadersContainIndependentLocators()
     {
+        $this->createClient();
+
         $fooLoader = $this->getLoader('foo');
         $barLoader = $this->getLoader('bar');
 

--- a/Tests/Functional/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Functional/Binary/Loader/FileSystemLoaderTest.php
@@ -29,9 +29,9 @@ class FileSystemLoaderTest extends WebTestCase
         return $this->getService(sprintf('liip_imagine.binary.loader.%s', $name));
     }
 
-    public function testMultipleLoadersContainIndependentLocators()
+    public function testMultipleLoadersHaveDifferentLocatorInstances()
     {
-        $this->createClient();
+        static::createClient();
 
         $fooLoader = $this->getLoader('foo');
         $barLoader = $this->getLoader('bar');

--- a/Tests/Functional/Binary/Locator/FileSystemLocatorTest.php
+++ b/Tests/Functional/Binary/Locator/FileSystemLocatorTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Functional\Binary\Locator;
+
+use Liip\ImagineBundle\Binary\Locator\FileSystemLocator;
+use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
+use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+
+/**
+ * @covers \Liip\ImagineBundle\Binary\Locator\FileSystemLocator
+ */
+class FileSystemLocatorTest extends WebTestCase
+{
+    /**
+     * @param string $name
+     *
+     * @return FileSystemLocator
+     */
+    private function getLoaderLocator($name)
+    {
+        return $this->getPrivateProperty($this->getService(sprintf('liip_imagine.binary.loader.%s', $name)), 'locator');
+    }
+
+    public function testBundleResourcesAll()
+    {
+        $this->createClient();
+
+        $locator = $this->getLoaderLocator('bundles_all');
+        $roots = $this->getPrivateProperty($locator, 'roots');
+
+        $this->assertTrue(count($roots) >= 2);
+        $this->assertStringEndsWith('FooBundle/Resources/public', $roots['LiipFooBundle']);
+        $this->assertStringEndsWith('BarBundle/Resources/public', $roots['LiipBarBundle']);
+
+        $this->assertFooBundleResourcesExist($locator);
+        $this->assertBarBundleResourcesExist($locator);
+    }
+
+    public function testBundleResourcesOnlyFoo()
+    {
+        $this->createClient();
+
+        $locator = $this->getLoaderLocator('bundles_only_foo');
+        $roots = $this->getPrivateProperty($locator, 'roots');
+
+        $this->assertTrue(count($roots) >= 1);
+        $this->assertStringEndsWith('FooBundle/Resources/public', $roots['LiipFooBundle']);
+
+        $this->assertFooBundleResourcesExist($locator);
+    }
+
+    public function testBundleResourcesOnlyBar()
+    {
+        $this->createClient();
+
+        $locator = $this->getLoaderLocator('bundles_only_bar');
+        $roots = $this->getPrivateProperty($locator, 'roots');
+
+        $this->assertTrue(count($roots) >= 1);
+        $this->assertStringEndsWith('BarBundle/Resources/public', $roots['LiipBarBundle']);
+
+        $this->assertBarBundleResourcesExist($locator, true);
+    }
+
+    /**
+     * @param LocatorInterface $locator
+     */
+    private function assertFooBundleResourcesExist(LocatorInterface $locator)
+    {
+        $this->assertLocatedFileContentsStartsWith($locator, 'file.ext', 'Fixtures/FooBundle');
+        $this->assertLocatedFileContentsStartsWith($locator, '@LiipFooBundle:file.ext', 'Fixtures/FooBundle');
+        $this->assertLocatedFileContentsStartsWith($locator, 'foo-bundle-file.ext', 'Fixtures/FooBundle');
+        $this->assertLocatedFileContentsStartsWith($locator, '@LiipFooBundle:foo-bundle-file.ext', 'Fixtures/FooBundle');
+    }
+
+    /**
+     * @param LocatorInterface $locator
+     * @param bool             $only
+     */
+    private function assertBarBundleResourcesExist(LocatorInterface $locator, $only = false)
+    {
+        $this->assertLocatedFileContentsStartsWith($locator, 'file.ext', $only ? 'Fixtures/BarBundle' : 'Fixtures/FooBundle');
+        $this->assertLocatedFileContentsStartsWith($locator, '@LiipBarBundle:file.ext', 'Fixtures/BarBundle');
+        $this->assertLocatedFileContentsStartsWith($locator, 'bar-bundle-file.ext', 'Fixtures/BarBundle');
+        $this->assertLocatedFileContentsStartsWith($locator, '@LiipBarBundle:bar-bundle-file.ext', 'Fixtures/BarBundle');
+    }
+
+    /**
+     * @param LocatorInterface $locator
+     * @param string           $filePath
+     * @param string           $expectedContents
+     * @param string|null      $message
+     */
+    private function assertLocatedFileContentsStartsWith(LocatorInterface $locator, $filePath, $expectedContents, $message = null)
+    {
+        $fileContents = file_get_contents($locator->locate($filePath));
+
+        $this->assertStringStartsWith($expectedContents, $fileContents, $message);
+    }
+}

--- a/Tests/Functional/Binary/Locator/FileSystemLocatorTest.php
+++ b/Tests/Functional/Binary/Locator/FileSystemLocatorTest.php
@@ -25,16 +25,16 @@ class FileSystemLocatorTest extends WebTestCase
      *
      * @return FileSystemLocator
      */
-    private function getLoaderLocator($name)
+    private function getFileSystemLoaderLocator($name)
     {
         return $this->getPrivateProperty($this->getService(sprintf('liip_imagine.binary.loader.%s', $name)), 'locator');
     }
 
-    public function testBundleResourcesAll()
+    public function testBundleResourcesOnAllLoader()
     {
-        $this->createClient();
+        static::createClient();
 
-        $locator = $this->getLoaderLocator('bundles_all');
+        $locator = $this->getFileSystemLoaderLocator('bundles_all');
         $roots = $this->getPrivateProperty($locator, 'roots');
 
         $this->assertTrue(count($roots) >= 2);
@@ -45,11 +45,11 @@ class FileSystemLocatorTest extends WebTestCase
         $this->assertBarBundleResourcesExist($locator);
     }
 
-    public function testBundleResourcesOnlyFoo()
+    public function testBundleResourcesOnFooLoader()
     {
-        $this->createClient();
+        static::createClient();
 
-        $locator = $this->getLoaderLocator('bundles_only_foo');
+        $locator = $this->getFileSystemLoaderLocator('bundles_only_foo');
         $roots = $this->getPrivateProperty($locator, 'roots');
 
         $this->assertTrue(count($roots) >= 1);
@@ -58,11 +58,11 @@ class FileSystemLocatorTest extends WebTestCase
         $this->assertFooBundleResourcesExist($locator);
     }
 
-    public function testBundleResourcesOnlyBar()
+    public function testBundleResourcesOnBarLoader()
     {
-        $this->createClient();
+        static::createClient();
 
-        $locator = $this->getLoaderLocator('bundles_only_bar');
+        $locator = $this->getFileSystemLoaderLocator('bundles_only_bar');
         $roots = $this->getPrivateProperty($locator, 'roots');
 
         $this->assertTrue(count($roots) >= 1);
@@ -102,8 +102,6 @@ class FileSystemLocatorTest extends WebTestCase
      */
     private function assertLocatedFileContentsStartsWith(LocatorInterface $locator, $filePath, $expectedContents, $message = null)
     {
-        $fileContents = file_get_contents($locator->locate($filePath));
-
-        $this->assertStringStartsWith($expectedContents, $fileContents, $message);
+        $this->assertStringStartsWith($expectedContents, file_get_contents($locator->locate($filePath)), $message);
     }
 }

--- a/Tests/Functional/Fixtures/BarBundle/LiipBarBundle.php
+++ b/Tests/Functional/Fixtures/BarBundle/LiipBarBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Functional\Fixtures\BarBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class LiipBarBundle extends Bundle
+{
+}

--- a/Tests/Functional/Fixtures/BarBundle/Resources/public/bar-bundle-file.ext
+++ b/Tests/Functional/Fixtures/BarBundle/Resources/public/bar-bundle-file.ext
@@ -1,0 +1,1 @@
+Fixtures/BarBundle/Resources/public/foo-bundle-file.ext

--- a/Tests/Functional/Fixtures/BarBundle/Resources/public/file.ext
+++ b/Tests/Functional/Fixtures/BarBundle/Resources/public/file.ext
@@ -1,0 +1,1 @@
+Fixtures/BarBundle/Resources/public/file.ext

--- a/Tests/Functional/Fixtures/FooBundle/LiipFooBundle.php
+++ b/Tests/Functional/Fixtures/FooBundle/LiipFooBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Functional\Fixtures\FooBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class LiipFooBundle extends Bundle
+{
+}

--- a/Tests/Functional/Fixtures/FooBundle/Resources/public/file.ext
+++ b/Tests/Functional/Fixtures/FooBundle/Resources/public/file.ext
@@ -1,0 +1,1 @@
+Fixtures/FooBundle/Resources/public/file.ext

--- a/Tests/Functional/Fixtures/FooBundle/Resources/public/foo-bundle-file.ext
+++ b/Tests/Functional/Fixtures/FooBundle/Resources/public/foo-bundle-file.ext
@@ -1,0 +1,1 @@
+Fixtures/FooBundle/Resources/public/foo-bundle-file.ext

--- a/Tests/Functional/WebTestCase.php
+++ b/Tests/Functional/WebTestCase.php
@@ -12,6 +12,7 @@
 namespace Liip\ImagineBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
+use Symfony\Component\HttpKernel\Kernel;
 
 abstract class WebTestCase extends BaseWebTestCase
 {
@@ -32,10 +33,6 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected function getService($name)
     {
-        if (!static::$kernel) {
-            $this->createClient();
-        }
-
         return static::$kernel->getContainer()->get($name);
     }
 
@@ -46,10 +43,22 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected function getParameter($name)
     {
-        if (!static::$kernel) {
-            $this->createClient();
-        }
-
         return static::$kernel->getContainer()->getParameter($name);
+    }
+
+    /**
+     * @param object $object
+     * @param string $name
+     *
+     * @return mixed
+     */
+    protected function getPrivateProperty($object, $name)
+    {
+        $r = new \ReflectionObject($object);
+
+        $p = $r->getProperty($name);
+        $p->setAccessible(true);
+
+        return $p->getValue($object);
     }
 }

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -24,6 +24,8 @@ class AppKernel extends Kernel
         $bundles = array(
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Liip\ImagineBundle\LiipImagineBundle(),
+            new \Liip\ImagineBundle\Tests\Functional\Fixtures\FooBundle\LiipFooBundle(),
+            new \Liip\ImagineBundle\Tests\Functional\Fixtures\BarBundle\LiipBarBundle(),
         );
 
         return $bundles;

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -25,6 +25,27 @@ liip_imagine:
         bar:
             filesystem:
                 data_root: "%kernel.root_dir%/../../Fixtures/FileSystemLocator/root-02"
+        bundles_all:
+            filesystem:
+                data_root: ~
+                bundle_resources:
+                    enabled: true
+        bundles_only_foo:
+            filesystem:
+                data_root: ~
+                bundle_resources:
+                    enabled: true
+                    access_control_type: blacklist
+                    access_control_list:
+                        - LiipBarBundle
+        bundles_only_bar:
+            filesystem:
+                data_root: ~
+                bundle_resources:
+                    enabled: true
+                    access_control_type: whitelist
+                    access_control_list:
+                        - LiipBarBundle
     resolvers:
         default:
             web_path:


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | 
| Fixed tickets | #881
| License | MIT
| Doc PR | Not yet, will be made after approval

This change adds the functionality to add bundle public resource paths automatically when the `bundle_resources` option is set. See #881 for the discussion on this.