### PR TITLE
[Tests] Support PHPUnit 5.x (and remove depredations)

### DIFF
--- a/Binary/Locator/FileSystemLocator.php
+++ b/Binary/Locator/FileSystemLocator.php
@@ -21,7 +21,7 @@ class FileSystemLocator implements LocatorInterface
     /**
      * @var string[]
      */
-    private $roots;
+    private $roots = array();
 
     /**
      * @param array[] $options

--- a/DependencyInjection/Compiler/LocatorsCompilerPass.php
+++ b/DependencyInjection/Compiler/LocatorsCompilerPass.php
@@ -22,7 +22,7 @@ class LocatorsCompilerPass extends AbstractCompilerPass
     {
         foreach ($container->findTaggedServiceIds('liip_imagine.binary.locator') as $id => $tags) {
             if (isset($tags[0]['shared'])) {
-                $this->setDefinitionSharing($container->getDefinition($id), $tags[0]['shared']);
+                $this->setDefinitionSharing($container->getDefinition($id), (bool) $tags[0]['shared']);
             }
         }
     }

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -86,7 +86,6 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
             ->end();
     }
 
-
     /*
      * @param string[]         $staticPaths
      * @param array            $config

--- a/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
@@ -25,12 +25,12 @@ class AwsS3ResolverFactory implements ResolverFactoryInterface
     public function create(ContainerBuilder $container, $resolverName, array $config)
     {
         $awsS3ClientId = 'liip_imagine.cache.resolver.'.$resolverName.'.client';
-        $awsS3ClientDefinition = new Definition('Aws\S3\S3Client');
+        $awsS3ClientDefinition = new Definition('\Aws\S3\S3Client');
         if (method_exists($awsS3ClientDefinition, 'setFactory')) {
-            $awsS3ClientDefinition->setFactory(array('Aws\S3\S3Client', 'factory'));
+            $awsS3ClientDefinition->setFactory(array('\Aws\S3\S3Client', 'factory'));
         } else {
             // to be removed when dependency on Symfony DependencyInjection is bumped to 2.6
-            $awsS3ClientDefinition->setFactoryClass('Aws\S3\S3Client');
+            $awsS3ClientDefinition->setFactoryClass('\Aws\S3\S3Client');
             $awsS3ClientDefinition->setFactoryMethod('factory');
         }
         $awsS3ClientDefinition->addArgument($config['client_config']);

--- a/Tests/Binary/Loader/AbstractDoctrineLoaderTest.php
+++ b/Tests/Binary/Loader/AbstractDoctrineLoaderTest.php
@@ -15,35 +15,53 @@ use Doctrine\Common\Persistence\ObjectRepository;
 use Liip\ImagineBundle\Binary\Loader\AbstractDoctrineLoader;
 
 /**
- * @covers Liip\ImagineBundle\Binary\Loader\AbstractDoctrineLoader<extended>
+ * @covers \Liip\ImagineBundle\Binary\Loader\AbstractDoctrineLoader<extended>
  */
 class AbstractDoctrineLoaderTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var ObjectRepository
+     * @var \PHPUnit_Framework_MockObject_MockObject|ObjectRepository
      */
     private $om;
 
     /**
-     * @var AbstractDoctrineLoader
+     * @var \PHPUnit_Framework_MockObject_MockObject|AbstractDoctrineLoader
      */
     private $loader;
 
     public function setUp()
     {
-        $this->om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->om = $this
+            ->getMockBuilder('\Doctrine\Common\Persistence\ObjectManager')
+            ->getMock();
 
-        $this->loader = $this->getMockBuilder('Liip\ImagineBundle\Binary\Loader\AbstractDoctrineLoader')->setConstructorArgs(array($this->om))->getMockForAbstractClass();
+        $this->loader = $this
+            ->getMockBuilder('\Liip\ImagineBundle\Binary\Loader\AbstractDoctrineLoader')
+            ->setConstructorArgs(array($this->om))
+            ->getMockForAbstractClass();
     }
 
     public function testFindWithValidObjectFirstHit()
     {
         $image = new \stdClass();
 
-        $this->loader->expects($this->atLeastOnce())->method('mapPathToId')->with('/foo/bar')->will($this->returnValue(1337));
-        $this->loader->expects($this->atLeastOnce())->method('getStreamFromImage')->with($image)->will($this->returnValue(fopen('data://text/plain,foo', 'r')));
+        $this->loader
+            ->expects($this->atLeastOnce())
+            ->method('mapPathToId')
+            ->with('/foo/bar')
+            ->will($this->returnValue(1337));
 
-        $this->om->expects($this->atLeastOnce())->method('find')->with(null, 1337)->will($this->returnValue($image));
+        $this->loader
+            ->expects($this->atLeastOnce())
+            ->method('getStreamFromImage')
+            ->with($image)
+            ->will($this->returnValue(fopen('data://text/plain,foo', 'r')));
+
+        $this->om
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->with(null, 1337)
+            ->will($this->returnValue($image));
 
         $this->assertEquals('foo', $this->loader->find('/foo/bar'));
     }
@@ -52,17 +70,27 @@ class AbstractDoctrineLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $image = new \stdClass();
 
-        $this->loader->expects($this->atLeastOnce())->method('mapPathToId')->will($this->returnValueMap(array(
-            array('/foo/bar.png', 1337),
-            array('/foo/bar', 4711),
-        )));
+        $this->loader
+            ->expects($this->atLeastOnce())
+            ->method('mapPathToId')
+            ->will($this->returnValueMap(array(
+                array('/foo/bar.png', 1337),
+                array('/foo/bar', 4711),
+            )));
 
-        $this->loader->expects($this->atLeastOnce())->method('getStreamFromImage')->with($image)->will($this->returnValue(fopen('data://text/plain,foo', 'r')));
+        $this->loader
+            ->expects($this->atLeastOnce())
+            ->method('getStreamFromImage')
+            ->with($image)
+            ->will($this->returnValue(fopen('data://text/plain,foo', 'r')));
 
-        $this->om->expects($this->atLeastOnce())->method('find')->will($this->returnValueMap(array(
-            array(null, 1337, null),
-            array(null, 4711, $image),
-        )));
+        $this->om
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->will($this->returnValueMap(array(
+                array(null, 1337, null),
+                array(null, 4711, $image),
+            )));
 
         $this->assertEquals('foo', $this->loader->find('/foo/bar.png'));
     }
@@ -72,10 +100,21 @@ class AbstractDoctrineLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testFindWithInvalidObject()
     {
-        $this->loader->expects($this->atLeastOnce())->method('mapPathToId')->with('/foo/bar')->will($this->returnValue(1337));
-        $this->loader->expects($this->never())->method('getStreamFromImage');
+        $this->loader
+            ->expects($this->atLeastOnce())
+            ->method('mapPathToId')
+            ->with('/foo/bar')
+            ->will($this->returnValue(1337));
 
-        $this->om->expects($this->atLeastOnce())->method('find')->with(null, 1337)->will($this->returnValue(null));
+        $this->loader
+            ->expects($this->never())
+            ->method('getStreamFromImage');
+
+        $this->om
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->with(null, 1337)
+            ->will($this->returnValue(null));
 
         $this->loader->find('/foo/bar');
     }

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -23,16 +23,14 @@ use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
  */
 class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    public function testImplementsLoaderInterface()
-    {
-        $r = new \ReflectionClass('Liip\ImagineBundle\Binary\Loader\FileSystemLoader');
-
-        $this->assertTrue($r->implementsInterface('Liip\ImagineBundle\Binary\Loader\LoaderInterface'));
-    }
-
     public function testConstruction()
     {
         $this->getFileSystemLoader();
+    }
+
+    public function testImplementsLoaderInterface()
+    {
+        $this->assertInstanceOf('\Liip\ImagineBundle\Binary\Loader\LoaderInterface', $this->getFileSystemLoader());
     }
 
     /**

--- a/Tests/Binary/Loader/StreamLoaderTest.php
+++ b/Tests/Binary/Loader/StreamLoaderTest.php
@@ -15,54 +15,46 @@ use Liip\ImagineBundle\Binary\Loader\StreamLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Binary\Loader\StreamLoader<extended>
+ * @covers \Liip\ImagineBundle\Binary\Loader\StreamLoader<extended>
  */
 class StreamLoaderTest extends AbstractTest
 {
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
+     * @expectedExceptionMessageRegExp {Source image file://.+ not found.}
+     */
     public function testThrowsIfInvalidPathGivenOnFind()
     {
         $loader = new StreamLoader('file://');
-
-        $path = $this->tempDir.'/invalid.jpeg';
-
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException',
-            'Source image file://'.$path.' not found.'
-        );
-
-        $loader->find($path);
+        $loader->find($this->temporaryPath.'/invalid.jpeg');
     }
 
     public function testReturnImageContentOnFind()
     {
-        $expectedContent = file_get_contents($this->fixturesDir.'/assets/cats.jpeg');
-
         $loader = new StreamLoader('file://');
 
         $this->assertSame(
-            $expectedContent,
-            $loader->find($this->fixturesDir.'/assets/cats.jpeg')
+            file_get_contents($this->fixturesPath.'/assets/cats.jpeg'),
+            $loader->find($this->fixturesPath.'/assets/cats.jpeg')
         );
     }
 
     public function testReturnImageContentWhenStreamContextProvidedOnFind()
     {
-        $expectedContent = file_get_contents($this->fixturesDir.'/assets/cats.jpeg');
-
-        $context = stream_context_create();
-
-        $loader = new StreamLoader('file://', $context);
+        $loader = new StreamLoader('file://', stream_context_create());
 
         $this->assertSame(
-            $expectedContent,
-            $loader->find($this->fixturesDir.'/assets/cats.jpeg')
+            file_get_contents($this->fixturesPath.'/assets/cats.jpeg'),
+            $loader->find($this->fixturesPath.'/assets/cats.jpeg')
         );
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The given context is no valid resource
+     */
     public function testThrowsIfInvalidResourceGivenInConstructor()
     {
-        $this->setExpectedException('InvalidArgumentException', 'The given context is no valid resource.');
-
-        new StreamLoader('not valid resource', true);
+        new StreamLoader('an-invalid-resource-name', true);
     }
 }

--- a/Tests/Binary/SimpleMimeTypeGuesserTest.php
+++ b/Tests/Binary/SimpleMimeTypeGuesserTest.php
@@ -15,11 +15,32 @@ use Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 
 /**
- * @covers Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser<extended>
+ * @covers \Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser<extended>
  */
 class SimpleMimeTypeGuesserTest extends \PHPUnit_Framework_TestCase
 {
-    public function provideImages()
+    /**
+     * @return SimpleMimeTypeGuesser
+     */
+    private function getSimpleMimeTypeGuesser()
+    {
+        return new SimpleMimeTypeGuesser(MimeTypeGuesser::getInstance());
+    }
+
+    public function testCouldBeConstructedWithSymfonyMimeTypeGuesserAsFirstArgument()
+    {
+        $this->getSimpleMimeTypeGuesser();
+    }
+
+    public function testImplementsMimeTypeGuesserInterface()
+    {
+        $this->assertInstanceOf('\Liip\ImagineBundle\Binary\MimeTypeGuesserInterface', $this->getSimpleMimeTypeGuesser());
+    }
+
+    /**
+     * @return array[]
+     */
+    public static function provideImageData()
     {
         return array(
             'gif' => array(__DIR__.'/../Fixtures/assets/cats.gif', 'image/gif'),
@@ -30,25 +51,14 @@ class SimpleMimeTypeGuesserTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testImplementsMimeTypeGuesserInterface()
-    {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser');
-
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\Binary\MimeTypeGuesserInterface'));
-    }
-
-    public function testCouldBeConstructedWithSymfonyMimeTypeGuesserAsFirstArgument()
-    {
-        new SimpleMimeTypeGuesser(MimeTypeGuesser::getInstance());
-    }
-
     /**
-     * @dataProvider provideImages
+     * @dataProvider provideImageData
+     *
+     * @param string $fileName
+     * @param string $mimeType
      */
-    public function testGuessMimeType($imageFile, $expectedMimeType)
+    public function testGuessMimeType($fileName, $mimeType)
     {
-        $guesser = new SimpleMimeTypeGuesser(MimeTypeGuesser::getInstance());
-
-        $this->assertEquals($expectedMimeType, $guesser->guess(file_get_contents($imageFile)));
+        $this->assertEquals($mimeType, $this->getSimpleMimeTypeGuesser()->guess(file_get_contents($fileName)));
     }
 }

--- a/Tests/Controller/ImagineControllerTest.php
+++ b/Tests/Controller/ImagineControllerTest.php
@@ -12,63 +12,21 @@
 namespace Liip\ImagineBundle\Tests\Controller;
 
 use Liip\ImagineBundle\Controller\ImagineController;
-use Liip\ImagineBundle\Imagine\Cache\CacheManager;
-use Liip\ImagineBundle\Imagine\Data\DataManager;
-use Liip\ImagineBundle\Imagine\Filter\FilterManager;
+use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Controller\ImagineController
+ * @covers \Liip\ImagineBundle\Controller\ImagineController
  */
-class ImagineControllerTest extends \PHPUnit_Framework_TestCase
+class ImagineControllerTest extends AbstractTest
 {
-    public function testCouldBeConstructedWithExpectedServices()
+    public function testConstruction()
     {
         new ImagineController(
             $this->createDataManagerMock(),
             $this->createFilterManagerMock(),
             $this->createCacheManagerMock(),
-            $this->createSignerMock(),
-            $this->createLoggerMock()
+            $this->createSignerInterfaceMock(),
+            $this->createLoggerInterfaceMock()
         );
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|DataManager
-     */
-    protected function createDataManagerMock()
-    {
-        return $this->getMock('Liip\ImagineBundle\Imagine\Data\DataManager', array(), array(), '', false);
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|FilterManager
-     */
-    protected function createFilterManagerMock()
-    {
-        return $this->getMock('Liip\ImagineBundle\Imagine\Filter\FilterManager', array(), array(), '', false);
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|CacheManager
-     */
-    protected function createCacheManagerMock()
-    {
-        return $this->getMock('Liip\ImagineBundle\Imagine\Cache\CacheManager', array(), array(), '', false);
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Liip\ImagineBundle\Imagine\Cache\SignerInterface
-     */
-    protected function createSignerMock()
-    {
-        return $this->getMock('Liip\ImagineBundle\Imagine\Cache\Signer', array(), array(), '', false);
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Psr\Log\LoggerInterface
-     */
-    protected function createLoggerMock()
-    {
-        return $this->getMock('Psr\Log\LoggerInterface');
     }
 }

--- a/Tests/DependencyInjection/Compiler/MetadataReaderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MetadataReaderCompilerPassTest.php
@@ -38,7 +38,7 @@ class MetadataReaderCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     private static function getReaderParamAndDefaultAndExifValues()
     {
-        $r = new \ReflectionClass('Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass');
+        $r = new \ReflectionClass('\Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass');
 
         return array(
             static::getVisibilityRestrictedStaticProperty($r, 'metadataReaderParameter'),
@@ -54,7 +54,7 @@ class MetadataReaderCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     private function getMetadataReaderCompilerPass($return)
     {
-        $mock = $this->getMockBuilder('Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass')
+        $mock = $this->getMockBuilder('\Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass')
             ->setMethods(array('isExifExtensionLoaded'))
             ->getMock();
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -22,15 +22,15 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @covers Liip\ImagineBundle\DependencyInjection\Configuration
+ * @covers \Liip\ImagineBundle\DependencyInjection\Configuration
  */
 class ConfigurationTest extends \Phpunit_Framework_TestCase
 {
     public function testImplementsConfigurationInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\DependencyInjection\Configuration');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\DependencyInjection\Configuration');
 
-        $this->assertTrue($rc->implementsInterface('Symfony\Component\Config\Definition\ConfigurationInterface'));
+        $this->assertTrue($rc->implementsInterface('\Symfony\Component\Config\Definition\ConfigurationInterface'));
     }
 
     public function testCouldBeConstructedWithResolversAndLoadersFactoriesAsArguments()
@@ -146,9 +146,12 @@ class ConfigurationTest extends \Phpunit_Framework_TestCase
         $this->assertArrayHasKey('filesystem', $config['loaders']['default']);
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Loaders has to be array
+     */
     public function testThrowIfLoadersNotArray()
     {
-        $this->setExpectedException('LogicException', 'Loaders has to be array');
         $this->processConfiguration(
             new Configuration(
                 array(
@@ -336,9 +339,12 @@ class ConfigurationTest extends \Phpunit_Framework_TestCase
         $this->assertArrayHasKey('web_path', $config['resolvers']['default']);
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Resolvers has to be array
+     */
     public function testThrowsIfResolversNotArray()
     {
-        $this->setExpectedException('LogicException', 'Resolvers has to be array');
         $config = $this->processConfiguration(
             new Configuration(
                 array(

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -24,9 +24,9 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
 {
     public function testImplementsLoaderFactoryInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory');
 
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface'));
+        $this->assertTrue($rc->implementsInterface('\Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface'));
     }
 
     public function testCouldBeConstructedWithoutAnyArguments()

--- a/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
@@ -18,7 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @requires PHP 5.4
- * @covers Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory<extended>
+ *
+ * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory<extended>
  */
 class FlysystemLoaderFactoryTest extends \Phpunit_Framework_TestCase
 {
@@ -27,17 +28,15 @@ class FlysystemLoaderFactoryTest extends \Phpunit_Framework_TestCase
         parent::setUp();
 
         if (!class_exists('\League\Flysystem\Filesystem')) {
-            $this->markTestSkipped(
-              'The league/flysystem PHP library is not available.'
-            );
+            $this->markTestSkipped('Requires the league/flysystem package.');
         }
     }
 
     public function testImplementsLoaderFactoryInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory');
 
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface'));
+        $this->assertTrue($rc->implementsInterface('\Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface'));
     }
 
     public function testCouldBeConstructedWithoutAnyArguments()

--- a/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
@@ -17,15 +17,15 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @covers Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory<extended>
+ * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory<extended>
  */
 class StreamLoaderFactoryTest extends \Phpunit_Framework_TestCase
 {
     public function testImplementsLoaderFactoryInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory');
 
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface'));
+        $this->assertTrue($rc->implementsInterface('\Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface'));
     }
 
     public function testCouldBeConstructedWithoutAnyArguments()

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -24,9 +24,9 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 {
     public function testImplementsResolverFactoryInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory');
 
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface'));
+        $this->assertTrue($rc->implementsInterface('\Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface'));
     }
 
     public function testCouldBeConstructedWithoutAnyArguments()
@@ -61,10 +61,10 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
 
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $resolverDefinition->getParent());
 
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(0));
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(0));
         $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.client', $resolverDefinition->getArgument(0));
 
         $this->assertEquals('theBucket', $resolverDefinition->getArgument(1));
@@ -116,7 +116,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.client'));
 
         $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.client');
-        $this->assertEquals('Aws\S3\S3Client', $clientDefinition->getClass());
+        $this->assertEquals('\Aws\S3\S3Client', $clientDefinition->getClass());
         $this->assertEquals(array('theClientConfigKey' => 'theClientConfigVal'), $clientDefinition->getArgument(0));
     }
 
@@ -142,10 +142,13 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
         ));
 
         $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.client');
-        $this->assertEquals(array('Aws\S3\S3Client', 'factory'), $clientDefinition->getFactory());
+        $this->assertEquals(array('\Aws\S3\S3Client', 'factory'), $clientDefinition->getFactory());
     }
 
-    public function testLegacyCreateS3ClientDefinitionWithFactoryOnCreate()
+    /**
+     * @group legacy
+     */
+    public function testCreateS3ClientDefinitionWithFactoryOnCreateLegacy()
     {
         if (SymfonyFramework::isKernelGreaterThanOrEqualTo(2, 6)) {
             $this->markTestSkipped('No need to test on symfony >= 2.6');
@@ -167,7 +170,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
         ));
 
         $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.client');
-        $this->assertEquals('Aws\S3\S3Client', $clientDefinition->getFactoryClass());
+        $this->assertEquals('\Aws\S3\S3Client', $clientDefinition->getFactoryClass());
         $this->assertEquals('factory', $clientDefinition->getFactoryMethod());
     }
 
@@ -225,20 +228,20 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
         $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.cached');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $cachedResolverDefinition);
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\DefinitionDecorator', $cachedResolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $cachedResolverDefinition->getParent());
 
         $this->assertFalse($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.cache', $resolverDefinition->getParent());
 
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(0));
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(0));
         $this->assertEquals('the_cache_service_id', $resolverDefinition->getArgument(0));
 
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(1));
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(1));
         $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.cached', $resolverDefinition->getArgument(1));
     }
 
@@ -261,28 +264,28 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
         $proxiedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $proxiedResolverDefinition);
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\DefinitionDecorator', $proxiedResolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $proxiedResolverDefinition->getParent());
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
         $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.cached');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $cachedResolverDefinition);
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\DefinitionDecorator', $cachedResolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.proxy', $cachedResolverDefinition->getParent());
 
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $cachedResolverDefinition->getArgument(0));
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\Reference', $cachedResolverDefinition->getArgument(0));
         $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.proxied', $cachedResolverDefinition->getArgument(0));
 
         $this->assertEquals(array('foo'), $cachedResolverDefinition->getArgument(1));
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.cache', $resolverDefinition->getParent());
 
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(0));
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(0));
         $this->assertEquals('the_cache_service_id', $resolverDefinition->getArgument(0));
 
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(1));
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\Reference', $resolverDefinition->getArgument(1));
         $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.cached', $resolverDefinition->getArgument(1));
     }
 
