### PR TITLE
Revert adding leading slash to S3 class names

### DIFF
--- a/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
@@ -25,12 +25,12 @@ class AwsS3ResolverFactory implements ResolverFactoryInterface
     public function create(ContainerBuilder $container, $resolverName, array $config)
     {
         $awsS3ClientId = 'liip_imagine.cache.resolver.'.$resolverName.'.client';
-        $awsS3ClientDefinition = new Definition('\Aws\S3\S3Client');
+        $awsS3ClientDefinition = new Definition('Aws\S3\S3Client');
         if (method_exists($awsS3ClientDefinition, 'setFactory')) {
-            $awsS3ClientDefinition->setFactory(array('\Aws\S3\S3Client', 'factory'));
+            $awsS3ClientDefinition->setFactory(array('Aws\S3\S3Client', 'factory'));
         } else {
             // to be removed when dependency on Symfony DependencyInjection is bumped to 2.6
-            $awsS3ClientDefinition->setFactoryClass('\Aws\S3\S3Client');
+            $awsS3ClientDefinition->setFactoryClass('Aws\S3\S3Client');
             $awsS3ClientDefinition->setFactoryMethod('factory');
         }
         $awsS3ClientDefinition->addArgument($config['client_config']);

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -116,7 +116,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.client'));
 
         $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.client');
-        $this->assertEquals('\Aws\S3\S3Client', $clientDefinition->getClass());
+        $this->assertEquals('Aws\S3\S3Client', $clientDefinition->getClass());
         $this->assertEquals(array('theClientConfigKey' => 'theClientConfigVal'), $clientDefinition->getArgument(0));
     }
 
@@ -142,7 +142,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
         ));
 
         $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.client');
-        $this->assertEquals(array('\Aws\S3\S3Client', 'factory'), $clientDefinition->getFactory());
+        $this->assertEquals(array('Aws\S3\S3Client', 'factory'), $clientDefinition->getFactory());
     }
 
     /**
@@ -170,7 +170,7 @@ class AwsS3ResolverFactoryTest extends \Phpunit_Framework_TestCase
         ));
 
         $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.client');
-        $this->assertEquals('\Aws\S3\S3Client', $clientDefinition->getFactoryClass());
+        $this->assertEquals('Aws\S3\S3Client', $clientDefinition->getFactoryClass());
         $this->assertEquals('factory', $clientDefinition->getFactoryMethod());
     }
 


### PR DESCRIPTION
Closes: #892

| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | /no
| Deprecations? | no
| Tests pass? | yes/no/maybe
| Fixed tickets | #892 
| License | MIT

The service definition for the S3 resolver was changed slightly and instantiation broke for others. This change reverts it.