### PR TITLE
Make getResolver public

### DIFF
--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -103,7 +103,7 @@ class CacheManager
      *
      * @return ResolverInterface
      */
-    protected function getResolver($filter, $resolver)
+    public function getResolver($filter, $resolver)
     {
         // BC
         if (false == $resolver) {


### PR DESCRIPTION
Hi, I'm trying to create a command to regenerate all images for a given filter something that is quite hard today. 

By making getResolver public it would be possible to access resolvers directly in the command. Maybe the whole resolvers handling should be refactored out to a separate manager?

| Q | A
| --- | ---
| Branch? | 1.0 <!--choose version number-->
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->