@@ -305,15 +308,15 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
         $proxiedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $proxiedResolverDefinition);
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\DefinitionDecorator', $proxiedResolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $proxiedResolverDefinition->getParent());
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
         $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.cached');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $cachedResolverDefinition);
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\DefinitionDecorator', $cachedResolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.proxy', $cachedResolverDefinition->getParent());
 
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $cachedResolverDefinition->getArgument(0));
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\Reference', $cachedResolverDefinition->getArgument(0));
         $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.proxied', $cachedResolverDefinition->getArgument(0));
 
         $this->assertEquals(array('foo' => 'bar'), $cachedResolverDefinition->getArgument(1));

--- a/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @covers Liip\ImagineBundle\DependencyInjection\Factory\Resolver\FlysystemResolverFactory<extended>
+ * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Resolver\FlysystemResolverFactory<extended>
  */
 class FlysystemResolverFactoryTest extends \Phpunit_Framework_TestCase
 {
@@ -26,17 +26,15 @@ class FlysystemResolverFactoryTest extends \Phpunit_Framework_TestCase
         parent::setUp();
 
         if (!class_exists('\League\Flysystem\Filesystem')) {
-            $this->markTestSkipped(
-                'The league/flysystem PHP library is not available.'
-            );
+            $this->markTestSkipped('Requires the league/flysystem package.');
         }
     }
 
     public function testImplementsResolverFactoryInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\FlysystemResolverFactory');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\DependencyInjection\Factory\Resolver\FlysystemResolverFactory');
 
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface'));
+        $this->assertTrue($rc->implementsInterface('\Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface'));
     }
 
     public function testCouldBeConstructedWithoutAnyArguments()
@@ -67,7 +65,7 @@ class FlysystemResolverFactoryTest extends \Phpunit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
 
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.flysystem', $resolverDefinition->getParent());
 
         $this->assertEquals('http://images.example.com', $resolverDefinition->getArgument(2));

--- a/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
@@ -17,15 +17,15 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @covers Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory<extended>
+ * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory<extended>
  */
 class WebPathResolverFactoryTest extends \Phpunit_Framework_TestCase
 {
     public function testImplementsResolverFactoryInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory');
 
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface'));
+        $this->assertTrue($rc->implementsInterface('\Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface'));
     }
 
     public function testCouldBeConstructedWithoutAnyArguments()
@@ -54,7 +54,7 @@ class WebPathResolverFactoryTest extends \Phpunit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
 
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
+        $this->assertInstanceOf('\Symfony\Component\DependencyInjection\DefinitionDecorator', $resolverDefinition);
         $this->assertEquals('liip_imagine.cache.resolver.prototype.web_path', $resolverDefinition->getParent());
 
         $this->assertEquals('theWebRoot', $resolverDefinition->getArgument(2));

--- a/Tests/DependencyInjection/LiipImagineExtensionTest.php
+++ b/Tests/DependencyInjection/LiipImagineExtensionTest.php
@@ -39,8 +39,7 @@ class LiipImagineExtensionTest extends AbstractTest
     public function testUserLoadThrowsExceptionUnlessDriverIsValid()
     {
         $loader = new LiipImagineExtension();
-        $config = array('driver' => 'foo');
-        $loader->load(array($config), new ContainerBuilder());
+        $loader->load(array(array('driver' => 'foo')), new ContainerBuilder());
     }
 
     public function testLoadWithDefaults()
@@ -73,8 +72,22 @@ class LiipImagineExtensionTest extends AbstractTest
         $this->assertEquals('value1', $variable1, sprintf('%s parameter is correct', $variable1));
     }
 
+    public static function provideFactoryData()
+    {
+        return array(
+            array(
+                'liip_imagine.mime_type_guesser',
+                array('Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser', 'getInstance'),
+            ),
+            array(
+                'liip_imagine.extension_guesser',
+                array('Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser', 'getInstance'),
+            ),
+        );
+    }
+
     /**
-     * @dataProvider factoriesProvider
+     * @dataProvider provideFactoryData
      */
     public function testFactoriesConfiguration($service, $factory)
     {
@@ -89,10 +102,11 @@ class LiipImagineExtensionTest extends AbstractTest
     }
 
     /**
-     * @legacy
-     * @dataProvider factoriesProvider
+     * @group legacy
+     *
+     * @dataProvider provideFactoryData
      */
-    public function testLegacyFactoriesConfiguration($service, $factory)
+    public function testFactoriesConfigurationLegacy($service, $factory)
     {
         if (SymfonyFramework::isKernelGreaterThanOrEqualTo(2, 6)) {
             $this->markTestSkipped('No need to test on symfony >= 2.6');
@@ -105,20 +119,6 @@ class LiipImagineExtensionTest extends AbstractTest
         $this->assertEquals($factory[1], $definition->getFactoryMethod());
     }
 
-    public function factoriesProvider()
-    {
-        return array(
-            array(
-              'liip_imagine.mime_type_guesser',
-              array('Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser', 'getInstance'),
-            ),
-            array(
-              'liip_imagine.extension_guesser',
-              array('Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser', 'getInstance'),
-            ),
-        );
-    }
-
     protected function createEmptyConfiguration()
     {
         $this->containerBuilder = new ContainerBuilder();
@@ -126,6 +126,7 @@ class LiipImagineExtensionTest extends AbstractTest
         $loader->addLoaderFactory(new FileSystemLoaderFactory());
         $loader->addResolverFactory(new WebPathResolverFactory());
         $loader->load(array(array()), $this->containerBuilder);
+
         $this->assertTrue($this->containerBuilder instanceof ContainerBuilder);
     }
 
@@ -136,6 +137,7 @@ class LiipImagineExtensionTest extends AbstractTest
         $loader->addLoaderFactory(new FileSystemLoaderFactory());
         $loader->addResolverFactory(new WebPathResolverFactory());
         $loader->load(array($this->getFullConfig()), $this->containerBuilder);
+
         $this->assertTrue($this->containerBuilder instanceof ContainerBuilder);
     }
 

--- a/Tests/Events/CacheResolveEventTest.php
+++ b/Tests/Events/CacheResolveEventTest.php
@@ -14,7 +14,7 @@ namespace Liip\ImagineBundle\Tests\Events;
 use Liip\ImagineBundle\Events\CacheResolveEvent;
 
 /**
- * @covers Liip\ImagineBundle\Events\CacheResolveEvent
+ * @covers \Liip\ImagineBundle\Events\CacheResolveEvent
  */
 class CacheResolveEventTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/Exception/Imagine/Cache/Resolver/NotResolvableExceptionTest.php
+++ b/Tests/Exception/Imagine/Cache/Resolver/NotResolvableExceptionTest.php
@@ -14,7 +14,7 @@ namespace Liip\ImagineBundle\Tests\Exception\Imagine\Cache\Resolver;
 use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;
 
 /**
- * @covers Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException
+ * @covers \Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException
  */
 class NotResolvableExceptionTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,6 +29,6 @@ class NotResolvableExceptionTest extends \PHPUnit_Framework_TestCase
     {
         $e = new NotResolvableException();
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Exception\ExceptionInterface', $e);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Exception\ExceptionInterface', $e);
     }
 }

--- a/Tests/Exception/Imagine/Cache/Resolver/NotStorableExceptionTest.php
+++ b/Tests/Exception/Imagine/Cache/Resolver/NotStorableExceptionTest.php
@@ -14,7 +14,7 @@ namespace Liip\ImagineBundle\Tests\Exception\Imagine\Cache\Resolver;
 use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotStorableException;
 
 /**
- * @covers Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotStorableException
+ * @covers \Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotStorableException
  */
 class NotStorableExceptionTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,6 +29,6 @@ class NotStorableExceptionTest extends \PHPUnit_Framework_TestCase
     {
         $e = new NotStorableException();
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Exception\ExceptionInterface', $e);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Exception\ExceptionInterface', $e);
     }
 }

--- a/Tests/Form/Type/ImageTypeTest.php
+++ b/Tests/Form/Type/ImageTypeTest.php
@@ -13,13 +13,14 @@ namespace Liip\ImagineBundle\Tests\Form\Type;
 
 use Liip\ImagineBundle\Form\Type\ImageType;
 use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
+use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @covers \Liip\ImagineBundle\Form\Type\ImageType
  */
