### PR TITLE
Resolve image caches in background. Using message queue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
       env: SYMFONY_VERSION=2.3.x-dev
     - php: 5.6
       env: SYMFONY_VERSION=2.7.x-dev
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.x-dev WITH_ENQUEUE=true
     - php: 7.1
       env: SYMFONY_VERSION=3.0.x-dev
     - php: 7.1
@@ -37,7 +39,7 @@ matrix:
     - php: 7.1
       env: SYMFONY_VERSION=3.2.x-dev
     - php: 7.1
-      env: SYMFONY_VERSION=3.3.x-dev
+      env: SYMFONY_VERSION=3.3.x-dev WITH_ENQUEUE=true
     - php: 7.1
       env: SYMFONY_VERSION=dev-master
   allow_failures:
@@ -55,6 +57,7 @@ before_install:
   - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION:0:3}" != "5.3" ]; then composer require --no-update --dev league/flysystem:~1.0; fi;
   - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION:0:1}" != "7" ]; then yes "" | pecl -q install -f mongo; composer require --no-update --dev doctrine/mongodb-odm:~1.0; fi;
   - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION:0:1}" == "7" ]; then yes "" | pecl -q install -f mongodb; travis_retry composer require --dev alcaeus/mongo-php-adapter:~1.0; composer require --no-update --dev doctrine/mongodb-odm:~1.0; fi
+  - if [ "$WITH_ENQUEUE" = true ] ; then composer require --no-update --dev enqueue/enqueue-bundle:^0.3.6; fi;
 
 install:
   - travis_retry composer update $COMPOSER_FLAGS

--- a/Async/CacheResolved.php
+++ b/Async/CacheResolved.php
@@ -1,0 +1,71 @@
+<?php
+namespace Liip\ImagineBundle\Async;
+
+use Enqueue\Util\JSON;
+
+class CacheResolved implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var \string[]
+     */
+    private $uris;
+    
+    /**
+     * @param string $path
+     * @param string[]|null $uris
+     */
+    public function __construct($path, array $uris)
+    {
+        $this->path = $path;
+        $this->uris = $uris;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return \string[]
+     */
+    public function getUris()
+    {
+        return $this->uris;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return array('path' => $this->path, 'uris' => $this->uris);
+    }
+
+    /**
+     * @param string $json
+     *
+     * @return static
+     */
+    public static function jsonDeserialize($json)
+    {
+        $data = JSON::decode($json);
+
+        if (empty($data['path'])) {
+            throw new \LogicException('The message does not contain "path" but it is required.');
+        }
+
+        if (empty($data['uris'])) {
+            throw new \LogicException('The message uris must not be empty array.');
+        }
+
+        return new static($data['path'], $data['uris']);
+    }
+}

