### PR TITLE
[Tests] Assert expected deprecation using symfony/phpunit-bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 
+sudo: false
+
 language: php
 
 php:
@@ -11,14 +13,14 @@ php:
   - 7.1
   - hhvm
 
-sudo: false
-
 cache:
   directories:
     - $HOME/.composer/cache/files
 
 env:
-  - SYMFONY_VERSION=2.8.x
+  global:
+    - SYMFONY_VERSION=2.8.x
+    - SYMFONY_DEPRECATIONS_HELPER=weak
 
 matrix:
   include:
@@ -58,7 +60,7 @@ install:
   - travis_retry composer update $COMPOSER_FLAGS
 
 script:
-  - SYMFONY_DEPRECATIONS_HELPER=weak ./bin/phpunit -vvv
+  - bin/simple-phpunit -vvv || bin/phpunit -vvv
 
 after_script:
   - if [ "${TRAVIS_PHP_VERSION}" != "5.3" ]; then bin/coveralls -vvv; fi;

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -84,10 +84,13 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideLoadCases
      *
+     * @group legacy
+     * @expectedDeprecation Method %s() will have a forth `LocatorInterface $locator` argument in version 2.0. Not defining it is deprecated since version 1.7.2
+     *
      * @param string $root
      * @param string $path
      */
-    public function testDeprecatedConstruction($root, $path)
+    public function testLegacyConstruction($root, $path)
     {
         $loader = new FileSystemLoader(
             MimeTypeGuesser::getInstance(),

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "doctrine/orm": "~2.3",
         "ext-gd": "*",
         "friendsofphp/php-cs-fixer": "~2.0",
-        "phpunit/phpunit": "~4.3",
+        "phpunit/phpunit": "~4.3|~5.0",
         "psr/log": "~1.0",
         "satooshi/php-coveralls": "~1.0",
         "sllh/php-cs-fixer-styleci-bridge": "~2.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | 
| License | MIT
| Doc PR | 

Use Symfony's `phpunit-bridge` to properly test deprecation messages.