-class ImageTypeTest extends \PHPUnit_Framework_TestCase
+class ImageTypeTest extends AbstractTest
 {
     public function testGetName()
     {
@@ -55,7 +56,10 @@ class ImageTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($resolver->isDefined('link_attr'));
     }
 
-    public function testLegacySetDefaultOptions()
+    /**
+     * @group legacy
+     */
+    public function testSetDefaultOptionsLegacy()
     {
         if (SymfonyFramework::isKernelGreaterThanOrEqualTo(2, 6)) {
             $this->markTestSkipped('No need to test on symfony >= 2.6');
@@ -88,7 +92,7 @@ class ImageTypeTest extends \PHPUnit_Framework_TestCase
 
         $view = new FormView();
         $type = new ImageType();
-        $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
+        $form = $this->createObjectMock('\Symfony\Component\Form\Test\FormInterface');
 
         $type->buildView($view, $form, $options);
 

--- a/Tests/Functional/AbstractSetupWebTestCase.php
+++ b/Tests/Functional/AbstractSetupWebTestCase.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\Filesystem\Filesystem;
+
+class AbstractSetupWebTestCase extends AbstractWebTestCase
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * @var Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * @var string
+     */
+    protected $webRoot;
+
+    /**
+     * @var string
+     */
+    protected $cacheRoot;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->client = $this->createClient();
+        $this->webRoot = self::$kernel->getContainer()->getParameter('kernel.root_dir').'/web';
+        $this->cacheRoot = $this->webRoot.'/media/cache';
+        $this->filesystem = new Filesystem();
+        $this->filesystem->remove($this->cacheRoot);
+    }
+}

--- a/Tests/Functional/AbstractWebTestCase.php
+++ b/Tests/Functional/AbstractWebTestCase.php
@@ -11,10 +11,9 @@
 
 namespace Liip\ImagineBundle\Tests\Functional;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
-use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-abstract class WebTestCase extends BaseWebTestCase
+abstract class AbstractWebTestCase extends WebTestCase
 {
     /**
      * @return string

--- a/Tests/Functional/Binary/ExtensionGuesserTest.php
+++ b/Tests/Functional/Binary/ExtensionGuesserTest.php
@@ -9,15 +9,19 @@
  * file that was distributed with this source code.
  */
 
-namespace Liip\ImagineBundle\Tests\Functional;
+namespace Liip\ImagineBundle\Tests\Functional\Binary;
 
-class MimeTypeGuesserTest extends WebTestCase
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
+
+class ExtensionGuesserTest extends AbstractWebTestCase
 {
     public function testCouldBeGetFromContainerAsService()
     {
         $this->createClient();
-        $guesser = self::$kernel->getContainer()->get('liip_imagine.mime_type_guesser');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser', $guesser);
+        $this->assertInstanceOf(
+            '\Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser',
+            self::$kernel->getContainer()->get('liip_imagine.extension_guesser')
+        );
     }
 }

--- a/Tests/Functional/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Functional/Binary/Loader/FileSystemLoaderTest.php
@@ -12,12 +12,12 @@
 namespace Liip\ImagineBundle\Tests\Functional\Binary\Loader;
 
 use Liip\ImagineBundle\Binary\Loader\FileSystemLoader;
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
 
 /**
  * @covers \Liip\ImagineBundle\Binary\Loader\FileSystemLoader
  */
-class FileSystemLoaderTest extends WebTestCase
+class FileSystemLoaderTest extends AbstractWebTestCase
 {
     /**
      * @param string $name

--- a/Tests/Functional/Binary/Locator/FileSystemLocatorTest.php
+++ b/Tests/Functional/Binary/Locator/FileSystemLocatorTest.php
@@ -13,12 +13,12 @@ namespace Liip\ImagineBundle\Tests\Functional\Binary\Locator;
 
 use Liip\ImagineBundle\Binary\Locator\FileSystemLocator;
 use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
 
 /**
  * @covers \Liip\ImagineBundle\Binary\Locator\FileSystemLocator
  */
-class FileSystemLocatorTest extends WebTestCase
+class FileSystemLocatorTest extends AbstractWebTestCase
 {
     /**
      * @param string $name

--- a/Tests/Functional/Binary/MimeTypeGuesserTest.php
+++ b/Tests/Functional/Binary/MimeTypeGuesserTest.php
@@ -9,15 +9,19 @@
  * file that was distributed with this source code.
  */
 
-namespace Liip\ImagineBundle\Tests\Functional;
+namespace Liip\ImagineBundle\Tests\Functional\Binary;
 
-class ExtensionGuesserTest extends WebTestCase
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
+
+class MimeTypeGuesserTest extends AbstractWebTestCase
 {
     public function testCouldBeGetFromContainerAsService()
     {
         $this->createClient();
-        $guesser = self::$kernel->getContainer()->get('liip_imagine.extension_guesser');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser', $guesser);
+        $this->assertInstanceOf(
+            '\Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser',
+            self::$kernel->getContainer()->get('liip_imagine.mime_type_guesser')
+        );
     }
 }

--- a/Tests/Functional/Binary/SimpleMimeTypeGuesserTest.php
+++ b/Tests/Functional/Binary/SimpleMimeTypeGuesserTest.php
@@ -11,16 +11,17 @@
 
 namespace Liip\ImagineBundle\Tests\Functional\Binary;
 
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
 
-class SimpleMimeTypeGuesserTest extends WebTestCase
+class SimpleMimeTypeGuesserTest extends AbstractWebTestCase
 {
     public function testCouldBeGetFromContainerAsService()
     {
         $this->createClient();
 
-        $service = self::$kernel->getContainer()->get('liip_imagine.binary.mime_type_guesser');
-
-        $this->assertInstanceOf('Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser', $service);
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser',
+            self::$kernel->getContainer()->get('liip_imagine.binary.mime_type_guesser')
+        );
     }
 }

--- a/Tests/Functional/Command/AbstractCommandTestCase.php
+++ b/Tests/Functional/Command/AbstractCommandTestCase.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Functional\Command;
+
+use Liip\ImagineBundle\Tests\Functional\AbstractSetupWebTestCase;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class AbstractCommandTestCase extends AbstractSetupWebTestCase
+{
+    /**
+     * @param Command $command
+     * @param array   $arguments
+     * @param array   $options
+     *
+     * @return string
+     */
+    protected function executeConsole(Command $command, array $arguments = array(), array $options = array())
+    {
+        $command->setApplication(new Application($this->createClient()->getKernel()));
+        if ($command instanceof ContainerAwareCommand) {
+            $command->setContainer($this->createClient()->getContainer());
+        }
+
+        $arguments = array_replace(array('command' => $command->getName()), $arguments);
+        $options = array_replace(array('--env' => 'test'), $options);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute($arguments, $options);
+
+        return $commandTester->getDisplay();
+    }
+}

--- a/Tests/Functional/Command/RemoveCacheTest.php
+++ b/Tests/Functional/Command/RemoveCacheTest.php
@@ -12,39 +12,12 @@
 namespace Liip\ImagineBundle\Tests\Functional\Command;
 
 use Liip\ImagineBundle\Command\RemoveCacheCommand;
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @covers Liip\ImagineBundle\Command\RemoveCacheCommand
+ * @covers \Liip\ImagineBundle\Command\RemoveCacheCommand
  */
-class RemoveCacheTest extends WebTestCase
+class RemoveCacheTest extends AbstractCommandTestCase
 {
-    protected $client;
-
-    protected $webRoot;
-
-    protected $filesystem;
-
-    protected $cacheRoot;
-
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->client = $this->createClient();
-
-        $this->webRoot = self::$kernel->getContainer()->getParameter('kernel.root_dir').'/web';
-        $this->cacheRoot = $this->webRoot.'/media/cache';
-
-        $this->filesystem = new Filesystem();
-        $this->filesystem->remove($this->cacheRoot);
-    }
-
     public function testExecuteSuccessfullyWithEmptyCacheAndWithoutParameters()
     {
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -278,30 +251,5 @@ class RemoveCacheTest extends WebTestCase
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats2.jpeg');
         $this->assertFileExists($this->cacheRoot.'/thumbnail_default/images/cats.jpeg');
-    }
-
-    /**
-     * Helper function return the result of command execution.
-     *
-     * @param Command $command
-     * @param array   $arguments
-     * @param array   $options
-     *
-     * @return string
-     */
-    protected function executeConsole(Command $command, array $arguments = array(), array $options = array())
-    {
-        $command->setApplication(new Application($this->createClient()->getKernel()));
-        if ($command instanceof ContainerAwareCommand) {
-            $command->setContainer($this->createClient()->getContainer());
-        }
-
-        $arguments = array_replace(array('command' => $command->getName()), $arguments);
-        $options = array_replace(array('--env' => 'test'), $options);
-
-        $commandTester = new CommandTester($command);
-        $commandTester->execute($arguments, $options);
-
-        return $commandTester->getDisplay();
     }
 }

--- a/Tests/Functional/Command/ResolveCacheTest.php
+++ b/Tests/Functional/Command/ResolveCacheTest.php
@@ -12,39 +12,12 @@
 namespace Liip\ImagineBundle\Tests\Functional\Command;
 
 use Liip\ImagineBundle\Command\ResolveCacheCommand;
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @covers Liip\ImagineBundle\Command\ResolveCacheCommand
+ * @covers \Liip\ImagineBundle\Command\ResolveCacheCommand
  */
-class ResolveCacheTest extends WebTestCase
+class ResolveCacheTest extends AbstractCommandTestCase
 {
-    protected $client;
-
-    protected $webRoot;
-
-    protected $filesystem;
-
-    protected $cacheRoot;
-
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->client = $this->createClient();
-
-        $this->webRoot = self::$kernel->getContainer()->getParameter('kernel.root_dir').'/web';
-        $this->cacheRoot = $this->webRoot.'/media/cache';
-
-        $this->filesystem = new Filesystem();
-        $this->filesystem->remove($this->cacheRoot);
-    }
-
     public function testShouldResolveWithEmptyCache()
     {
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -142,30 +115,5 @@ class ResolveCacheTest extends WebTestCase
         $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
         $this->assertContains('http://localhost/media/cache/thumbnail_default/images/cats.jpeg', $output);
         $this->assertContains('http://localhost/media/cache/thumbnail_default/images/cats2.jpeg', $output);
-    }
-
-    /**
-     * Helper function return the result of command execution.
-     *
-     * @param Command $command
-     * @param array   $arguments
-     * @param array   $options
-     *
-     * @return string
-     */
-    protected function executeConsole(Command $command, array $arguments = array(), array $options = array())
-    {
-        $command->setApplication(new Application($this->createClient()->getKernel()));
-        if ($command instanceof ContainerAwareCommand) {
-            $command->setContainer($this->createClient()->getContainer());
-        }
-
-        $arguments = array_replace(array('command' => $command->getName()), $arguments);
-        $options = array_replace(array('--env' => 'test'), $options);
-
-        $commandTester = new CommandTester($command);
-        $commandTester->execute($arguments, $options);
-
-        return $commandTester->getDisplay();
     }
 }

--- a/Tests/Functional/Controller/ImagineControllerTest.php
+++ b/Tests/Functional/Controller/ImagineControllerTest.php
@@ -12,47 +12,19 @@
 namespace Liip\ImagineBundle\Tests\Functional\Controller;
 
 use Liip\ImagineBundle\Imagine\Cache\Signer;
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
-use Symfony\Bundle\FrameworkBundle\Client;
-use Symfony\Component\Filesystem\Filesystem;
+use Liip\ImagineBundle\Tests\Functional\AbstractSetupWebTestCase;
 
 /**
- * @covers Liip\ImagineBundle\Controller\ImagineController
+ * @covers \Liip\ImagineBundle\Controller\ImagineController
  */
-class ImagineControllerTest extends WebTestCase
+class ImagineControllerTest extends AbstractSetupWebTestCase
 {
-    /**
-     * @var Client
-     */
-    protected $client;
-
-    protected $webRoot;
-
-    protected $cacheRoot;
-
-    /**
-     * @var Filesystem
-     */
-    protected $filesystem;
-
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->client = $this->createClient();
-
-        $this->webRoot = self::$kernel->getContainer()->getParameter('kernel.root_dir').'/web';
-        $this->cacheRoot = $this->webRoot.'/media/cache';
-
-        $this->filesystem = new Filesystem();
-        $this->filesystem->remove($this->cacheRoot);
-    }
-
     public function testCouldBeGetFromContainer()
     {
-        $controller = self::$kernel->getContainer()->get('liip_imagine.controller');
-
-        $this->assertInstanceOf('Liip\ImagineBundle\Controller\ImagineController', $controller);
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Controller\ImagineController',
+            self::$kernel->getContainer()->get('liip_imagine.controller')
+        );
     }
 
     public function testShouldResolvePopulatingCacheFirst()
@@ -64,7 +36,7 @@ class ImagineControllerTest extends WebTestCase
 
         $response = $this->client->getResponse();
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
 
@@ -82,7 +54,7 @@ class ImagineControllerTest extends WebTestCase
 
         $response = $this->client->getResponse();
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
 
@@ -158,7 +130,7 @@ class ImagineControllerTest extends WebTestCase
 
         $response = $this->client->getResponse();
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/'.$expectedCachePath, $response->getTargetUrl());
 
@@ -193,7 +165,7 @@ class ImagineControllerTest extends WebTestCase
 
         $response = $this->client->getResponse();
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache'.'/'.$expectedCachePath, $response->getTargetUrl());
 
@@ -213,7 +185,7 @@ class ImagineControllerTest extends WebTestCase
 
         $response = $this->client->getResponse();
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/foo bar.jpeg', $response->getTargetUrl());
 

--- a/Tests/Functional/Imagine/Cache/Resolver/NoCacheWebPathResolverTest.php
+++ b/Tests/Functional/Imagine/Cache/Resolver/NoCacheWebPathResolverTest.php
@@ -11,19 +11,20 @@
 
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Cache\Resolver;
 
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Cache\Resolver\NoCacheWebPathResolver
+ * @covers \Liip\ImagineBundle\Imagine\Cache\Resolver\NoCacheWebPathResolver
  */
-class NoCacheWebPathResolverTest extends WebTestCase
+class NoCacheWebPathResolverTest extends AbstractWebTestCase
 {
     public function testCouldBeGetFromContainer()
     {
         $this->createClient();
 
-        $resolver = self::$kernel->getContainer()->get('liip_imagine.cache.resolver.no_cache_web_path');
-
-        $this->assertInstanceOf('Liip\ImagineBundle\Imagine\Cache\Resolver\NoCacheWebPathResolver', $resolver);
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Imagine\Cache\Resolver\NoCacheWebPathResolver',
+            self::$kernel->getContainer()->get('liip_imagine.cache.resolver.no_cache_web_path')
+        );
     }
 }

--- a/Tests/Functional/Imagine/Cache/SignerTest.php
+++ b/Tests/Functional/Imagine/Cache/SignerTest.php
@@ -9,15 +9,19 @@
  * file that was distributed with this source code.
  */
 
-namespace Liip\ImagineBundle\Tests\Functional;
+namespace Liip\ImagineBundle\Tests\Functional\Imagine\Cache;
 
-class SignerTest extends WebTestCase
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
+
+class SignerTest extends AbstractWebTestCase
 {
     public function testGetAsService()
     {
         $this->createClient();
-        $service = self::$kernel->getContainer()->get('liip_imagine.cache.signer');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Imagine\Cache\SignerInterface', $service);
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Imagine\Cache\SignerInterface',
+            self::$kernel->getContainer()->get('liip_imagine.cache.signer')
+        );
     }
 }

--- a/Tests/Functional/Imagine/Data/DataManagerTest.php
+++ b/Tests/Functional/Imagine/Data/DataManagerTest.php
@@ -11,15 +11,20 @@
 
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Data;
 
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
 
-class DataManagerTest extends WebTestCase
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Data\DataManager
+ */
+class DataManagerTest extends AbstractWebTestCase
 {
     public function testCouldBeGetFromContainerAsService()
     {
         $this->createClient();
-        $service = self::$kernel->getContainer()->get('liip_imagine.data.manager');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Imagine\Data\DataManager', $service);
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Imagine\Data\DataManager',
+            self::$kernel->getContainer()->get('liip_imagine.data.manager')
+        );
     }
 }

--- a/Tests/Functional/Imagine/Filter/FilterManagerTest.php
+++ b/Tests/Functional/Imagine/Filter/FilterManagerTest.php
@@ -11,15 +11,20 @@
 
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter;
 
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
 
-class FilterManagerTest extends WebTestCase
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Filter\FilterManager
+ */
+class FilterManagerTest extends AbstractWebTestCase
 {
     public function testCouldBeGetFromContainerAsService()
     {
         $this->createClient();
-        $service = self::$kernel->getContainer()->get('liip_imagine.filter.manager');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Imagine\Filter\FilterManager', $service);
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Imagine\Filter\FilterManager',
+            self::$kernel->getContainer()->get('liip_imagine.filter.manager')
+        );
     }
 }

--- a/Tests/Functional/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
+++ b/Tests/Functional/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
@@ -11,15 +11,20 @@
 
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter\Loader;
 
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
 
-class DownscaleFilterLoaderTest extends WebTestCase
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader
+ */
+class DownscaleFilterLoaderTest extends AbstractWebTestCase
 {
     public function testCouldBeGetFromContainerAsService()
     {
         $this->createClient();
-        $service = self::$kernel->getContainer()->get('liip_imagine.filter.loader.downscale');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader', $service);
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader',
+            self::$kernel->getContainer()->get('liip_imagine.filter.loader.downscale')
+        );
     }
 }

--- a/Tests/Functional/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
+++ b/Tests/Functional/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
@@ -11,20 +11,22 @@
 
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter\Loader;
 
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
 
 /**
- * Functional test cases for GrayscaleFilterLoader class.
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\GrayscaleFilterLoader
  *
  * @author Gregoire Humeau <gregoire.humeau@gmail.com>
  */
-class GrayscaleFilterLoaderTest extends WebTestCase
+class GrayscaleFilterLoaderTest extends AbstractWebTestCase
 {
     public function testCouldBeGetFromContainerAsService()
     {
         $this->createClient();
-        $service = self::$kernel->getContainer()->get('liip_imagine.filter.loader.grayscale');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Imagine\Filter\Loader\GrayscaleFilterLoader', $service);
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Imagine\Filter\Loader\GrayscaleFilterLoader',
+                self::$kernel->getContainer()->get('liip_imagine.filter.loader.grayscale')
+        );
     }
 }

--- a/Tests/Functional/Imagine/Filter/Loader/InterlaceFilterLoaderTest.php
+++ b/Tests/Functional/Imagine/Filter/Loader/InterlaceFilterLoaderTest.php
@@ -11,15 +11,20 @@
 
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter\Loader;
 
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
 
-class InterlaceFilterLoaderTest extends WebTestCase
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\InterlaceFilterLoader
+ */
+class InterlaceFilterLoaderTest extends AbstractWebTestCase
 {
     public function testCouldBeGetFromContainerAsService()
     {
         $this->createClient();
-        $service = self::$kernel->getContainer()->get('liip_imagine.filter.loader.interlace');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Imagine\Filter\Loader\InterlaceFilterLoader', $service);
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Imagine\Filter\Loader\InterlaceFilterLoader',
+            self::$kernel->getContainer()->get('liip_imagine.filter.loader.interlace')
+        );
     }
 }

--- a/Tests/Functional/Imagine/Filter/Loader/RotateFilterLoaderTest.php
+++ b/Tests/Functional/Imagine/Filter/Loader/RotateFilterLoaderTest.php
@@ -11,20 +11,22 @@
 
 namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter\Loader;
 
-use Liip\ImagineBundle\Tests\Functional\WebTestCase;
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
 
 /**
- * Functional test cases for RotateFilterLoader class.
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\RotateFilterLoader
  *
  * @author Bocharsky Victor <bocharsky.bw@gmail.com>
  */
-class RotateFilterLoaderTest extends WebTestCase
+class RotateFilterLoaderTest extends AbstractWebTestCase
 {
     public function testCouldBeGetFromContainerAsService()
     {
         $this->createClient();
-        $service = self::$kernel->getContainer()->get('liip_imagine.filter.loader.rotate');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Imagine\Filter\Loader\RotateFilterLoader', $service);
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Imagine\Filter\Loader\RotateFilterLoader',
+            self::$kernel->getContainer()->get('liip_imagine.filter.loader.rotate')
+        );
     }
 }

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -1,61 +1,79 @@
+---
+
 parameters:
-    locale:            en
-    secret:            ThisTokenIsNotSoSecretChangeIt
+
+    locale: en
+    secret: ThisTokenIsNotSoSecretChangeIt
 
 framework:
-    #esi:             ~
-    #translator:      { fallback: "%locale%" }
-    test: ~
-    templating:      { engines: ['php'] }
+
+    secret:         "%secret%"
+    default_locale: "%locale%"
+    translator:     ~
+    test:           ~
+
+    templating:
+        engines: [ 'php' ]
+
     session:
         storage_id: session.storage.mock_file
-    secret:          "%secret%"
-    router:          { resource: "%kernel.root_dir%/config/routing.yml" }
-    default_locale:  "%locale%"
-    translator:      ~
+
+    router:
+        resource: "%kernel.root_dir%/config/routing.yml"
 
 liip_imagine:
+
     loaders:
+
         default:
             filesystem:
                 data_root: "%kernel.root_dir%/web"
+
         foo:
             filesystem:
                 data_root: "%kernel.root_dir%/../../Fixtures/FileSystemLocator/root-01"
+
         bar:
             filesystem:
                 data_root: "%kernel.root_dir%/../../Fixtures/FileSystemLocator/root-02"
+
         bundles_all:
             filesystem:
                 data_root: ~
                 bundle_resources:
                     enabled: true
+
         bundles_only_foo:
             filesystem:
                 data_root: ~
                 bundle_resources:
-                    enabled: true
+                    enabled:             true
                     access_control_type: blacklist
-                    access_control_list:
-                        - LiipBarBundle
+                    access_control_list: [ 'LiipBarBundle' ]
+
         bundles_only_bar:
             filesystem:
                 data_root: ~
                 bundle_resources:
-                    enabled: true
+                    enabled:             true
                     access_control_type: whitelist
-                    access_control_list:
-                        - LiipBarBundle
+                    access_control_list: [ 'LiipBarBundle' ]
+
     resolvers:
+
         default:
             web_path:
-                web_root: "%kernel.root_dir%/web"
+                web_root:     "%kernel.root_dir%/web"
                 cache_prefix: media/cache
 
     filter_sets:
+
         thumbnail_web_path:
             filters:
                 thumbnail: { size: [223, 223], mode: inset }
+
         thumbnail_default:
             filters:
                 thumbnail: { size: [223, 223], mode: inset }
+
+...

--- a/Tests/Functional/app/config/routing.yml
+++ b/Tests/Functional/app/config/routing.yml
@@ -1,2 +1,6 @@
+---
+
 _liip_imagine:
     resource: "@LiipImagineBundle/Resources/config/routing.xml"
+
+...

--- a/Tests/Imagine/Cache/Resolver/AmazonS3ResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/AmazonS3ResolverTest.php
@@ -16,15 +16,15 @@ use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Cache\Resolver\AmazonS3Resolver
+ * @covers \Liip\ImagineBundle\Imagine\Cache\Resolver\AmazonS3Resolver
  */
 class AmazonS3ResolverTest extends AbstractTest
 {
     public function testImplementsResolverInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\Imagine\Cache\Resolver\AmazonS3Resolver');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\Imagine\Cache\Resolver\AmazonS3Resolver');
 
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface'));
+        $this->assertTrue($rc->implementsInterface('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface'));
     }
 
     public function testNoDoubleSlashesInObjectUrlOnResolve()
@@ -33,8 +33,7 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('get_object_url')
-            ->with('images.example.com', 'thumb/some-folder/path.jpg')
-        ;
+            ->with('images.example.com', 'thumb/some-folder/path.jpg');
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->resolve('/some-folder/path.jpg', 'thumb');
@@ -46,14 +45,17 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('get_object_url')
-            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, array('torrent' => true))
-        ;
+            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, array('torrent' => true));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->setObjectUrlOption('torrent', true);
         $resolver->resolve('/some-folder/path.jpg', 'thumb');
     }
 
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotStorableException
+     * @expectedExceptionMessage The object could not be created on Amazon S3
+     */
     public function testThrowsAndLogIfCanNotCreateObjectOnAmazon()
     {
         $binary = new Binary('aContent', 'image/jpeg', 'jpeg');
@@ -62,22 +64,15 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('create_object')
-            ->will($this->returnValue($this->createCFResponseMock(false)))
-        ;
+            ->will($this->returnValue($this->createCFResponseMock(false)));
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createLoggerInterfaceMock();
         $logger
             ->expects($this->once())
-            ->method('error')
-        ;
+            ->method('error');
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->setLogger($logger);
-
-        $this->setExpectedException(
-            'Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotStorableException',
-            'The object could not be created on Amazon S3.'
-        );
         $resolver->store($binary, 'foobar.jpg', 'thumb');
     }
 
@@ -89,11 +84,9 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('create_object')
-            ->will($this->returnValue($this->createCFResponseMock(true)))
-        ;
+            ->will($this->returnValue($this->createCFResponseMock(true)));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-
         $resolver->store($binary, 'foobar.jpg', 'thumb');
     }
 
@@ -103,8 +96,7 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('if_object_exists')
-            ->will($this->returnValue(false))
-        ;
+            ->will($this->returnValue(false));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
 
@@ -118,8 +110,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('get_object_url')
             ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, array())
-            ->will($this->returnValue('http://images.example.com/some-folder/path.jpg'))
-        ;
+            ->will($this->returnValue('http://images.example.com/some-folder/path.jpg'));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
 
@@ -134,19 +125,15 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3 = $this->createAmazonS3Mock();
         $s3
             ->expects($this->never())
-            ->method('if_object_exists')
-        ;
+            ->method('if_object_exists');
         $s3
             ->expects($this->never())
-            ->method('delete_object')
-        ;
+            ->method('delete_object');
         $s3
             ->expects($this->never())
-            ->method('delete_all_objects')
-        ;
+            ->method('delete_all_objects');
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-
         $resolver->remove(array(), array());
     }
 