--- a/Async/ResolveCache.php
+++ b/Async/ResolveCache.php
@@ -1,0 +1,86 @@
+<?php
+namespace Liip\ImagineBundle\Async;
+
+use Enqueue\Util\JSON;
+
+class ResolveCache implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var array|null|\string[]
+     */
+    private $filters;
+
+    /**
+     * @var bool
+     */
+    private $force;
+
+    /**
+     * @param string $path
+     * @param string[]|null $filters
+     * @param bool $force
+     */
+    public function __construct($path, array $filters = null, $force = false)
+    {
+        $this->path = $path;
+        $this->filters = $filters;
+        $this->force = $force;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return null|\string[]
+     */
+    public function getFilters()
+    {
+        return $this->filters;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isForce()
+    {
+        return $this->force;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return array('path' => $this->path, 'filters' => $this->filters, 'force' => $this->force);
+    }
+
+    /**
+     * @param string $json
+     *
+     * @return static
+     */
+    public static function jsonDeserialize($json)
+    {
+        $data = array_replace(array('path' => null, 'filters' => null, 'force' => false), JSON::decode($json));
+
+        if (false == $data['path']) {
+            throw new \LogicException('The message does not contain "path" but it is required.');
+        }
+
+        if (false == (is_null($data['filters']) || is_array($data['filters']))) {
+            throw new \LogicException('The message filters could be either null or array.');
+        }
+
+        return new static($data['path'], $data['filters'], $data['force']);
+    }
+}

--- a/Async/ResolveCacheProcessor.php
+++ b/Async/ResolveCacheProcessor.php
@@ -1,0 +1,108 @@
+<?php
+namespace Liip\ImagineBundle\Async;
+
+use Enqueue\Client\ProducerInterface;
+use Enqueue\Client\TopicSubscriberInterface;
+use Enqueue\Consumption\QueueSubscriberInterface;
+use Enqueue\Consumption\Result;
+use Enqueue\Psr\PsrContext;
+use Enqueue\Psr\PsrMessage;
+use Enqueue\Psr\PsrProcessor;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Liip\ImagineBundle\Imagine\Data\DataManager;
+use Liip\ImagineBundle\Imagine\Filter\FilterManager;
+
+class ResolveCacheProcessor implements PsrProcessor, TopicSubscriberInterface, QueueSubscriberInterface
+{
+    /**
+     * @var CacheManager
+     */
+    private $cacheManager;
+
+    /**
+     * @var FilterManager
+     */
+    private $filterManager;
+
+    /**
+     * @var DataManager
+     */
+    private $dataManager;
+
+    /**
+     * @var ProducerInterface
+     */
+    private $producer;
+
+    /**
+     * @param CacheManager $cacheManager
+     * @param FilterManager $filterManager
+     * @param DataManager $dataManager
+     * @param ProducerInterface $producer
+     */
+    public function __construct(
+        CacheManager $cacheManager,
+        FilterManager $filterManager,
+        DataManager $dataManager,
+        ProducerInterface $producer
+    ) {
+        $this->cacheManager = $cacheManager;
+        $this->filterManager = $filterManager;
+        $this->dataManager = $dataManager;
+        $this->producer = $producer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(PsrMessage $psrMessage, PsrContext $psrContext)
+    {
+        try {
+            $message = ResolveCache::jsonDeserialize($psrMessage->getBody());
+        } catch (\Exception $e) {
+            return Result::reject($e->getMessage());
+        }
+
+        $filters = $message->getFilters() ?: array_keys($this->filterManager->getFilterConfiguration()->all());
+        $path = $message->getPath();
+        $results = array();
+        foreach ($filters as $filter) {
+            if ($this->cacheManager->isStored($path, $filter) && $message->isForce()) {
+                $this->cacheManager->remove($path, $filter);
+            }
+
+            if (false == $this->cacheManager->isStored($path, $filter)) {
+                $binary = $this->dataManager->find($filter, $path);
+                $this->cacheManager->store(
+                    $this->filterManager->applyFilter($binary, $filter),
+                    $path,
+                    $filter
+                );
+            }
+
+            $results[$filter] = $this->cacheManager->resolve($path, $filter);
+        }
+
+        $this->producer->send(Topics::CACHE_RESOLVED, new CacheResolved($path, $results));
+
+        return self::ACK;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedTopics()
+    {
+        return array(
+            Topics::RESOLVE_CACHE => array('queueName' => Topics::RESOLVE_CACHE,  'queueNameHardcoded' => true),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedQueues()
+    {
+        return array(Topics::RESOLVE_CACHE);
+    }
+}

--- a/Async/Topics.php
+++ b/Async/Topics.php
@@ -1,0 +1,9 @@
+<?php
+namespace Liip\ImagineBundle\Async;
+
+class Topics
+{
+    const RESOLVE_CACHE = 'liip_imagine_resolve_cache';
+
+    const CACHE_RESOLVED = 'liip_imagine_cache_resolved';
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -158,7 +158,10 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end()
-            ->booleanNode('enqueue')->defaultFalse()->info('Enables integration with enqueue if set true. Allows resolve image caches in background by sending messages to MQ.')->end()
+            ->booleanNode('enqueue')
+                ->defaultFalse()
+                ->info('Enables integration with enqueue if set true. Allows resolve image caches in background by sending messages to MQ.')
+            ->end()
         ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -158,6 +158,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end()
+            ->booleanNode('enqueue')->defaultFalse()->info('Enables integration with enqueue if set true. Allows resolve image caches in background by sending messages to MQ.')->end()
         ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -72,6 +72,10 @@ class LiipImagineExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('imagine.xml');
 
+        if ($config['enqueue']) {
+            $loader->load('enqueue.xml');
+        }
+
         $this->setFactories($container);
 
         if (interface_exists('Imagine\Image\Metadata\MetadataReaderInterface')) {

--- a/LiipImagineBundle.php
+++ b/LiipImagineBundle.php
@@ -11,6 +11,8 @@
 
 namespace Liip\ImagineBundle;
 
+use Enqueue\Bundle\DependencyInjection\Compiler\AddTopicMetaPass;
+use Liip\ImagineBundle\Async\Topics;
 use Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\LocatorsCompilerPass;
@@ -53,5 +55,12 @@ class LiipImagineBundle extends Bundle
         $extension->addLoaderFactory(new StreamLoaderFactory());
         $extension->addLoaderFactory(new FileSystemLoaderFactory());
         $extension->addLoaderFactory(new FlysystemLoaderFactory());
-    }
+
+        if (class_exists('Enqueue\Bundle\DependencyInjection\Compiler\AddTopicMetaPass')) {
+            $container->addCompilerPass(AddTopicMetaPass::create()
+                ->add(Topics::RESOLVE_CACHE, 'Send message to this topic when you want to resolve image\'s cache.')
+                ->add(Topics::CACHE_RESOLVED, 'The topic contains messages about resolved image\'s caches')
+            );
+        }
+     }
 }

--- a/Resources/config/enqueue.xml
+++ b/Resources/config/enqueue.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="liip_imagine.async.resolve_cache_processor" class="Liip\ImagineBundle\Async\ResolveCacheProcessor">
+            <argument type="service" id="liip_imagine.cache.manager" />
+            <argument type="service" id="liip_imagine.filter.manager" />
+            <argument type="service" id="liip_imagine.data.manager" />
+            <argument type="service" id="enqueue.producer" />
+
+            <tag name="enqueue.client.processor" />
+        </service>
+    </services>
+</container>

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -45,5 +45,10 @@ usage to the architecture of bundle.
     cache-manager
     commands
 
+.. toctree::
+    :maxdepth: 1
+
+    resolve-cache-images-in-background
+
 
 .. _`LiipImagineBundle`: https://github.com/liip/LiipImagineBundle

--- a/Resources/doc/resolve-cache-images-in-background.rst
+++ b/Resources/doc/resolve-cache-images-in-background.rst
@@ -1,0 +1,98 @@
+Resolve cache images in background
+==================================
+
+Overview
+--------
+
+By default the LiipImagineBundle processes the image on demand.
+It does in resolve controller and saves the result, does a 301 redirect to the processed static image.
+The approach has its benefits.
+The most notable is simplicity.
+Though there are some disadvantages:
+
+* It takes huge amount of time during the first request since we have to do a lot of things.
+* The images are processed by web servers. It increases the overall load on them and may affect the site performance.
+* The resolve controller url is different from the cached image one.
+  If there is nothing in the cache the page will contain the url to resolve controller.
+  The varnish may cache the page with those links to the resolve controller.
+  A browser keeps sending requests to it though there is no need for it after the first call.
+
+The bundle provides a solution. It utilize messaging pattern and works on top of `enqueue library`_.
+
+Step 1: Install EnqueueBundle
+-----------------------------
+
+First, we have to `install EnqueueBundle`_. You have to basically use composer to install the bundle,
+register it to AppKernel and adjust settings. Here's the most simplest configuration without any extra dependencies.
+It is based on `filesystem transport`_.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    enqueue:
+        transport:
+            default: fs
+            fs:
+                store_dir: '%kernel.root_dir%/../var/queues'
+        client: ~
+
+Step 2: Configure LiipImagineBundle
+-----------------------------------
+
+At this step we instruct LiipImagineBundle to load some extra stuff required to process images in background.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        enqueue: true
+
+Step 3: Run consumers
+---------------------
+
+Before we can start using it we need a pool of consumers (at least one) to be working in background.
+Here's how you can run it:
+
+.. code-block:: bash
+
+    $ ./app/console enqueue:consume --setup-broker -vvv
+
+Step 4: Send resolve cache message
+----------------------------------
+
+You have to send a message in order to process images in background.
+The message must contain the original image path (in terms of LiipImagineBundle).
+If you do not define filters the background process will resolve cache for all available filters.
+If the cache already exist the background process does recreate it by default
+You can force cache to be recreated and in this case the cached image is removed and a new one replaces it.
+
+.. code-block:: php
+
+    <?php
+
+    use Enqueue\Client\ProducerInterface;
+    use Liip\ImagineBundle\Async\Topics;
+    use Liip\ImagineBundle\Async\ResolveCache;
+    use Symfony\Component\DependencyInjection\ContainerInterface;
+
+    /**
+     * @var ContainerInterface $container
+     * @var ProducerInterface $producer
+     */
+    $producer = $container->get('enqueue.producer');
+
+    // resolve all caches
+    $producer->send(Topics::RESOLVE_CACHE, new ResolveCache('the/path/img.png'));
+
+    // resolve specific cache
+    $producer->send(Topics::RESOLVE_CACHE, new ResolveCache('the/path/img.png', array('fooFilter')));
+
+    // force resolve (removes the cache if exists)
+    $producer->send(Topics::RESOLVE_CACHE, new ResolveCache('the/path/img.png', null, true));
+
+
+.. _`enqueue library`: https://github.com/php-enqueue/enqueue-dev
+.. _`install EnqueueBundle`: https://github.com/php-enqueue/enqueue-dev/blob/master/docs/bundle/quick_tour.md
+.. _`filesystem transport`: https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/filesystem.md

--- a/Tests/Async/CacheResolvedTest.php
+++ b/Tests/Async/CacheResolvedTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace Liip\ImagineBundle\Tests\Async;
+
+use Liip\ImagineBundle\Async\CacheResolved;
+
+class CacheResolvedTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        if (false == getenv('WITH_ENQUEUE')) {
+            self::markTestSkipped('The tests are run without enqueue integration. Skip them');
+        }
+    }
+
+    public function testCouldBeJsonSerialized()
+    {
+        $message = new CacheResolved('thePath', array(
+            'fooFilter' => 'http://example.com/fooFilter/thePath',
+            'barFilter' => 'http://example.com/barFilter/thePath',
+        ));
+
+        $this->assertEquals(
+            '{"path":"thePath","uris":{"fooFilter":"http:\/\/example.com\/fooFilter\/thePath","barFilter":"http:\/\/example.com\/barFilter\/thePath"}}',
+            json_encode($message)
+        );
+    }
+
+    public function testCouldBeJsonDeSerialized()
+    {
+        $message = CacheResolved::jsonDeserialize('{"path":"thePath","uris":{"fooFilter":"http:\/\/example.com\/fooFilter\/thePath","barFilter":"http:\/\/example.com\/barFilter\/thePath"}}');
+
+        $this->assertInstanceOf('Liip\ImagineBundle\Async\CacheResolved', $message);
+        $this->assertEquals('thePath', $message->getPath());
+        $this->assertEquals(array(
+            'fooFilter' => 'http://example.com/fooFilter/thePath',
+            'barFilter' => 'http://example.com/barFilter/thePath',
+        ), $message->getUris());
+    }
+}

--- a/Tests/Async/ResolveCacheProcessorTest.php
+++ b/Tests/Async/ResolveCacheProcessorTest.php
@@ -1,0 +1,344 @@
+<?php
+namespace Liip\ImagineBundle\Tests\Async;
+
+use Enqueue\Client\ProducerInterface;
+use Enqueue\Consumption\Result;
+use Enqueue\Null\NullContext;
+use Enqueue\Null\NullMessage;
+use Liip\ImagineBundle\Async\CacheResolved;
+use Liip\ImagineBundle\Async\ResolveCacheProcessor;
+use Liip\ImagineBundle\Async\Topics;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Liip\ImagineBundle\Imagine\Data\DataManager;
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+use Liip\ImagineBundle\Imagine\Filter\FilterManager;
+use Liip\ImagineBundle\Model\Binary;
+
+class ResolveCacheProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        if (false == getenv('WITH_ENQUEUE')) {
+            self::markTestSkipped('The tests are run without enqueue integration. Skip them');
+        }
+    }
+
+    public function testShouldImplementProcessorInterface()
+    {
+        $rc = new \ReflectionClass('Liip\ImagineBundle\Async\ResolveCacheProcessor');
+
+        $this->assertTrue($rc->implementsInterface('Enqueue\Psr\PsrProcessor'));
+    }
+
+    public function testShouldImplementTopicSubscriberInterface()
+    {
+        $rc = new \ReflectionClass('Liip\ImagineBundle\Async\ResolveCacheProcessor');
+
+        $this->assertTrue($rc->implementsInterface('Enqueue\Client\TopicSubscriberInterface'));
+    }
+
+    public function testShouldImplementQueueSubscriberInterface()
+    {
+        $rc = new \ReflectionClass('Liip\ImagineBundle\Async\ResolveCacheProcessor');
+
+        $this->assertTrue($rc->implementsInterface('Enqueue\Consumption\QueueSubscriberInterface'));
+    }
+
+    public function testShouldSubscribeToExpectedTopic()
+    {
+        $topics = ResolveCacheProcessor::getSubscribedTopics();
+
+        $this->assertInternalType('array', $topics);
+        $this->assertArrayHasKey(Topics::RESOLVE_CACHE, $topics);
+        $this->assertEquals(array(
+            'queueName' => 'liip_imagine_resolve_cache',
+            'queueNameHardcoded' => true,
+        ), $topics[Topics::RESOLVE_CACHE]);
+    }
+
+    public function testShouldSubscribeToExpectedQueue()
+    {
+        $queues = ResolveCacheProcessor::getSubscribedQueues();
+
+        $this->assertInternalType('array', $queues);
+        $this->assertEquals(array('liip_imagine_resolve_cache'), $queues);
+    }
+
+    public function testCouldBeConstructedWithExpectedArguments()
+    {
+        new ResolveCacheProcessor(
+            $this->createCacheManagerMock(),
+            $this->createFilterManagerMock(),
+            $this->createDataManagerMock(),
+            $this->createProducerMock()
+        );
+    }
+
+    public function testShouldRejectMessagesWithInvalidJsonBody()
+    {
+        $processor = new ResolveCacheProcessor(
+            $this->createCacheManagerMock(),
+            $this->createFilterManagerMock(),
+            $this->createDataManagerMock(),
+            $this->createProducerMock()
+        );
+
+        $message = new NullMessage();
+        $message->setBody('[}');
+
+        $result = $processor->process($message, new NullContext());
+
+        $this->assertInstanceOf('Enqueue\Consumption\Result', $result);
+        $this->assertEquals(Result::REJECT, (string) $result);
+        $this->assertStringStartsWith('The malformed json given.', $result->getReason());
+    }
+
+    public function testShouldRejectMessagesWithoutPass()
+    {
+        $processor = new ResolveCacheProcessor(
+            $this->createCacheManagerMock(),
+            $this->createFilterManagerMock(),
+            $this->createDataManagerMock(),
+            $this->createProducerMock()
+        );
+
+        $message = new NullMessage();
+        $message->setBody('{}');
+
+        $result = $processor->process($message, new NullContext());
+
+        $this->assertInstanceOf('Enqueue\Consumption\Result', $result);
+        $this->assertEquals(Result::REJECT, (string) $result);
+        $this->assertEquals('The message does not contain "path" but it is required.', $result->getReason());
+    }
+
+    public function testShouldResolveCacheIfNotStored()
+    {
+        $originalBinary = $this->createDummyBinary();
+        $filteredBinary = $this->createDummyBinary();
+
+        $filterManagerMock = $this->createFilterManagerMock();
+        $filterManagerMock
+            ->expects($this->once())
+            ->method('getFilterConfiguration')
+            ->willReturn(new FilterConfiguration(array(
+                'fooFilter' => array('fooFilterConfig'),
+            )))
+        ;
+        $filterManagerMock
+            ->expects($this->once())
+            ->method('applyFilter')
+            ->with($this->identicalTo($originalBinary), 'fooFilter')
+            ->willReturn($filteredBinary)
+        ;
+
+        $cacheManagerMock = $this->createCacheManagerMock();
+        $cacheManagerMock
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->willReturn(false)
+        ;
+        $cacheManagerMock
+            ->expects($this->once())
+            ->method('store')
+            ->with(
+                $this->identicalTo($filteredBinary),
+                'theImagePath',
+                'fooFilter'
+            )
+        ;
+        $cacheManagerMock
+            ->expects($this->once())
+            ->method('resolve')
+            ->with('theImagePath', 'fooFilter')
+        ;
+
+        $dataManagerMock = $this->createDataManagerMock();
+        $dataManagerMock
+            ->expects($this->once())
+            ->method('find')
+            ->with('fooFilter', 'theImagePath')
+            ->willReturn($originalBinary)
+        ;
+
+        $processor = new ResolveCacheProcessor(
+            $cacheManagerMock,
+            $filterManagerMock,
+            $dataManagerMock,
+            $this->createProducerMock()
+        );
+
+        $message = new NullMessage();
+        $message->setBody('{"path": "theImagePath"}');
+
+        $result = $processor->process($message, new NullContext());
+
+        $this->assertEquals(Result::ACK, $result);
+    }
+
+    public function testShouldNotResolveCacheIfStoredAndNotForce()
+    {
+        $filterManagerMock = $this->createFilterManagerMock();
+        $filterManagerMock
+            ->expects($this->once())
+            ->method('getFilterConfiguration')
+            ->willReturn(new FilterConfiguration(array(
+                'fooFilter' => array('fooFilterConfig'),
+            )))
+        ;
+        $filterManagerMock
+            ->expects($this->never())
+            ->method('applyFilter')
+        ;
+
+        $cacheManagerMock = $this->createCacheManagerMock();
+        $cacheManagerMock
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->willReturn(true)
+        ;
+        $cacheManagerMock
+            ->expects($this->never())
+            ->method('store')
+        ;
+        $cacheManagerMock
+            ->expects($this->once())
+            ->method('resolve')
+            ->with('theImagePath', 'fooFilter')
+            ->willReturn('fooFilterUri')
+        ;
+
+        $dataManagerMock = $this->createDataManagerMock();
+        $dataManagerMock
+            ->expects($this->never())
+            ->method('find')
+        ;
+
+        $processor = new ResolveCacheProcessor(
+            $cacheManagerMock,
+            $filterManagerMock,
+            $dataManagerMock,
+            $this->createProducerMock()
+        );
+
+        $message = new NullMessage();
+        $message->setBody('{"path": "theImagePath"}');
+
+        $result = $processor->process($message, new NullContext());
+
+        $this->assertEquals(Result::ACK, $result);
+    }
+
+    public function testShouldSendMessageOnSuccessResolve()
+    {
+        $filterManagerMock = $this->createFilterManagerMock();
+        $filterManagerMock
+            ->expects($this->once())
+            ->method('getFilterConfiguration')
+            ->willReturn(new FilterConfiguration(array(
+                'fooFilter' => array('fooFilterConfig'),
+                'barFilter' => array('barFilterConfig'),
+                'bazFilter' => array('bazFilterConfig'),
+            )))
+        ;
+        $filterManagerMock
+            ->expects($this->atLeastOnce())
+            ->method('applyFilter')
+            ->willReturn($this->createDummyBinary())
+        ;
+
+        $cacheManagerMock = $this->createCacheManagerMock();
+        $cacheManagerMock
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->willReturn(false)
+        ;
+        $cacheManagerMock
+            ->expects($this->atLeastOnce())
+            ->method('store')
+        ;
+        $cacheManagerMock
+            ->expects($this->atLeastOnce())
+            ->method('resolve')
+            ->willReturnCallback(function($path, $filter) {
+                return $path.$filter.'Uri';
+            })
+        ;
+
+        $dataManagerMock = $this->createDataManagerMock();
+        $dataManagerMock
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->willReturn($this->createDummyBinary())
+        ;
+
+        $testCase = $this;
+        $producerMock = $this->createProducerMock();
+        $producerMock
+            ->expects($this->once())
+            ->method('send')
+            ->with(Topics::CACHE_RESOLVED, $this->isInstanceOf('Liip\ImagineBundle\Async\CacheResolved'))
+        ->willReturnCallback(function($topic, CacheResolved $message) use ($testCase) {
+            $testCase->assertEquals('theImagePath', $message->getPath());
+            $testCase->assertEquals(array(
+                'fooFilter' => 'theImagePathfooFilterUri',
+                'barFilter' => 'theImagePathbarFilterUri',
+                'bazFilter' => 'theImagePathbazFilterUri',
+            ), $message->getUris());
+        });
+
+        $processor = new ResolveCacheProcessor(
+            $cacheManagerMock,
+            $filterManagerMock,
+            $dataManagerMock,
+            $producerMock
+        );
+
+        $message = new NullMessage();
+        $message->setBody('{"path": "theImagePath"}');
+
+        $result = $processor->process($message, new NullContext());
+
+        $this->assertEquals(Result::ACK, $result);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|CacheManager
+     */
+    private function createCacheManagerMock()
+    {
+        return $this->createMock('Liip\ImagineBundle\Imagine\Cache\CacheManager', array(), array(), '', false);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|FilterManager
+     */
+    private function createFilterManagerMock()
+    {
+        return $this->createMock('Liip\ImagineBundle\Imagine\Filter\FilterManager', array(), array(), '', false);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|DataManager
+     */
+    private function createDataManagerMock()
+    {
+        return $this->createMock('Liip\ImagineBundle\Imagine\Data\DataManager', array(), array(), '', false);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|ProducerInterface
+     */
+    private function createProducerMock()
+    {
+        return $this->createMock('Enqueue\Client\ProducerInterface');
+    }
+
+    /**
+     * @return Binary
+     */
+    private function createDummyBinary()
+    {
+        return new Binary('theContent', 'image/png', 'png');
+    }
+}

--- a/Tests/Async/ResolveCacheTest.php
+++ b/Tests/Async/ResolveCacheTest.php
@@ -1,0 +1,87 @@
+<?php
+namespace Liip\ImagineBundle\Tests\Async;
+
+use Liip\ImagineBundle\Async\ResolveCache;
+
+class ResolveCacheTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        if (false == getenv('WITH_ENQUEUE')) {
+            self::markTestSkipped('The tests are run without enqueue integration. Skip them');
+        }
+    }
+
+    public function testCouldBeJsonSerializedWithoutFiltersAndForce()
+    {
+        $message = new ResolveCache('thePath');
+
+        $this->assertEquals('{"path":"thePath","filters":null,"force":false}', json_encode($message));
+    }
+
+    public function testCouldBeJsonSerializedWithFilters()
+    {
+        $message = new ResolveCache('thePath', array('fooFilter', 'barFilter'));
+
+        $this->assertEquals('{"path":"thePath","filters":["fooFilter","barFilter"],"force":false}', json_encode($message));
+    }
+
+    public function testCouldBeJsonSerializedWithFiltersAndForce()
+    {
+        $message = new ResolveCache('thePath', array('fooFilter', 'barFilter'), true);
+
+        $this->assertEquals('{"path":"thePath","filters":["fooFilter","barFilter"],"force":true}', json_encode($message));
+    }
+
+    public function testCouldBeJsonDeSerializedWithoutFiltersAndForce()
+    {
+        $message = ResolveCache::jsonDeserialize('{"path":"thePath","filters":null,"force":false}');
+
+        $this->assertInstanceOf('Liip\ImagineBundle\Async\ResolveCache', $message);
+        $this->assertEquals('thePath', $message->getPath());
+        $this->assertNull($message->getFilters());
+        $this->assertFalse($message->isForce());
+    }
+
+    public function testCouldBeJsonDeSerializedWithFilters()
+    {
+        $message = ResolveCache::jsonDeserialize('{"path":"thePath","filters":["fooFilter","barFilter"],"force":false}');
+
+        $this->assertInstanceOf('Liip\ImagineBundle\Async\ResolveCache', $message);
+        $this->assertEquals('thePath', $message->getPath());
+        $this->assertEquals(array('fooFilter', 'barFilter'), $message->getFilters());
+        $this->assertFalse($message->isForce());
+    }
+
+    public function testCouldBeJsonDeSerializedWithFiltersAndForce()
+    {
+        $message = ResolveCache::jsonDeserialize('{"path":"thePath","filters":["fooFilter","barFilter"],"force":true}');
+
+        $this->assertInstanceOf('Liip\ImagineBundle\Async\ResolveCache', $message);
+        $this->assertEquals('thePath', $message->getPath());
+        $this->assertEquals(array('fooFilter', 'barFilter'), $message->getFilters());
+        $this->assertTrue($message->isForce());
+    }
+
+    public function testCouldBeJsonDeSerializedWithOnlyPath()
+    {
+        $message = ResolveCache::jsonDeserialize('{"path":"thePath"}');
+
+        $this->assertInstanceOf('Liip\ImagineBundle\Async\ResolveCache', $message);
+        $this->assertEquals('thePath', $message->getPath());
+        $this->assertNull($message->getFilters());
+        $this->assertFalse($message->isForce());
+    }
+
+    public function testThrowIfMessageMissingPathOnJsonDeserialize()
+    {
+        $this->setExpectedException('LogicException', 'The message does not contain "path" but it is required.');
+        ResolveCache::jsonDeserialize('{}');
+    }
+
+    public function testThrowIfMessageContainsNotSupportedFilters()
+    {
+        $this->setExpectedException('LogicException', 'The message filters could be either null or array.');
+        ResolveCache::jsonDeserialize('{"path": "aPath", "filters": "stringFilterIsNotAllowed"}');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
         "doctrine/mongodb-odm": "required to use mongodb-backed doctrine components",
         "league/flysystem": "required to use FlySystem data loader or cache resolver",
         "monolog/monolog": "A psr/log compatible logger is required to enable logging",
-        "twig/twig": "required to use the provided Twig extension. Version 1.12 or greater needed"
+        "twig/twig": "required to use the provided Twig extension. Version 1.12 or greater needed",
+        "enqueue/enqueue-bundle": "add if you like to process images in background"
     },
     "minimum-stability": "dev",
     "config": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0 <!--choose version number-->
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | -
| Fixed tickets | -
| License | MIT
| Doc PR | - 

The PR adds an ability to resolve image caches (apply filters and so on) in background process. 
Right now if the new image is uploaded the cache images are not created. There is a controller for that and at first request the cache image is created and stored to the cache. The approach works but has some disadvantages. 

1. The first request to the cache takes more time ( we have to read the original image, apply filters and upload the filtered image to the cache.
2. Varnish may cache the controller pass and not the actual cache image. 

This PR adds optional dependency on [enqueue/enqueue-bundle](https://github.com/php-enqueue/enqueue-bundle) and allows to process the images once they are uploaded. 

Here's how you to use this:

1. [Install the EnqueueBundle](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/bundle/quick_tour.md)
2. Enable integration in LiipImagineBundle

```yaml
liip_imagine:
    enqueue: true
    # other options
```

3. Send a message once the image is uploaded

```php
<?php
use Liip\ImagineBundle\Async\Topics;
use Liip\ImagineBundle\Async\ResolveCache;

/** @var ProducerInterface $producer */
$producer = $this->get('enqueue.producer');

// resolve all caches 
$producer->send(Topics::RESOLVE_CACHE, new ResolveCache('the/path/img.png'));

// resolve specific cache
$producer->send(Topics::RESOLVE_CACHE, new ResolveCache('the/path/img.png', ['fooFilter']));

// force resolve (removes the cache if exists)
$producer->send(Topics::RESOLVE_CACHE, new ResolveCache('the/path/img.png', null, true));
```

4. Run the consumer 

You can run many instances to improve performance. 

```bash
$ ./app/console enqueue:consume --setup-broker -vvv
```


This is a RFC. Tests and doc will be added if the feature is accepted.  There are other processors may be added as well, to delete cache or to cache a single filter. 