@@ -157,17 +144,14 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('if_object_exists')
             ->with('images.example.com', 'thumb/some-folder/path.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $s3
             ->expects($this->once())
             ->method('delete_object')
             ->with('images.example.com', 'thumb/some-folder/path.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)))
-        ;
+            ->will($this->returnValue($this->createCFResponseMock(true)));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-
         $resolver->remove(array('some-folder/path.jpg'), array('thumb'));
     }
 
@@ -178,29 +162,24 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->at(0))
             ->method('if_object_exists')
             ->with('images.example.com', 'filter/pathOne.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $s3
             ->expects($this->at(1))
             ->method('delete_object')
             ->with('images.example.com', 'filter/pathOne.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)))
-        ;
+            ->will($this->returnValue($this->createCFResponseMock(true)));
         $s3
             ->expects($this->at(2))
             ->method('if_object_exists')
             ->with('images.example.com', 'filter/pathTwo.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $s3
             ->expects($this->at(3))
             ->method('delete_object')
             ->with('images.example.com', 'filter/pathTwo.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)))
-        ;
+            ->will($this->returnValue($this->createCFResponseMock(true)));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-
         $resolver->remove(array('pathOne.jpg', 'pathTwo.jpg'), array('filter'));
     }
 
@@ -211,53 +190,44 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->at(0))
             ->method('if_object_exists')
             ->with('images.example.com', 'filterOne/pathOne.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $s3
             ->expects($this->at(1))
             ->method('delete_object')
             ->with('images.example.com', 'filterOne/pathOne.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)))
-        ;
+            ->will($this->returnValue($this->createCFResponseMock(true)));
         $s3
             ->expects($this->at(2))
             ->method('if_object_exists')
             ->with('images.example.com', 'filterOne/pathTwo.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $s3
             ->expects($this->at(3))
             ->method('delete_object')
             ->with('images.example.com', 'filterOne/pathTwo.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)))
-        ;
+            ->will($this->returnValue($this->createCFResponseMock(true)));
         $s3
             ->expects($this->at(4))
             ->method('if_object_exists')
             ->with('images.example.com', 'filterTwo/pathOne.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $s3
             ->expects($this->at(5))
             ->method('delete_object')
             ->with('images.example.com', 'filterTwo/pathOne.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)))
-        ;
+            ->will($this->returnValue($this->createCFResponseMock(true)));
         $s3
             ->expects($this->at(6))
             ->method('if_object_exists')
             ->with('images.example.com', 'filterTwo/pathTwo.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $s3
             ->expects($this->at(7))
             ->method('delete_object')
             ->with('images.example.com', 'filterTwo/pathTwo.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)))
-        ;
+            ->will($this->returnValue($this->createCFResponseMock(true)));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-
         $resolver->remove(
             array('pathOne.jpg', 'pathTwo.jpg'),
             array('filterOne', 'filterTwo')
@@ -271,15 +241,12 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('if_object_exists')
             ->with('images.example.com', 'filter/path.jpg')
-            ->will($this->returnValue(false))
-        ;
+            ->will($this->returnValue(false));
         $s3
             ->expects($this->never())
-            ->method('delete_object')
-        ;
+            ->method('delete_object');
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-
         $resolver->remove(array('path.jpg'), array('filter'));
     }
 
@@ -290,23 +257,19 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('if_object_exists')
             ->with('images.example.com', 'filter/path.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $s3
             ->expects($this->once())
             ->method('delete_object')
-            ->will($this->returnValue($this->createCFResponseMock(false)))
-        ;
+            ->will($this->returnValue($this->createCFResponseMock(false)));
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createLoggerInterfaceMock();
         $logger
             ->expects($this->once())
-            ->method('error')
-        ;
+            ->method('error');
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->setLogger($logger);
-
         $resolver->remove(array('path.jpg'), array('filter'));
     }
 
@@ -317,11 +280,9 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('delete_all_objects')
             ->with('images.example.com', '/filter/i')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-
         $resolver->remove(array(), array('filter'));
     }
 
@@ -332,11 +293,9 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('delete_all_objects')
             ->with('images.example.com', '/filterOne|filterTwo/i')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-
         $resolver->remove(array(), array('filterOne', 'filterTwo'));
     }
 
@@ -347,18 +306,15 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('delete_all_objects')
             ->with('images.example.com', '/filter/i')
-            ->will($this->returnValue(false))
-        ;
+            ->will($this->returnValue(false));
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createLoggerInterfaceMock();
         $logger
             ->expects($this->once())
-            ->method('error')
-        ;
+            ->method('error');
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->setLogger($logger);
-
         $resolver->remove(array(), array('filter'));
     }
 
@@ -369,12 +325,11 @@ class AmazonS3ResolverTest extends AbstractTest
      */
     protected function createCFResponseMock($ok = true)
     {
-        $s3Response = $this->getMock('CFResponse', array('isOK'), array(), '', false);
+        $s3Response = $this->createObjectMock('CFResponse', array('isOK'), false);
         $s3Response
             ->expects($this->once())
             ->method('isOK')
-            ->will($this->returnValue($ok))
-        ;
+            ->will($this->returnValue($ok));
 
         return $s3Response;
     }
@@ -384,15 +339,17 @@ class AmazonS3ResolverTest extends AbstractTest
      */
     protected function createAmazonS3Mock()
     {
-        $mockedMethods = array(
-            'if_object_exists',
-            'create_object',
-            'get_object_url',
-            'delete_object',
-            'delete_all_objects',
-            'authenticate',
-        );
-
-        return $this->getMock('AmazonS3', $mockedMethods, array(), '', false);
+        return $this
+            ->getMockBuilder('AmazonS3')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'if_object_exists',
+                'create_object',
+                'get_object_url',
+                'delete_object',
+                'delete_all_objects',
+                'authenticate',
+            ))
+            ->getMock();
     }
 }

--- a/Tests/Imagine/Cache/Resolver/CacheResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/CacheResolverTest.php
@@ -17,7 +17,7 @@ use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Cache\Resolver\CacheResolver
+ * @covers \Liip\ImagineBundle\Imagine\Cache\Resolver\CacheResolver
  */
 class CacheResolverTest extends AbstractTest
 {
@@ -27,13 +27,12 @@ class CacheResolverTest extends AbstractTest
 
     public function testResolveIsSavedToCache()
     {
-        $resolver = $this->createResolverMock();
+        $resolver = $this->createCacheResolverInterfaceMock();
         $resolver
             ->expects($this->once())
             ->method('resolve')
             ->with($this->path, $this->filter)
-            ->will($this->returnValue($this->webPath))
-        ;
+            ->will($this->returnValue($this->webPath));
 
         $cacheResolver = new CacheResolver(new ArrayCache(), $resolver);
 
@@ -46,17 +45,15 @@ class CacheResolverTest extends AbstractTest
 
     public function testNotCallInternalResolverIfCachedOnIsStored()
     {
-        $resolver = $this->createResolverMock();
+        $resolver = $this->createCacheResolverInterfaceMock();
         $resolver
             ->expects($this->once())
             ->method('resolve')
             ->with($this->path, $this->filter)
-            ->will($this->returnValue($this->webPath))
-        ;
+            ->will($this->returnValue($this->webPath));
         $resolver
             ->expects($this->never())
-            ->method('isStored')
-        ;
+            ->method('isStored');
 
         $cacheResolver = new CacheResolver(new ArrayCache(), $resolver);
 
@@ -69,12 +66,11 @@ class CacheResolverTest extends AbstractTest
 
     public function testCallInternalResolverIfNotCachedOnIsStored()
     {
-        $resolver = $this->createResolverMock();
+        $resolver = $this->createCacheResolverInterfaceMock();
         $resolver
             ->expects($this->exactly(2))
             ->method('isStored')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
 
         $cacheResolver = new CacheResolver(new ArrayCache(), $resolver);
 
@@ -86,12 +82,11 @@ class CacheResolverTest extends AbstractTest
     {
         $binary = new Binary('aContent', 'image/jpeg', 'jpg');
 
-        $resolver = $this->createResolverMock();
+        $resolver = $this->createCacheResolverInterfaceMock();
         $resolver
             ->expects($this->exactly(2))
             ->method('store')
-            ->with($this->identicalTo($binary), $this->webPath, $this->filter)
-        ;
+            ->with($this->identicalTo($binary), $this->webPath, $this->filter);
 
         $cacheResolver = new CacheResolver(new ArrayCache(), $resolver);
 
@@ -102,19 +97,17 @@ class CacheResolverTest extends AbstractTest
 
     public function testSavesToCacheIfInternalResolverReturnUrlOnResolve()
     {
-        $resolver = $this->createResolverMock();
+        $resolver = $this->createCacheResolverInterfaceMock();
         $resolver
             ->expects($this->once())
             ->method('resolve')
             ->with($this->path, $this->filter)
-            ->will($this->returnValue('/the/expected/browser'))
-        ;
+            ->will($this->returnValue('/the/expected/browser'));
 
-        $cache = $this->getMock('Doctrine\Common\Cache\Cache');
+        $cache = $this->getMockBuilder('\Doctrine\Common\Cache\Cache')->getMock();
         $cache
             ->expects($this->exactly(1))
-            ->method('save')
-        ;
+            ->method('save');
 
         $cacheResolver = new CacheResolver($cache, $resolver);
 
@@ -123,17 +116,15 @@ class CacheResolverTest extends AbstractTest
 
     public function testRemoveSinglePathCacheOnRemove()
     {
-        $resolver = $this->createResolverMock();
+        $resolver = $this->createCacheResolverInterfaceMock();
         $resolver
             ->expects($this->once())
             ->method('resolve')
             ->with($this->path, $this->filter)
-            ->will($this->returnValue($this->webPath))
-        ;
+            ->will($this->returnValue($this->webPath));
         $resolver
             ->expects($this->once())
-            ->method('remove')
-        ;
+            ->method('remove');
 
         $cache = new ArrayCache();
 
@@ -142,8 +133,8 @@ class CacheResolverTest extends AbstractTest
 
         /*
          * Checking 2 items:
-         * * The result of one resolve execution.
-         * * The index of entity.
+         * - The result of one resolve execution.
+         * - The index of entity.
          */
         $this->assertCount(2, $this->getCacheEntries($cache));
 
@@ -155,16 +146,14 @@ class CacheResolverTest extends AbstractTest
 
     public function testRemoveAllFilterCacheOnRemove()
     {
-        $resolver = $this->createResolverMock();
+        $resolver = $this->createCacheResolverInterfaceMock();
         $resolver
             ->expects($this->exactly(4))
             ->method('resolve')
-            ->will($this->returnValue('aCachePath'))
-        ;
+            ->will($this->returnValue('aCachePath'));
         $resolver
             ->expects($this->once())
-            ->method('remove')
-        ;
+            ->method('remove');
 
         $cache = new ArrayCache();
 
@@ -176,8 +165,8 @@ class CacheResolverTest extends AbstractTest
 
         /*
          * Checking 6 items:
-         * * The result of four resolve execution.
-         * * The index of two entities.
+         * - The result of four resolve execution.
+         * - The index of two entities.
          */
         $this->assertCount(6, $this->getCacheEntries($cache));
 

--- a/Tests/Imagine/Cache/Resolver/FlysystemResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/FlysystemResolverTest.php
@@ -18,7 +18,7 @@ use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\Routing\RequestContext;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Cache\Resolver\FlysystemResolver
+ * @covers \Liip\ImagineBundle\Imagine\Cache\Resolver\FlysystemResolver
  */
 class FlysystemResolverTest extends AbstractTest
 {
@@ -35,29 +35,29 @@ class FlysystemResolverTest extends AbstractTest
 
     public function testImplementsResolverInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\Imagine\Cache\Resolver\FlysystemResolver');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\Imagine\Cache\Resolver\FlysystemResolver');
 
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface'));
+        $this->assertTrue($rc->implementsInterface('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface'));
     }
 
     public function testResolveUriForFilter()
     {
-        $fs = $this->getFlysystemMock();
+        $resolver = new FlysystemResolver($this->createFlySystemMock(), new RequestContext(), 'http://images.example.com');
 
-        $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
-        $uri = $resolver->resolve('/some-folder/path.jpg', 'thumb');
-        $this->assertEquals('http://images.example.com/media/cache/thumb/some-folder/path.jpg', $uri);
+        $this->assertEquals(
+            'http://images.example.com/media/cache/thumb/some-folder/path.jpg',
+            $resolver->resolve('/some-folder/path.jpg', 'thumb')
+        );
     }
 
     public function testRemoveObjectsForFilter()
     {
         $expectedFilter = 'theFilter';
-        $fs = $this->getFlysystemMock();
+        $fs = $this->createFlySystemMock();
         $fs
             ->expects($this->once())
             ->method('deleteDir')
-            ->with('media/cache/theFilter')
-        ;
+            ->with('media/cache/theFilter');
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
         $resolver->remove(array(), array($expectedFilter));
@@ -67,12 +67,11 @@ class FlysystemResolverTest extends AbstractTest
     {
         $binary = new Binary('aContent', 'image/jpeg', 'jpeg');
 
-        $fs = $this->getFlysystemMock();
+        $fs = $this->createFlySystemMock();
         $fs
             ->expects($this->once())
             ->method('put')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
 
@@ -81,12 +80,11 @@ class FlysystemResolverTest extends AbstractTest
 
     public function testIsStoredChecksObjectExistence()
     {
-        $fs = $this->getFlysystemMock();
+        $fs = $this->createFlySystemMock();
         $fs
             ->expects($this->once())
             ->method('has')
-            ->will($this->returnValue(false))
-        ;
+            ->will($this->returnValue(false));
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
 
@@ -95,7 +93,7 @@ class FlysystemResolverTest extends AbstractTest
 
     public function testReturnResolvedImageUrlOnResolve()
     {
-        $fs = $this->getFlysystemMock();
+        $fs = $this->createFlySystemMock();
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
 
@@ -107,55 +105,47 @@ class FlysystemResolverTest extends AbstractTest
 
     public function testRemoveCacheForPathAndFilterOnRemove()
     {
-        $fs = $this->getFlysystemMock();
+        $fs = $this->createFlySystemMock();
         $fs
             ->expects($this->once())
             ->method('has')
             ->with('media/cache/thumb/some-folder/path.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $fs
             ->expects($this->once())
             ->method('delete')
             ->with('media/cache/thumb/some-folder/path.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
-
         $resolver->remove(array('some-folder/path.jpg'), array('thumb'));
     }
 
     public function testRemoveCacheForSomePathsAndFilterOnRemove()
     {
-        $fs = $this->getFlysystemMock();
+        $fs = $this->createFlySystemMock();
         $fs
             ->expects($this->at(0))
             ->method('has')
             ->with('media/cache/thumb/pathOne.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $fs
             ->expects($this->at(1))
             ->method('delete')
             ->with('media/cache/thumb/pathOne.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $fs
             ->expects($this->at(2))
             ->method('has')
             ->with('media/cache/thumb/pathTwo.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $fs
             ->expects($this->at(3))
             ->method('delete')
             ->with('media/cache/thumb/pathTwo.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
-
         $resolver->remove(
             array('pathOne.jpg', 'pathTwo.jpg'),
             array('thumb')
@@ -164,58 +154,49 @@ class FlysystemResolverTest extends AbstractTest
 
     public function testRemoveCacheForSomePathsAndSomeFiltersOnRemove()
     {
-        $fs = $this->getFlysystemMock();
+        $fs = $this->createFlySystemMock();
         $fs
             ->expects($this->at(0))
             ->method('has')
             ->with('media/cache/filterOne/pathOne.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $fs
             ->expects($this->at(1))
             ->method('delete')
             ->with('media/cache/filterOne/pathOne.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $fs
             ->expects($this->at(2))
             ->method('has')
             ->with('media/cache/filterTwo/pathOne.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $fs
             ->expects($this->at(3))
             ->method('delete')
             ->with('media/cache/filterTwo/pathOne.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $fs
             ->expects($this->at(4))
             ->method('has')
             ->with('media/cache/filterOne/pathTwo.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $fs
             ->expects($this->at(5))
             ->method('delete')
             ->with('media/cache/filterOne/pathTwo.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $fs
             ->expects($this->at(6))
             ->method('has')
             ->with('media/cache/filterTwo/pathTwo.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
         $fs
             ->expects($this->at(7))
             ->method('delete')
             ->with('media/cache/filterTwo/pathTwo.jpg')
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
-
         $resolver->remove(
             array('pathOne.jpg', 'pathTwo.jpg'),
             array('filterOne', 'filterTwo')
@@ -224,17 +205,15 @@ class FlysystemResolverTest extends AbstractTest
 
     public function testDoNothingWhenObjectNotExistForPathAndFilterOnRemove()
     {
-        $fs = $this->getFlysystemMock();
+        $fs = $this->createFlySystemMock();
         $fs
             ->expects($this->once())
             ->method('has')
             ->with('media/cache/thumb/some-folder/path.jpg')
-            ->will($this->returnValue(false))
-        ;
+            ->will($this->returnValue(false));
         $fs
             ->expects($this->never())
-            ->method('delete')
-        ;
+            ->method('delete');
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
         $resolver->remove(array('some-folder/path.jpg'), array('thumb'));
@@ -244,15 +223,13 @@ class FlysystemResolverTest extends AbstractTest
     {
         $expectedFilter = 'theFilter';
 
-        $fs = $this->getFlysystemMock();
+        $fs = $this->createFlySystemMock();
         $fs
             ->expects($this->once())
             ->method('deleteDir')
-            ->with('media/cache/theFilter')
-        ;
+            ->with('media/cache/theFilter');
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
-
         $resolver->remove(array(), array($expectedFilter));
     }
 
@@ -261,36 +238,35 @@ class FlysystemResolverTest extends AbstractTest
         $expectedFilterOne = 'theFilterOne';
         $expectedFilterTwo = 'theFilterTwo';
 
-        $fs = $this->getFlysystemMock();
+        $fs = $this->createFlySystemMock();
         $fs
             ->expects($this->at(0))
             ->method('deleteDir')
-            ->with('media/cache/theFilterOne')
-        ;
+            ->with('media/cache/theFilterOne');
         $fs
             ->expects($this->at(1))
             ->method('deleteDir')
-            ->with('media/cache/theFilterTwo')
-        ;
+            ->with('media/cache/theFilterTwo');
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
-
         $resolver->remove(array(), array($expectedFilterOne, $expectedFilterTwo));
     }
 
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|Filesystem
      */
-    protected function getFlysystemMock()
+    protected function createFlySystemMock()
     {
-        $mockedMethods = array(
-            'delete',
-            'deleteDir',
-            'has',
-            'put',
-            'remove',
-        );
-
-        return $this->getMock('League\Flysystem\Filesystem', $mockedMethods, array(), '', false);
+        return $this
+            ->getMockBuilder('\League\Flysystem\Filesystem')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'delete',
+                'deleteDir',
+                'has',
+                'put',
+                'remove',
+            ))
+            ->getMock();
     }
 }

--- a/Tests/Imagine/Cache/Resolver/NoCacheWebPathResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/NoCacheWebPathResolverTest.php
@@ -17,7 +17,7 @@ use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\Routing\RequestContext;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Cache\Resolver\NoCacheWebPathResolver
+ * @covers \Liip\ImagineBundle\Imagine\Cache\Resolver\NoCacheWebPathResolver
  */
 class NoCacheWebPathResolverTest extends AbstractTest
 {
@@ -28,9 +28,7 @@ class NoCacheWebPathResolverTest extends AbstractTest
 
     public function testComposeSchemaHostAndPathOnResolve()
     {
-        $context = new RequestContext('', 'GET', 'thehost', 'theSchema');
-
-        $resolver = new NoCacheWebPathResolver($context);
+        $resolver = new NoCacheWebPathResolver(new RequestContext('', 'GET', 'thehost', 'theSchema'));
 
         $this->assertEquals('theschema://thehost/aPath', $resolver->resolve('aPath', 'aFilter'));
     }
@@ -39,31 +37,24 @@ class NoCacheWebPathResolverTest extends AbstractTest
     {
         $resolver = new NoCacheWebPathResolver(new RequestContext());
 
-        $this->assertNull($resolver->store(
-            new Binary('aContent', 'image/jpeg', 'jpg'),
-            'a/path',
-            'aFilter'
-        ));
+        $this->assertNull($resolver->store(new Binary('aContent', 'image/jpeg', 'jpg'), 'a/path', 'aFilter'));
     }
 
     public function testDoNothingForPathAndFilterOnRemove()
     {
         $resolver = new NoCacheWebPathResolver(new RequestContext());
-
         $resolver->remove(array('a/path'), array('aFilter'));
     }
 
     public function testDoNothingForSomePathsAndSomeFiltersOnRemove()
     {
         $resolver = new NoCacheWebPathResolver(new RequestContext());
-
         $resolver->remove(array('foo', 'bar'), array('foo', 'bar'));
     }
 
     public function testDoNothingForEmptyPathAndEmptyFilterOnRemove()
     {
         $resolver = new NoCacheWebPathResolver(new RequestContext());
-
         $resolver->remove(array(), array());
     }
 }

--- a/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
@@ -14,14 +14,15 @@ namespace Liip\ImagineBundle\Tests\Imagine\Cache\Resolver;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ProxyResolver;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Model\Binary;
+use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Cache\Resolver\ProxyResolver
+ * @covers \Liip\ImagineBundle\Imagine\Cache\Resolver\ProxyResolver
  */
-class ProxyResolverTest extends \Phpunit_Framework_TestCase
+class ProxyResolverTest extends AbstractTest
 {
     /**
-     * @var ResolverInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|ResolverInterface
      */
     private $primaryResolver;
 
@@ -32,8 +33,7 @@ class ProxyResolverTest extends \Phpunit_Framework_TestCase
 
     public function setUp()
     {
-        $this->primaryResolver = $this->getMock('Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface');
-
+        $this->primaryResolver = $this->createObjectMock('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface');
         $this->resolver = new ProxyResolver($this->primaryResolver, array('http://images.example.com'));
     }
 
@@ -46,8 +46,7 @@ class ProxyResolverTest extends \Phpunit_Framework_TestCase
             ->expects($this->once())
             ->method('resolve')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue('http://foo.com/thumbs/foo/bar/bazz.png'))
-        ;
+            ->will($this->returnValue('http://foo.com/thumbs/foo/bar/bazz.png'));
 
         $result = $this->resolver->resolve($expectedPath, $expectedFilter);
 
@@ -63,8 +62,7 @@ class ProxyResolverTest extends \Phpunit_Framework_TestCase
             ->expects($this->once())
             ->method('resolve')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue('http://foo.com/thumbs/foo/bar/bazz.png'))
-        ;
+            ->will($this->returnValue('http://foo.com/thumbs/foo/bar/bazz.png'));
 
         $result = $this->resolver->resolve($expectedPath, $expectedFilter);
 
@@ -80,8 +78,7 @@ class ProxyResolverTest extends \Phpunit_Framework_TestCase
             ->expects($this->once())
             ->method('resolve')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue('https://s3-eu-west-1.amazonaws.com/s3-cache.example.com/thumbs/foo/bar/bazz.png'))
-        ;
+            ->will($this->returnValue('https://s3-eu-west-1.amazonaws.com/s3-cache.example.com/thumbs/foo/bar/bazz.png'));
 
         $this->resolver = new ProxyResolver($this->primaryResolver, array(
             'https://s3-eu-west-1.amazonaws.com/s3-cache.example.com' => 'http://images.example.com',
@@ -101,8 +98,7 @@ class ProxyResolverTest extends \Phpunit_Framework_TestCase
             ->expects($this->once())
             ->method('resolve')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue('http://foo.com/thumbs/foo/bar/bazz.png'))
-        ;
+            ->will($this->returnValue('http://foo.com/thumbs/foo/bar/bazz.png'));
 
         $this->resolver = new ProxyResolver($this->primaryResolver, array(
             'regexp/http:\/\/.*?\//' => 'http://bar.com/',
@@ -122,8 +118,7 @@ class ProxyResolverTest extends \Phpunit_Framework_TestCase
             ->expects($this->once())
             ->method('isStored')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue(true))
-        ;
+            ->will($this->returnValue(true));
 
         $this->assertTrue($this->resolver->isStored($expectedPath, $expectedFilter));
     }
@@ -137,8 +132,7 @@ class ProxyResolverTest extends \Phpunit_Framework_TestCase
         $this->primaryResolver
             ->expects($this->once())
             ->method('store')
-            ->with($expectedBinary, $expectedPath, $expectedFilter)
-        ;
+            ->with($expectedBinary, $expectedPath, $expectedFilter);
 
         $this->resolver->store($expectedBinary, $expectedPath, $expectedFilter);
     }
@@ -151,8 +145,7 @@ class ProxyResolverTest extends \Phpunit_Framework_TestCase
         $this->primaryResolver
             ->expects($this->once())
             ->method('remove')
-            ->with($expectedPaths, $expectedFilters)
-        ;
+            ->with($expectedPaths, $expectedFilters);
 
         $this->resolver->remove($expectedPaths, $expectedFilters);
     }

--- a/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
@@ -17,17 +17,23 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Routing\RequestContext;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Cache\Resolver\WebPathResolver
+ * @covers \Liip\ImagineBundle\Imagine\Cache\Resolver\WebPathResolver
  */
 class WebPathResolverTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var Filesystem */
+    /**
+     * @var Filesystem
+     */
     private $filesystem;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $basePath;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $existingFile;
 
     public function setUp()
@@ -46,9 +52,9 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsResolverInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\Imagine\Cache\Resolver\WebPathResolver');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\Imagine\Cache\Resolver\WebPathResolver');
 
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface'));
+        $this->assertTrue($rc->implementsInterface('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface'));
     }
 
     public function testCouldBeConstructedWithRequiredArguments()
@@ -287,8 +293,7 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         $filesystemMock
             ->expects($this->once())
             ->method('dumpFile')
-            ->with('/aWebRoot/aCachePrefix/aFilter/aPath', 'theContent')
-        ;
+            ->with('/aWebRoot/aCachePrefix/aFilter/aPath', 'theContent');
 
         $resolver = new WebPathResolver(
             $filesystemMock,
@@ -305,8 +310,7 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         $filesystemMock = $this->createFilesystemMock();
         $filesystemMock
             ->expects($this->never())
-            ->method('remove')
-        ;
+            ->method('remove');
 
         $resolver = new WebPathResolver(
             $filesystemMock,
@@ -324,8 +328,7 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         $filesystemMock
             ->expects($this->once())
             ->method('remove')
-            ->with('/aWebRoot/aCachePrefix/aFilter/aPath')
-        ;
+            ->with('/aWebRoot/aCachePrefix/aFilter/aPath');
 
         $resolver = new WebPathResolver(
             $filesystemMock,
@@ -343,13 +346,11 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         $filesystemMock
             ->expects($this->at(0))
             ->method('remove')
-            ->with('/aWebRoot/aCachePrefix/aFilter/aPathOne')
-        ;
+            ->with('/aWebRoot/aCachePrefix/aFilter/aPathOne');
         $filesystemMock
             ->expects($this->at(1))
             ->method('remove')
-            ->with('/aWebRoot/aCachePrefix/aFilter/aPathTwo')
-        ;
+            ->with('/aWebRoot/aCachePrefix/aFilter/aPathTwo');
 
         $resolver = new WebPathResolver(
             $filesystemMock,
@@ -367,23 +368,19 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
         $filesystemMock
             ->expects($this->at(0))
             ->method('remove')
-            ->with('/aWebRoot/aCachePrefix/aFilterOne/aPathOne')
-        ;
+            ->with('/aWebRoot/aCachePrefix/aFilterOne/aPathOne');
         $filesystemMock
             ->expects($this->at(1))
             ->method('remove')
-            ->with('/aWebRoot/aCachePrefix/aFilterTwo/aPathOne')
-        ;
+            ->with('/aWebRoot/aCachePrefix/aFilterTwo/aPathOne');
         $filesystemMock
             ->expects($this->at(2))
             ->method('remove')
-            ->with('/aWebRoot/aCachePrefix/aFilterOne/aPathTwo')
-        ;
+            ->with('/aWebRoot/aCachePrefix/aFilterOne/aPathTwo');
         $filesystemMock
             ->expects($this->at(3))
             ->method('remove')
-            ->with('/aWebRoot/aCachePrefix/aFilterTwo/aPathTwo')
-        ;
+            ->with('/aWebRoot/aCachePrefix/aFilterTwo/aPathTwo');
 
         $resolver = new WebPathResolver(
             $filesystemMock,
@@ -406,8 +403,7 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
             ->method('remove')
             ->with(array(
                 '/aWebRoot/aCachePrefix/aFilter',
-            ))
-        ;
+            ));
 
         $resolver = new WebPathResolver(
             $filesystemMock,
@@ -428,8 +424,7 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
             ->with(array(
                 '/aWebRoot/aCachePrefix/aFilterOne',
                 '/aWebRoot/aCachePrefix/aFilterTwo',
-            ))
-        ;
+            ));
 
         $resolver = new WebPathResolver(
             $filesystemMock,
@@ -482,6 +477,6 @@ class WebPathResolverTest extends \PHPUnit_Framework_TestCase
      */
     protected function createFilesystemMock()
     {
-        return $this->getMock('Symfony\Component\Filesystem\Filesystem');
+        return $this->getMockBuilder('\Symfony\Component\Filesystem\Filesystem')->getMock();
     }
 }

--- a/Tests/Imagine/Cache/SignerTest.php
+++ b/Tests/Imagine/Cache/SignerTest.php
@@ -14,13 +14,16 @@ namespace Liip\ImagineBundle\Tests\Imagine\Cache;
 use Liip\ImagineBundle\Imagine\Cache\Signer;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Cache\Signer
+ */
 class SignerTest extends AbstractTest
 {
     public function testImplementsSignerInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\Imagine\Cache\Signer');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\Imagine\Cache\Signer');
 
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\Imagine\Cache\SignerInterface'));
+        $this->assertTrue($rc->implementsInterface('\Liip\ImagineBundle\Imagine\Cache\SignerInterface'));
     }
 
     public function testCouldBeConstructedWithSecret()

--- a/Tests/Imagine/Data/DataManagerTest.php
+++ b/Tests/Imagine/Data/DataManagerTest.php
@@ -11,24 +11,22 @@
 
 namespace Liip\ImagineBundle\Tests\Imagine\Data;
 
-use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
 use Liip\ImagineBundle\Imagine\Data\DataManager;
 use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Data\DataManager
+ * @covers \Liip\ImagineBundle\Imagine\Data\DataManager
  */
 class DataManagerTest extends AbstractTest
 {
     public function testUseDefaultLoaderUsedIfNoneSet()
     {
-        $loader = $this->getMockLoader();
+        $loader = $this->createBinaryLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('find')
-            ->with('cats.jpeg')
-        ;
+            ->with('cats.jpeg');
 
         $config = $this->createFilterConfigurationMock();
         $config
@@ -39,17 +37,15 @@ class DataManagerTest extends AbstractTest
                 'size' => array(180, 180),
                 'mode' => 'outbound',
                 'data_loader' => null,
-            )))
-        ;
+            )));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
-            ->will($this->returnValue('image/png'))
-        ;
+            ->will($this->returnValue('image/png'));
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->getMockExtensionGuesser(), $config, 'default');
+        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config, 'default');
         $dataManager->addLoader('default', $loader);
 
         $dataManager->find('thumbnail', 'cats.jpeg');
@@ -57,12 +53,11 @@ class DataManagerTest extends AbstractTest
 
     public function testUseLoaderRegisteredForFilterOnFind()
     {
-        $loader = $this->getMockLoader();
+        $loader = $this->createBinaryLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('find')
-            ->with('cats.jpeg')
-        ;
+            ->with('cats.jpeg');
 
         $config = $this->createFilterConfigurationMock();
         $config
@@ -73,30 +68,31 @@ class DataManagerTest extends AbstractTest
                 'size' => array(180, 180),
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            )))
-        ;
+            )));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
-            ->will($this->returnValue('image/png'))
-        ;
+            ->will($this->returnValue('image/png'));
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->getMockExtensionGuesser(), $config);
+        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config);
         $dataManager->addLoader('the_loader', $loader);
 
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The mime type of image cats.jpeg was not guessed
+     */
     public function testThrowsIfMimeTypeWasNotGuessedOnFind()
     {
-        $loader = $this->getMockLoader();
+        $loader = $this->createBinaryLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('find')
-            ->with('cats.jpeg')
-        ;
+            ->with('cats.jpeg');
 
         $config = $this->createFilterConfigurationMock();
         $config
@@ -107,32 +103,31 @@ class DataManagerTest extends AbstractTest
                 'size' => array(180, 180),
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            )))
-        ;
+            )));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
-            ->will($this->returnValue(null))
-        ;
+            ->will($this->returnValue(null));
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->getMockExtensionGuesser(), $config);
+        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config);
         $dataManager->addLoader('the_loader', $loader);
-
-        $this->setExpectedException('LogicException', 'The mime type of image cats.jpeg was not guessed.');
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The mime type of image cats.jpeg must be image/xxx got text/plain
+     */
     public function testThrowsIfMimeTypeNotImageOneOnFind()
     {
-        $loader = $this->getMockLoader();
+        $loader = $this->createBinaryLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('find')
             ->with('cats.jpeg')
-            ->will($this->returnValue('content'))
-        ;
+            ->will($this->returnValue('content'));
 
         $config = $this->createFilterConfigurationMock();
         $config
@@ -143,32 +138,31 @@ class DataManagerTest extends AbstractTest
                 'size' => array(180, 180),
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            )))
-        ;
+            )));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
-            ->will($this->returnValue('text/plain'))
-        ;
+            ->will($this->returnValue('text/plain'));
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->getMockExtensionGuesser(), $config);
+        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config);
         $dataManager->addLoader('the_loader', $loader);
-
-        $this->setExpectedException('LogicException', 'The mime type of image cats.jpeg must be image/xxx got text/plain.');
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The mime type of image cats.jpeg was not guessed
+     */
     public function testThrowsIfLoaderReturnBinaryWithEmtptyMimeTypeOnFind()
     {
-        $loader = $this->getMockLoader();
+        $loader = $this->createBinaryLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('find')
             ->with('cats.jpeg')
-            ->will($this->returnValue(new Binary('content', null)))
-        ;
+            ->will($this->returnValue(new Binary('content', null)));
 
         $config = $this->createFilterConfigurationMock();
         $config
@@ -179,33 +173,32 @@ class DataManagerTest extends AbstractTest
                 'size' => array(180, 180),
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            )))
-        ;
+            )));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->never())
-            ->method('guess')
-        ;
+            ->method('guess');
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->getMockExtensionGuesser(), $config);
+        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config);
         $dataManager->addLoader('the_loader', $loader);
-
-        $this->setExpectedException('LogicException', 'The mime type of image cats.jpeg was not guessed.');
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The mime type of image cats.jpeg must be image/xxx got text/plain
+     */
     public function testThrowsIfLoaderReturnBinaryWithMimeTypeNotImageOneOnFind()
     {
         $binary = new Binary('content', 'text/plain');
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createBinaryLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('find')
             ->with('cats.jpeg')
-            ->will($this->returnValue($binary))
-        ;
+            ->will($this->returnValue($binary));
 
         $config = $this->createFilterConfigurationMock();
         $config
@@ -216,22 +209,22 @@ class DataManagerTest extends AbstractTest
                 'size' => array(180, 180),
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            )))
-        ;
+            )));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->never())
-            ->method('guess')
-        ;
+            ->method('guess');
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->getMockExtensionGuesser(), $config);
+        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config);
         $dataManager->addLoader('the_loader', $loader);
-
-        $this->setExpectedException('LogicException', 'The mime type of image cats.jpeg must be image/xxx got text/plain.');
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Could not find data loader "" for "thumbnail" filter type
+     */
     public function testThrowIfLoaderNotRegisteredForGivenFilterOnFind()
     {
         $config = $this->createFilterConfigurationMock();
@@ -243,12 +236,9 @@ class DataManagerTest extends AbstractTest
                 'size' => array(180, 180),
                 'mode' => 'outbound',
                 'data_loader' => null,
-            )))
-        ;
+            )));
 
-        $dataManager = new DataManager($this->getMockMimeTypeGuesser(), $this->getMockExtensionGuesser(), $config);
-
-        $this->setExpectedException('InvalidArgumentException', 'Could not find data loader "" for "thumbnail" filter type');
+        $dataManager = new DataManager($this->createMimeTypeGuesserInterfaceMock(), $this->createExtensionGuesserInterfaceMock(), $config);
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
@@ -257,20 +247,18 @@ class DataManagerTest extends AbstractTest
         $expectedContent = 'theImageBinaryContent';
         $expectedMimeType = 'image/png';
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createBinaryLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('find')
-            ->will($this->returnValue($expectedContent))
-        ;
+            ->will($this->returnValue($expectedContent));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
             ->with($expectedContent)
-            ->will($this->returnValue($expectedMimeType))
-        ;
+            ->will($this->returnValue($expectedMimeType));
 
         $config = $this->createFilterConfigurationMock();
         $config
@@ -281,10 +269,9 @@ class DataManagerTest extends AbstractTest
                 'size' => array(180, 180),
                 'mode' => 'outbound',
                 'data_loader' => null,
-            )))
-        ;
+            )));
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->getMockExtensionGuesser(), $config, 'default');
+        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config, 'default');
         $dataManager->addLoader('default', $loader);
 
         $binary = $dataManager->find('thumbnail', 'cats.jpeg');
@@ -300,28 +287,25 @@ class DataManagerTest extends AbstractTest
         $mimeType = 'image/png';
         $expectedFormat = 'png';
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createBinaryLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('find')
-            ->will($this->returnValue($content))
-        ;
+            ->will($this->returnValue($content));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
             ->with($content)
-            ->will($this->returnValue($mimeType))
-        ;
+            ->will($this->returnValue($mimeType));
 
-        $extensionGuesser = $this->getMockExtensionGuesser();
+        $extensionGuesser = $this->createExtensionGuesserInterfaceMock();
         $extensionGuesser
             ->expects($this->once())
             ->method('guess')
             ->with($mimeType)
-            ->will($this->returnValue($expectedFormat))
-        ;
+            ->will($this->returnValue($expectedFormat));
 
         $config = $this->createFilterConfigurationMock();
         $config
@@ -332,8 +316,7 @@ class DataManagerTest extends AbstractTest
                 'size' => array(180, 180),
                 'mode' => 'outbound',
                 'data_loader' => null,
-            )))
-        ;
+            )));
 
         $dataManager = new DataManager($mimeTypeGuesser, $extensionGuesser, $config, 'default');
         $dataManager->addLoader('default', $loader);
@@ -346,7 +329,7 @@ class DataManagerTest extends AbstractTest
 
     public function testUseDefaultGlobalImageUsedIfImageNotFound()
     {
-        $loader = $this->getMockLoader();
+        $loader = $this->createBinaryLoaderInterfaceMock();
 
         $config = $this->createFilterConfigurationMock();
         $config
@@ -355,17 +338,15 @@ class DataManagerTest extends AbstractTest
             ->with('thumbnail')
             ->will($this->returnValue(array(
                 'default_image' => null,
-            )))
-        ;
+            )));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->never())
-            ->method('guess')
-        ;
+            ->method('guess');
 
         $defaultGlobalImage = 'cats.jpeg';
-        $dataManager = new DataManager($mimeTypeGuesser, $this->getMockExtensionGuesser(), $config, 'default', 'cats.jpeg');
+        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config, 'default', 'cats.jpeg');
         $dataManager->addLoader('default', $loader);
 
         $defaultImage = $dataManager->getDefaultImageUrl('thumbnail');
@@ -374,7 +355,7 @@ class DataManagerTest extends AbstractTest
 
     public function testUseDefaultFilterImageUsedIfImageNotFound()
     {
-        $loader = $this->getMockLoader();
+        $loader = $this->createBinaryLoaderInterfaceMock();
 
         $defaultFilterImage = 'cats.jpeg';
 
@@ -385,43 +366,17 @@ class DataManagerTest extends AbstractTest
             ->with('thumbnail')
             ->will($this->returnValue(array(
                 'default_image' => $defaultFilterImage,
-            )))
-        ;
+            )));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->never())
-            ->method('guess')
-        ;
+            ->method('guess');
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->getMockExtensionGuesser(), $config, 'default', null);
+        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config, 'default', null);
         $dataManager->addLoader('default', $loader);
 
         $defaultImage = $dataManager->getDefaultImageUrl('thumbnail');
         $this->assertEquals($defaultImage, $defaultFilterImage);
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|LoaderInterface
-     */
-    protected function getMockLoader()
-    {
-        return $this->getMock('Liip\ImagineBundle\Binary\Loader\LoaderInterface');
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Liip\ImagineBundle\Binary\MimeTypeGuesserInterface
-     */
-    protected function getMockMimeTypeGuesser()
-    {
-        return $this->getMock('Liip\ImagineBundle\Binary\MimeTypeGuesserInterface');
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface
-     */
-    protected function getMockExtensionGuesser()
-    {
-        return $this->getMock('Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface');
     }
 }

--- a/Tests/Imagine/Filter/FilterConfigurationTest.php
+++ b/Tests/Imagine/Filter/FilterConfigurationTest.php
@@ -15,7 +15,7 @@ use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Filter\FilterConfiguration
+ * @covers \Liip\ImagineBundle\Imagine\Filter\FilterConfiguration
  */
 class FilterConfigurationTest extends AbstractTest
 {
@@ -54,11 +54,13 @@ class FilterConfigurationTest extends AbstractTest
         $this->assertEquals(array('barConfig'), $filters['bar']);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Could not find configuration for a filter: thumbnail
+     */
     public function testGetUndefinedFilter()
     {
         $filterConfiguration = new FilterConfiguration();
-
-        $this->setExpectedException('RuntimeException', 'Could not find configuration for a filter: thumbnail');
         $filterConfiguration->get('thumbnail');
     }
 

--- a/Tests/Imagine/Filter/FilterManagerTest.php
+++ b/Tests/Imagine/Filter/FilterManagerTest.php
@@ -12,15 +12,18 @@
 namespace Liip\ImagineBundle\Tests\Filter;
 
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
-use Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface;
 use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Filter\FilterManager
+ * @covers \Liip\ImagineBundle\Imagine\Filter\FilterManager
  */
 class FilterManagerTest extends AbstractTest
 {
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Could not find filter loader for "thumbnail" filter type
+     */
     public function testThrowsIfNoLoadersAddedForFilterOnApplyFilter()
     {
         $config = $this->createFilterConfigurationMock();
@@ -36,18 +39,16 @@ class FilterManagerTest extends AbstractTest
                     ),
                 ),
                 'post_processors' => array(),
-            )))
-        ;
+            )));
 
         $binary = new Binary('aContent', 'image/png', 'png');
 
         $filterManager = new FilterManager(
             $config,
-            $this->createImagineMock(),
-            $this->getMockMimeTypeGuesser()
+            $this->createImagineInterfaceMock(),
+            $this->createMimeTypeGuesserInterfaceMock()
         );
 
-        $this->setExpectedException('InvalidArgumentException', 'Could not find filter loader for "thumbnail" filter type');
         $filterManager->applyFilter($binary, 'thumbnail');
     }
 
@@ -73,42 +74,38 @@ class FilterManagerTest extends AbstractTest
                     'thumbnail' => $thumbConfig,
                 ),
                 'post_processors' => array(),
-            )))
-        ;
+            )));
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($expectedFilteredContent))
-        ;
+            ->will($this->returnValue($expectedFilteredContent));
 
-        $imagine = $this->createImagineMock();
+        $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
             ->with($originalContent)
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $config,
             $imagine,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
 
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
         $this->assertEquals($expectedFilteredContent, $filteredBinary->getContent());
     }
 
@@ -134,41 +131,37 @@ class FilterManagerTest extends AbstractTest
                     'thumbnail' => $thumbConfig,
                 ),
                 'post_processors' => array(),
-            )))
-        ;
+            )));
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'))
-        ;
+            ->will($this->returnValue('aFilteredContent'));
 
-        $imagine = $this->createImagineMock();
+        $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $config,
             $imagine,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
 
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
         $this->assertEquals($expectedFormat, $filteredBinary->getFormat());
     }
 
@@ -196,41 +189,37 @@ class FilterManagerTest extends AbstractTest
                     'thumbnail' => $thumbConfig,
                 ),
                 'post_processors' => array(),
-            )))
-        ;
+            )));
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'))
-        ;
+            ->will($this->returnValue('aFilteredContent'));
 
-        $imagine = $this->createImagineMock();
+        $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $config,
             $imagine,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
 
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
         $this->assertEquals($expectedFormat, $filteredBinary->getFormat());
     }
 
@@ -256,36 +245,31 @@ class FilterManagerTest extends AbstractTest
                     'thumbnail' => $thumbConfig,
                 ),
                 'post_processors' => array(),
-            )))
-        ;
+            )));
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'))
-        ;
+            ->will($this->returnValue('aFilteredContent'));
 
-        $imagine = $this->createImagineMock();
+        $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->never())
-            ->method('guess')
-        ;
+            ->method('guess');
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $config,
@@ -296,7 +280,7 @@ class FilterManagerTest extends AbstractTest
 
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
         $this->assertEquals($expectedMimeType, $filteredBinary->getMimeType());
     }
 
@@ -325,38 +309,33 @@ class FilterManagerTest extends AbstractTest
                     'thumbnail' => $thumbConfig,
                 ),
                 'post_processors' => array(),
-            )))
-        ;
+            )));
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($expectedContent))
-        ;
+            ->will($this->returnValue($expectedContent));
 
-        $imagine = $this->createImagineMock();
+        $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
             ->with($expectedContent)
-            ->will($this->returnValue($expectedMimeType))
-        ;
+            ->will($this->returnValue($expectedMimeType));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $config,
@@ -367,7 +346,7 @@ class FilterManagerTest extends AbstractTest
 
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
         $this->assertEquals($expectedMimeType, $filteredBinary->getMimeType());
     }
 
@@ -394,40 +373,36 @@ class FilterManagerTest extends AbstractTest
                     'thumbnail' => $thumbConfig,
                 ),
                 'post_processors' => array(),
-            )))
-        ;
+            )));
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
             ->with('png', array('quality' => $expectedQuality))
-            ->will($this->returnValue('aFilteredContent'))
-        ;
+            ->will($this->returnValue('aFilteredContent'));
 
-        $imagine = $this->createImagineMock();
+        $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $config,
             $imagine,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filterManager->applyFilter($binary, 'thumbnail'));
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filterManager->applyFilter($binary, 'thumbnail'));
     }
 
     public function testAlters100QualityIfNotSetOnApplyFilter()
@@ -452,40 +427,36 @@ class FilterManagerTest extends AbstractTest
                     'thumbnail' => $thumbConfig,
                 ),
                 'post_processors' => array(),
-            )))
-        ;
+            )));
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
             ->with('png', array('quality' => $expectedQuality))
-            ->will($this->returnValue('aFilteredContent'))
-        ;
+            ->will($this->returnValue('aFilteredContent'));
 
-        $imagine = $this->createImagineMock();
+        $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $config,
             $imagine,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filterManager->applyFilter($binary, 'thumbnail'));
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filterManager->applyFilter($binary, 'thumbnail'));
     }
 
     public function testMergeRuntimeConfigWithOneFromFilterConfigurationOnApplyFilter()
@@ -521,55 +492,53 @@ class FilterManagerTest extends AbstractTest
                     'thumbnail' => $thumbConfig,
                 ),
                 'post_processors' => array(),
-            )))
-        ;
+            )));
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'))
-        ;
+            ->will($this->returnValue('aFilteredContent'));
 
-        $imagine = $this->createImagineMock();
+        $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbMergedConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $config,
             $imagine,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
 
         $this->assertInstanceOf(
-            'Liip\ImagineBundle\Model\Binary',
+            '\Liip\ImagineBundle\Model\Binary',
             $filterManager->applyFilter($binary, 'thumbnail', $runtimeConfig)
         );
     }
-
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Could not find filter loader for "thumbnail" filter type
+     */
     public function testThrowsIfNoLoadersAddedForFilterOnApply()
     {
         $binary = new Binary('aContent', 'image/png', 'png');
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
-            $this->createImagineMock(),
-            $this->getMockMimeTypeGuesser()
+            $this->createImagineInterfaceMock(),
+            $this->createMimeTypeGuesserInterfaceMock()
         );
 
-        $this->setExpectedException('InvalidArgumentException', 'Could not find filter loader for "thumbnail" filter type');
         $filterManager->apply($binary, array(
             'filters' => array(
                 'thumbnail' => array(
@@ -592,33 +561,30 @@ class FilterManagerTest extends AbstractTest
             'mode' => 'outbound',
         );
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($expectedFilteredContent))
-        ;
+            ->will($this->returnValue($expectedFilteredContent));
 
-        $imagineMock = $this->createImagineMock();
+        $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
             ->with($originalContent)
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
             $imagineMock,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
 
@@ -629,7 +595,7 @@ class FilterManagerTest extends AbstractTest
             'post_processors' => array(),
         ));
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
         $this->assertEquals($expectedFilteredContent, $filteredBinary->getContent());
     }
 
@@ -645,32 +611,29 @@ class FilterManagerTest extends AbstractTest
             'mode' => 'outbound',
         );
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'))
-        ;
+            ->will($this->returnValue('aFilteredContent'));
 
-        $imagineMock = $this->createImagineMock();
+        $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
             $imagineMock,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
 
@@ -681,7 +644,7 @@ class FilterManagerTest extends AbstractTest
             'post_processors' => array(),
         ));
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
         $this->assertEquals($expectedFormat, $filteredBinary->getFormat());
     }
 
@@ -698,32 +661,29 @@ class FilterManagerTest extends AbstractTest
             'mode' => 'outbound',
         );
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'))
-        ;
+            ->will($this->returnValue('aFilteredContent'));
 
-        $imagineMock = $this->createImagineMock();
+        $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
             $imagineMock,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
 
@@ -735,7 +695,7 @@ class FilterManagerTest extends AbstractTest
             'post_processors' => array(),
         ));
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
         $this->assertEquals($expectedFormat, $filteredBinary->getFormat());
     }
 
@@ -751,33 +711,29 @@ class FilterManagerTest extends AbstractTest
             'mode' => 'outbound',
         );
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'))
-        ;
+            ->will($this->returnValue('aFilteredContent'));
 
-        $imagineMock = $this->createImagineMock();
+        $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->never())
-            ->method('guess')
-        ;
+            ->method('guess');
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
@@ -793,7 +749,7 @@ class FilterManagerTest extends AbstractTest
             'post_processors' => array(),
         ));
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
         $this->assertEquals($expectedMimeType, $filteredBinary->getMimeType());
     }
 
@@ -811,35 +767,31 @@ class FilterManagerTest extends AbstractTest
             'mode' => 'outbound',
         );
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($expectedContent))
-        ;
+            ->will($this->returnValue($expectedContent));
 
-        $imagineMock = $this->createImagineMock();
+        $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $mimeTypeGuesser = $this->getMockMimeTypeGuesser();
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
             ->with($expectedContent)
-            ->will($this->returnValue($expectedMimeType))
-        ;
+            ->will($this->returnValue($expectedMimeType));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
@@ -856,7 +808,7 @@ class FilterManagerTest extends AbstractTest
             'post_processors' => array(),
         ));
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
         $this->assertEquals($expectedMimeType, $filteredBinary->getMimeType());
     }
 
@@ -872,33 +824,30 @@ class FilterManagerTest extends AbstractTest
             'mode' => 'outbound',
         );
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
             ->with('png', array('quality' => $expectedQuality))
-            ->will($this->returnValue('aFilteredContent'))
-        ;
+            ->will($this->returnValue('aFilteredContent'));
 
-        $imagineMock = $this->createImagineMock();
+        $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
             $imagineMock,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
 
@@ -910,7 +859,7 @@ class FilterManagerTest extends AbstractTest
             'post_processors' => array(),
         ));
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
     }
 
     public function testAlters100QualityIfNotSetOnApply()
@@ -925,33 +874,30 @@ class FilterManagerTest extends AbstractTest
             'mode' => 'outbound',
         );
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
             ->with('png', array('quality' => $expectedQuality))
-            ->will($this->returnValue('aFilteredContent'))
-        ;
+            ->will($this->returnValue('aFilteredContent'));
 
-        $imagineMock = $this->createImagineMock();
+        $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
             $imagineMock,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
 
@@ -962,7 +908,7 @@ class FilterManagerTest extends AbstractTest
             'post_processors' => array(),
         ));
 
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
     }
 
     public function testApplyPostProcessor()
@@ -988,40 +934,36 @@ class FilterManagerTest extends AbstractTest
                 'post_processors' => array(
                     'foo' => array(),
                 ),
-            )))
-        ;
+            )));
 
         $thumbConfig = array(
             'size' => array(180, 180),
             'mode' => 'outbound',
         );
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($originalContent))
-        ;
+            ->will($this->returnValue($originalContent));
 
-        $imagineMock = $this->createImagineMock();
+        $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
             ->with($originalContent)
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $processedBinary = new Binary($expectedPostProcessedContent, 'image/png', 'png');
 
-        $postProcessor = $this->getPostProcessorMock();
+        $postProcessor = $this->createPostProcessorInterfaceMock();
         $postProcessor
             ->expects($this->once())
             ->method('process')
@@ -1031,16 +973,19 @@ class FilterManagerTest extends AbstractTest
         $filterManager = new FilterManager(
             $config,
             $imagineMock,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
         $filterManager->addLoader('thumbnail', $loader);
         $filterManager->addPostProcessor('foo', $postProcessor);
 
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
-        $this->assertInstanceOf('Liip\ImagineBundle\Model\Binary', $filteredBinary);
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\Binary', $filteredBinary);
         $this->assertEquals($expectedPostProcessedContent, $filteredBinary->getContent());
     }
-
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Could not find post processor "foo"
+     */
     public function testThrowsIfNoPostProcessorAddedForFilterOnApplyFilter()
     {
         $originalContent = 'aContent';
@@ -1063,56 +1008,50 @@ class FilterManagerTest extends AbstractTest
                 'post_processors' => array(
                     'foo' => array(),
                 ),
-            )))
-        ;
+            )));
 
         $thumbConfig = array(
             'size' => array(180, 180),
             'mode' => 'outbound',
         );
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($originalContent))
-        ;
+            ->will($this->returnValue($originalContent));
 
-        $imagineMock = $this->createImagineMock();
+        $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
             ->with($originalContent)
-            ->will($this->returnValue($image))
-        ;
+            ->will($this->returnValue($image));
 
-        $loader = $this->getMockLoader();
+        $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0))
-        ;
+            ->will($this->returnArgument(0));
 
         $filterManager = new FilterManager(
             $config,
             $imagineMock,
-            $this->getMockMimeTypeGuesser()
+            $this->createMimeTypeGuesserInterfaceMock()
         );
+
         $filterManager->addLoader('thumbnail', $loader);
-
-        $this->setExpectedException('InvalidArgumentException', 'Could not find post processor "foo"');
-
         $filterManager->applyFilter($binary, 'thumbnail');
     }
 
     public function testApplyPostProcessorsWhenNotDefined()
     {
-        $binary = $this->getMock('Liip\ImagineBundle\Binary\BinaryInterface');
+        $binary = $this->getMockBuilder('\Liip\ImagineBundle\Binary\BinaryInterface')->getMock();
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
-            $this->createImagineMock(),
-            $this->getMockMimeTypeGuesser()
+            $this->createImagineInterfaceMock(),
+            $this->createMimeTypeGuesserInterfaceMock()
         );
 
         $this->assertSame($binary, $filterManager->applyPostProcessors($binary, array()));
@@ -1121,21 +1060,9 @@ class FilterManagerTest extends AbstractTest
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|LoaderInterface
      */
-    protected function getMockLoader()
+    protected function createFilterLoaderInterfaceMock()
     {
-        return $this->getMock('Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Liip\ImagineBundle\Binary\MimeTypeGuesserInterface
-     */
-    protected function getMockMimeTypeGuesser()
-    {
-        return $this->getMock('Liip\ImagineBundle\Binary\MimeTypeGuesserInterface');
-    }
-
-    protected function getPostProcessorMock()
-    {
-        return $this->getMock('Liip\ImagineBundle\Imagine\Filter\PostProcessor\PostProcessorInterface');
+//        $this->getMock()
+        return $this->createObjectMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
     }
 }

--- a/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
@@ -15,10 +15,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\AutoRotateFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * Test cases for RotateFilterLoader class.
- * Depending on the EXIF value checks whether rotate and flip are called.
- *
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\AutoRotateFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\AutoRotateFilterLoader
  */
 class AutoRotateFilterLoaderTest extends AbstractTest
 {
@@ -36,12 +33,12 @@ class AutoRotateFilterLoaderTest extends AbstractTest
         $loader = new AutoRotateFilterLoader();
 
         // Mocks the image and makes it use the fake meta data.
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
 
-        if (method_exists('Imagine\Image\ImageInterface', 'metadata')) {
+        if (method_exists('\Imagine\Image\ImageInterface', 'metadata')) {
             // Mocks the metadata and makes it return the expected exif value for the rotation.
             // If $exifValue is null, it means the image doesn't contain any metadata.
-            $metaData = $this->getMockMetaData();
+            $metaData = $this->getMetadataBagMock();
 
             $metaData
                 ->expects($this->atLeastOnce())

--- a/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
@@ -17,9 +17,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\CropFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * Test cases for CropFilterLoader class.
- *
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\CropFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\CropFilterLoader
  *
  * @author Alex Wilson <a@ax.gy>
  */
@@ -29,7 +27,7 @@ class CropFilterLoaderTest extends AbstractTest
      * @param int[] $coordinates
      * @param int[] $area
      *
-     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\CropFilterLoader::load
+     * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\CropFilterLoader::load
      *
      * @dataProvider cropDataProvider
      */
@@ -43,7 +41,7 @@ class CropFilterLoaderTest extends AbstractTest
 
         $loader = new CropFilterLoader();
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image->expects($this->once())
             ->method('crop')
             ->with(new Point($x, $y), new Box($width, $height))

--- a/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
@@ -16,9 +16,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * Test cases for DownscaleFilterLoader class.
- *
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader
  *
  * @author Minin Anton <anton.a.minin@gmail.com>
  */
@@ -31,17 +29,15 @@ class DownscaleFilterLoaderTest extends AbstractTest
         $initialSize = new Box(50, 200);
         $resultSize = new Box(50, 200);
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->method('getSize')
-            ->willReturn($initialSize)
-        ;
+            ->willReturn($initialSize);
         $image
             ->method('resize')
             ->willReturnCallback(function ($box) use (&$resultSize) {
                 $resultSize = $box;
-            })
-        ;
+            });
 
         $loader->load($image, array('max' => array(100, 90)));
 

--- a/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundDownscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundDownscaleFilterLoaderTest.php
@@ -16,7 +16,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader
  *
  * Due to int casting in Imagine\Image\Box which can lead to wrong pixel
  * numbers ( e.g. float(201) casted to int(200) ). Solved by round the

--- a/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundUpscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundUpscaleFilterLoaderTest.php
@@ -16,7 +16,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\UpscaleFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\UpscaleFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\UpscaleFilterLoader
  *
  * Due to int casting in Imagine\Image\Box which can lead to wrong pixel
  * numbers ( e.g. float(201) casted to int(200) ). Solved by round the

--- a/Tests/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
@@ -19,9 +19,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\GrayscaleFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * Test cases for GrayscaleFilterLoader class.
- *
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\GrayscaleFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\GrayscaleFilterLoader
  *
  * @author Gregoire Humeau <gregoire.humeau@gmail.com>
  */

--- a/Tests/Imagine/Filter/Loader/InterlaceFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/InterlaceFilterLoaderTest.php
@@ -15,7 +15,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\InterlaceFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\InterlaceFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\InterlaceFilterLoader
  */
 class InterlaceFilterLoaderTest extends AbstractTest
 {
@@ -23,7 +23,7 @@ class InterlaceFilterLoaderTest extends AbstractTest
     {
         $loader = new InterlaceFilterLoader();
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('interlace')
@@ -32,6 +32,6 @@ class InterlaceFilterLoaderTest extends AbstractTest
 
         $result = $loader->load($image, array('mode' => 'TEST'));
 
-        $this->assertInstanceOf('Imagine\Image\ImageInterface', $result);
+        $this->assertInstanceOf('\Imagine\Image\ImageInterface', $result);
     }
 }

--- a/Tests/Imagine/Filter/Loader/PasteFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/PasteFilterLoaderTest.php
@@ -17,9 +17,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * Test cases for PasteFilterLoader class.
- *
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader
  *
  * @author Alex Wilson <a@ax.gy>
  */
@@ -40,7 +38,7 @@ class PasteFilterLoaderTest extends AbstractTest
      * @param int   $y
      * @param Point $expected
      *
-     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader::load
+     * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader::load
      *
      * @dataProvider pasteProvider
      */
@@ -50,7 +48,7 @@ class PasteFilterLoaderTest extends AbstractTest
             self::DUMMY_IMAGE_WIDTH,
             self::DUMMY_IMAGE_HEIGHT
         );
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image->method('getSize')->willReturn($mockImageSize);
         $image->method('copy')->willReturn($image);
         $image->expects($this->once())
@@ -58,7 +56,7 @@ class PasteFilterLoaderTest extends AbstractTest
             ->with($image, $expected)
             ->willReturn($image);
 
-        $imagineMock = $this->createImagineMock();
+        $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->method('open')
             ->willReturn($image);

--- a/Tests/Imagine/Filter/Loader/ResizeFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ResizeFilterLoaderTest.php
@@ -16,9 +16,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\ResizeFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * Test cases for ResizeFilterLoader class.
- *
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ResizeFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ResizeFilterLoader
  *
  * @author Alex Wilson <a@ax.gy>
  */
@@ -28,7 +26,7 @@ class ResizeFilterLoaderTest extends AbstractTest
      * @param int $width
      * @param int $height
      *
-     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ResizeFilterLoader::load
+     * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ResizeFilterLoader::load
      *
      * @dataProvider resizeDataProvider
      */
@@ -36,7 +34,7 @@ class ResizeFilterLoaderTest extends AbstractTest
     {
         $loader = new ResizeFilterLoader();
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image->expects($this->once())
             ->method('resize')
             ->with(new Box($width, $height))

--- a/Tests/Imagine/Filter/Loader/RotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/RotateFilterLoaderTest.php
@@ -15,9 +15,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\RotateFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * Test cases for RotateFilterLoader class.
- *
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\RotateFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\RotateFilterLoader
  *
  * @author Bocharsky Victor <bocharsky.bw@gmail.com>
  */
@@ -27,7 +25,7 @@ class RotateFilterLoaderTest extends AbstractTest
     {
         $loader = new RotateFilterLoader();
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
 
         $result = $loader->load($image, array('angle' => 0));
         $this->assertSame($image, $result);
@@ -37,8 +35,8 @@ class RotateFilterLoaderTest extends AbstractTest
     {
         $loader = new RotateFilterLoader();
 
-        $image = $this->getMockImage();
-        $rotatedImage = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
+        $rotatedImage = $this->getImageInterfaceMock();
 
         $image
             ->expects($this->once())

--- a/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
@@ -17,9 +17,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\UpscaleFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * Test cases for ScaleFilterLoader class.
- *
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader
  *
  * @author Alex Wilson <a@ax.gy>
  */
@@ -51,7 +49,7 @@ class ScaleFilterLoaderTest extends AbstractTest
             self::UPSCALE_DUMMY_IMAGE_WIDTH,
             self::UPSCALE_DUMMY_IMAGE_HEIGHT
         );
-        $mockImage = parent::getMockImage();
+        $mockImage = parent::getImageInterfaceMock();
         $mockImage->method('getSize')->willReturn(new Box(
             self::UPSCALE_DUMMY_IMAGE_WIDTH,
             self::UPSCALE_DUMMY_IMAGE_HEIGHT
@@ -60,13 +58,13 @@ class ScaleFilterLoaderTest extends AbstractTest
         return $mockImage;
     }
 
-    protected function getMockImage()
+    protected function getImageInterfaceMock()
     {
         $mockImageSize = new Box(
             self::DUMMY_IMAGE_WIDTH,
             self::DUMMY_IMAGE_HEIGHT
         );
-        $mockImage = parent::getMockImage();
+        $mockImage = parent::getImageInterfaceMock();
         $mockImage->method('getSize')->willReturn(new Box(
             self::DUMMY_IMAGE_WIDTH,
             self::DUMMY_IMAGE_HEIGHT
@@ -76,12 +74,12 @@ class ScaleFilterLoaderTest extends AbstractTest
     }
 
     /**
-     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader::load
+     * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader::load
      */
     public function testItShouldPreserveRatio()
     {
         $loader = new ScaleFilterLoader();
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image->expects($this->once())
             ->method('resize')
             ->with(new Box(
@@ -99,7 +97,7 @@ class ScaleFilterLoaderTest extends AbstractTest
      * @param int[] $dimension
      * @param Box   $expected
      *
-     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader::load
+     * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader::load
      *
      * @dataProvider dimensionsDataProvider
      */
@@ -107,7 +105,7 @@ class ScaleFilterLoaderTest extends AbstractTest
     {
         $loader = new ScaleFilterLoader();
 
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image->expects($this->once())
             ->method('resize')
             ->with($expected)
@@ -121,14 +119,14 @@ class ScaleFilterLoaderTest extends AbstractTest
     }
 
     /**
-     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader::load
+     * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader::load
      *
      * @expectedException \InvalidArgumentException
      */
     public function itShouldThrowInvalidArgumentException()
     {
         $scale = new ScaleFilterLoader('foo', 'bar');
-        $scale->load($this->getMockImage(), array());
+        $scale->load($this->getImageInterfaceMock(), array());
     }
 
     /**

--- a/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
@@ -16,9 +16,7 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * Test cases for ThumbnailFilterLoader class.
- *
- * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader
  *
  * @author Alex Wilson <a@ax.gy>
  */
@@ -39,7 +37,7 @@ class ThumbnailFilterLoaderTest extends AbstractTest
      * @param int $height
      * @param Box $expected
      *
-     * @covers Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader::load
+     * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader::load
      *
      * @dataProvider heightWidthProvider
      */
@@ -51,7 +49,7 @@ class ThumbnailFilterLoaderTest extends AbstractTest
             self::DUMMY_IMAGE_WIDTH,
             self::DUMMY_IMAGE_HEIGHT
         );
-        $image = $this->getMockImage();
+        $image = $this->getImageInterfaceMock();
         $image->method('getSize')->willReturn($mockImageSize);
         $image->method('copy')->willReturn($image);
         $image->expects($this->once())

--- a/Tests/LiipImagineBundleTest.php
+++ b/Tests/LiipImagineBundleTest.php
@@ -11,12 +11,14 @@
 
 namespace Liip\ImagineBundle\Tests;
 
+use Liip\ImagineBundle\DependencyInjection\LiipImagineExtension;
 use Liip\ImagineBundle\LiipImagineBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @covers \Liip\ImagineBundle\LiipImagineBundle
  */
-class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
+class LiipImagineBundleTest extends AbstractTest
 {
     public function testSubClassOfBundle()
     {
@@ -30,7 +32,7 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createExtensionMock()));
+            ->will($this->returnValue($this->createLiipImagineExtensionMock()));
         $containerMock
             ->expects($this->at(0))
             ->method('addCompilerPass')
@@ -47,7 +49,7 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createExtensionMock()));
+            ->will($this->returnValue($this->createLiipImagineExtensionMock()));
         $containerMock
             ->expects($this->at(1))
             ->method('addCompilerPass')
@@ -64,7 +66,7 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createExtensionMock()));
+            ->will($this->returnValue($this->createLiipImagineExtensionMock()));
         $containerMock
             ->expects($this->at(2))
             ->method('addCompilerPass')
@@ -81,7 +83,7 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createExtensionMock()));
+            ->will($this->returnValue($this->createLiipImagineExtensionMock()));
         $containerMock
             ->expects($this->at(3))
             ->method('addCompilerPass')
@@ -98,7 +100,7 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createExtensionMock()));
+            ->will($this->returnValue($this->createLiipImagineExtensionMock()));
         $containerMock
             ->expects($this->at(4))
             ->method('addCompilerPass')
@@ -110,7 +112,7 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
 
     public function testAddWebPathResolverFactoryOnBuild()
     {
-        $extensionMock = $this->createExtensionMock();
+        $extensionMock = $this->createLiipImagineExtensionMock();
         $extensionMock
             ->expects($this->at(0))
             ->method('addResolverFactory')
@@ -129,7 +131,7 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
 
     public function testAddAwsS3ResolverFactoryOnBuild()
     {
-        $extensionMock = $this->createExtensionMock();
+        $extensionMock = $this->createLiipImagineExtensionMock();
         $extensionMock
             ->expects($this->at(1))
             ->method('addResolverFactory')
@@ -148,7 +150,7 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
 
     public function testAddFlysystemResolverFactoryOnBuild()
     {
-        $extensionMock = $this->createExtensionMock();
+        $extensionMock = $this->createLiipImagineExtensionMock();
         $extensionMock
             ->expects($this->at(2))
             ->method('addResolverFactory')
@@ -167,7 +169,7 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
 
     public function testAddStreamLoaderFactoryOnBuild()
     {
-        $extensionMock = $this->createExtensionMock();
+        $extensionMock = $this->createLiipImagineExtensionMock();
         $extensionMock
             ->expects($this->at(3))
             ->method('addLoaderFactory')
@@ -186,7 +188,7 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
 
     public function testAddFilesystemLoaderFactoryOnBuild()
     {
-        $extensionMock = $this->createExtensionMock();
+        $extensionMock = $this->createLiipImagineExtensionMock();
         $extensionMock
             ->expects($this->at(4))
             ->method('addLoaderFactory')
@@ -205,7 +207,7 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
 
     public function testAddFlysystemLoaderFactoryOnBuild()
     {
-        $extensionMock = $this->createExtensionMock();
+        $extensionMock = $this->createLiipImagineExtensionMock();
         $extensionMock
             ->expects($this->at(5))
             ->method('addLoaderFactory')
@@ -222,19 +224,23 @@ class LiipImagineBundleTest extends \Phpunit_Framework_TestCase
         $bundle->build($containerMock);
     }
 
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|ContainerBuilder
+     */
     protected function createContainerBuilderMock()
     {
-        return $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder', array(), array(), '', false);
+        return $this->createObjectMock('Symfony\Component\DependencyInjection\ContainerBuilder', array(), false);
     }
 
-    protected function createExtensionMock()
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|LiipImagineExtension
+     */
+    protected function createLiipImagineExtensionMock()
     {
-        $methods = array(
+        return $this->createObjectMock('Liip\ImagineBundle\DependencyInjection\LiipImagineExtension', array(
             'getNamespace',
             'addResolverFactory',
             'addLoaderFactory',
-        );
-
-        return $this->getMock('Liip\ImagineBundle\DependencyInjection\LiipImagineExtension', $methods, array(), '', false);
+        ), false);
     }
 }

--- a/Tests/Model/BinaryTest.php
+++ b/Tests/Model/BinaryTest.php
@@ -14,15 +14,15 @@ namespace Liip\ImagineBundle\Tests\Model;
 use Liip\ImagineBundle\Model\Binary;
 
 /**
- * @covers Liip\ImagineBundle\Model\Binary
+ * @covers \Liip\ImagineBundle\Model\Binary
  */
 class BinaryTest extends \PHPUnit_Framework_TestCase
 {
     public function testImplementsBinaryInterface()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\Model\Binary');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\Model\Binary');
 
-        $this->assertTrue($rc->implementsInterface('Liip\ImagineBundle\Binary\BinaryInterface'));
+        $this->assertTrue($rc->implementsInterface('\Liip\ImagineBundle\Binary\BinaryInterface'));
     }
 
     public function testAllowGetContentSetInConstructor()

--- a/Tests/Templating/Helper/ImagineHelperTest.php
+++ b/Tests/Templating/Helper/ImagineHelperTest.php
@@ -11,19 +11,19 @@
 
 namespace Liip\ImagineBundle\Tests\Templating\Helper;
 
-use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Templating\Helper\ImagineHelper;
+use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Templating\Helper\ImagineHelper
+ * @covers \Liip\ImagineBundle\Templating\Helper\ImagineHelper
  */
-class ImagineHelperTest extends \PHPUnit_Framework_TestCase
+class ImagineHelperTest extends AbstractTest
 {
     public function testSubClassOfHelper()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\Templating\Helper\ImagineHelper');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\Templating\Helper\ImagineHelper');
 
-        $this->assertTrue($rc->isSubclassOf('Symfony\Component\Templating\Helper\Helper'));
+        $this->assertTrue($rc->isSubclassOf('\Symfony\Component\Templating\Helper\Helper'));
     }
 
     public function testCouldBeConstructedWithCacheManagerAsArgument()
@@ -49,19 +49,10 @@ class ImagineHelperTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getBrowserPath')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue($expectedCachePath))
-        ;
+            ->will($this->returnValue($expectedCachePath));
 
         $helper = new ImagineHelper($cacheManager);
 
         $this->assertEquals($expectedCachePath, $helper->filter($expectedPath, $expectedFilter));
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|CacheManager
-     */
-    protected function createCacheManagerMock()
-    {
-        return $this->getMock('Liip\ImagineBundle\Imagine\Cache\CacheManager', array(), array(), '', false);
     }
 }

--- a/Tests/Templating/ImagineExtensionTest.php
+++ b/Tests/Templating/ImagineExtensionTest.php
@@ -13,17 +13,18 @@ namespace Liip\ImagineBundle\Tests\Templating\Helper;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Templating\ImagineExtension;
+use Liip\ImagineBundle\Tests\AbstractTest;
 
 /**
- * @covers Liip\ImagineBundle\Templating\ImagineExtension
+ * @covers \Liip\ImagineBundle\Templating\ImagineExtension
  */
-class ImagineExtensionTest extends \PHPUnit_Framework_TestCase
+class ImagineExtensionTest extends AbstractTest
 {
     public function testSubClassOfHelper()
     {
-        $rc = new \ReflectionClass('Liip\ImagineBundle\Templating\ImagineExtension');
+        $rc = new \ReflectionClass('\Liip\ImagineBundle\Templating\ImagineExtension');
 
-        $this->assertTrue($rc->isSubclassOf('Twig_Extension'));
+        $this->assertTrue($rc->isSubclassOf('\Twig_Extension'));
     }
 
     public function testCouldBeConstructedWithCacheManagerAsArgument()
@@ -49,8 +50,7 @@ class ImagineExtensionTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getBrowserPath')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue($expectedCachePath))
-        ;
+            ->will($this->returnValue($expectedCachePath));
 
         $extension = new ImagineExtension($cacheManager);
 
@@ -65,13 +65,5 @@ class ImagineExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $filters);
         $this->assertCount(1, $filters);
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|CacheManager
-     */
-    protected function createCacheManagerMock()
-    {
-        return $this->getMock('Liip\ImagineBundle\Imagine\Cache\CacheManager', array(), array(), '', false);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,13 @@
         "symfony/translation": "~2.3|~3.0"
     },
     "require-dev": {
+        "ext-gd": "*",
         "amazonwebservices/aws-sdk-for-php": "~1.0",
         "aws/aws-sdk-php": "~2.4",
         "doctrine/cache": "~1.1",
         "doctrine/orm": "~2.3",
-        "ext-gd": "*",
         "friendsofphp/php-cs-fixer": "~2.0",
-        "phpunit/phpunit": "~4.3",
+        "phpunit/phpunit": "~4.3|~5.0",
         "psr/log": "~1.0",
         "satooshi/php-coveralls": "~1.0",
         "sllh/php-cs-fixer-styleci-bridge": "~2.1",
@@ -50,16 +50,16 @@
         "twig/twig": "~1.12|~2.0"
     },
     "suggest": {
-        "alcaeus/mongo-php-adapter": "required on PHP >= 7.0 to use mongo components with mongodb extension",
-        "amazonwebservices/aws-sdk-for-php": "required to use AWS version 1 cache resolver",
-        "aws/aws-sdk-php": "required to use AWS version 2/3 cache resolver",
-        "doctrine/mongodb-odm": "required to use mongodb-backed doctrine components",
         "ext-exif": "required to read EXIF metadata from images",
         "ext-gd": "required to use gd driver",
         "ext-gmagick": "required to use gmagick driver",
         "ext-imagick": "required to use imagick driver",
         "ext-mongo": "required for mongodb components on PHP <7.0",
         "ext-mongodb": "required for mongodb components on PHP >=7.0",
+        "alcaeus/mongo-php-adapter": "required on PHP >= 7.0 to use mongo components with mongodb extension",
+        "amazonwebservices/aws-sdk-for-php": "required to use AWS version 1 cache resolver",
+        "aws/aws-sdk-php": "required to use AWS version 2/3 cache resolver",
+        "doctrine/mongodb-odm": "required to use mongodb-backed doctrine components",
         "league/flysystem": "required to use FlySystem data loader or cache resolver",
         "monolog/monolog": "A psr/log compatible logger is required to enable logging",
         "twig/twig": "required to use the provided Twig extension. Version 1.12 or greater needed"


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Support PHPUnit `5.x` officially in `composer.json` and fix up unit tests to remove all deprecation warning introduced. Additional cleanup of unit tests included, as well.