### PR TITLE
Add Flip Filter

### DIFF
--- a/Imagine/Filter/Loader/FlipFilterLoader.php
+++ b/Imagine/Filter/Loader/FlipFilterLoader.php
@@ -12,10 +12,9 @@
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Image\ImageInterface;
+use Liip\ImagineBundle\Utility\OptionsResolver\OptionsResolver;
 use Liip\ImagineBundle\Exception\InvalidArgumentException;
-use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
 
 class FlipFilterLoader implements LoaderInterface
@@ -40,22 +39,12 @@ class FlipFilterLoader implements LoaderInterface
      */
     private function sanitizeOptions(array $options)
     {
-        $normalizer = function (Options $options, $value) {
-            return $value === 'horizontal' ? 'x' : ($value === 'vertical' ? 'y' : $value);
-        };
-
         $resolver = new OptionsResolver();
-
-        /** @todo remove in v2.0 */
-        if (SymfonyFramework::isKernelGreaterThanOrEqualTo('2', '7')) {
-            $resolver->setDefault('axis', 'x');
-            $resolver->setAllowedValues('axis', array('x', 'horizontal', 'y', 'vertical'));
-            $resolver->setNormalizer('axis', $normalizer);
-        } else {
-            $resolver->setDefaults(array('axis' => 'x'));
-            $resolver->setAllowedValues(array('axis' => array('x', 'horizontal', 'y', 'vertical')));
-            $resolver->setNormalizers(array('axis' => $normalizer));
-        }
+        $resolver->setDefault('axis', 'x');
+        $resolver->setAllowedValues('axis', array('x', 'horizontal', 'y', 'vertical'));
+        $resolver->setNormalizer('axis', function (Options $options, $value) {
+            return $value === 'horizontal' ? 'x' : ($value === 'vertical' ? 'y' : $value);
+        });
 
         try {
             return $resolver->resolve($options);

--- a/Imagine/Filter/Loader/FlipFilterLoader.php
+++ b/Imagine/Filter/Loader/FlipFilterLoader.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Imagine\Filter\Loader;
+
+use Imagine\Image\ImageInterface;
+use Liip\ImagineBundle\Exception\InvalidArgumentException;
+use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
+
+class FlipFilterLoader implements LoaderInterface
+{
+    /**
+     * @param ImageInterface $image
+     * @param array          $options
+     *
+     * @return ImageInterface
+     */
+    public function load(ImageInterface $image, array $options = array())
+    {
+        $options = $this->sanitizeOptions($options);
+
+        return $options['axis'] === 'x' ? $image->flipHorizontally() : $image->flipVertically();
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    private function sanitizeOptions(array $options)
+    {
+        $normalizer = function (Options $options, $value) {
+            return $value === 'horizontal' ? 'x' : ($value === 'vertical' ? 'y' : $value);
+        };
+
+        $resolver = new OptionsResolver();
+
+        /** @todo remove in v2.0 */
+        if (SymfonyFramework::isKernelGreaterThanOrEqualTo('2', '7')) {
+            $resolver->setDefault('axis', 'x');
+            $resolver->setAllowedValues('axis', array('x', 'horizontal', 'y', 'vertical'));
+            $resolver->setNormalizer('axis', $normalizer);
+        } else {
+            $resolver->setDefaults(array('axis' => 'x'));
+            $resolver->setAllowedValues(array('axis' => array('x', 'horizontal', 'y', 'vertical')));
+            $resolver->setNormalizers(array('axis' => $normalizer));
+        }
+
+        try {
+            return $resolver->resolve($options);
+        } catch (ExceptionInterface $e) {
+            throw new InvalidArgumentException('The "axis" option must be set to "x", "horizontal", "y", or "vertical".');
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,26 +4,39 @@
 |:----------------------:|:-----------------------:|:-----------------------:|:-----------------------:|:-----------------------:|
 | [![Travis](https://src.run/shield/liip/LiipImagineBundle/1.0/travis.svg)](https://src.run/service/liip/LiipImagineBundle/1.0/travis) | [![Style CI](https://src.run/shield/liip/LiipImagineBundle/1.0/styleci.svg)](https://src.run/service/liip/LiipImagineBundle/1.0/styleci) | [![Coverage](https://src.run/shield/liip/LiipImagineBundle/1.0/coveralls.svg)](https://src.run/service/liip/LiipImagineBundle/1.0/coveralls) | [![Downloads](https://src.run/shield/liip/LiipImagineBundle/packagist_dt.svg)](https://src.run/service/liip/LiipImagineBundle/packagist) | [![Latest Stable Version](https://src.run/shield/liip/LiipImagineBundle/packagist_v.svg)](https://src.run/service/liip/LiipImagineBundle/packagist) | 
 
-*This bundle provides an image manipulation abstraction toolkit for
-[Symfony](http://symfony.com/)-based projects.*
+*This bundle provides an image manipulation abstraction toolkit for [Symfony](http://symfony.com/)-based projects.*
 
 ## Overview
 
 - [Filter Sets](http://symfony.com/doc/master/bundles/LiipImagineBundle/basic-usage.html):
-  Using any Symfony-supported configuration language (such as YML and XML), 
-  you can create *filter set* definitions that specify transformation routines. 
-  These include a set of *filters* and *post-processors*, as well as other,
-  optional parameters.
+  Using any Symfony-supported configuration language (such as YML and XML), you can create *filter set* definitions that
+  specify transformation routines. These definitions include a set of
+  *[filters](http://symfony.com/doc/current/bundles/LiipImagineBundle/filters.html)* and
+  *[post-processors](http://symfony.com/doc/current/bundles/LiipImagineBundle/post-processors.html)*,
+  as well as other optional parameters.
+
 - [Filters](http://symfony.com/doc/master/bundles/LiipImagineBundle/filters.html):
-  Many built-in filters are provided, allowing the application of common 
-  transformations. Examples include `thumbnail`, `scale`, `crop`, `strip`, `watermark`,  
-  and many more. Additionally, [custom filters](http://symfony.com/doc/master/bundles/LiipImagineBundle/filters.html#filter-custom) 
-  are supported.
+  Image transformations are applied using *filters*. A set of
+  [build-in filters](http://symfony.com/doc/current/bundles/LiipImagineBundle/filters.html) are provided by the bundle,
+  implementing the most common transformations; examples include
+  [thumbnail](http://symfony.com/doc/current/bundles/LiipImagineBundle/filters/sizing.html#thumbnails),
+  [scale](http://symfony.com/doc/current/bundles/LiipImagineBundle/filters/sizing.html#scale),
+  [crop](http://symfony.com/doc/current/bundles/LiipImagineBundle/filters/sizing.html#cropping-images),
+  [flip](http://symfony.com/doc/current/bundles/LiipImagineBundle/filters/orientation.html#flip),
+  [strip](http://symfony.com/doc/current/bundles/LiipImagineBundle/filters/general.html#strip), and
+  [watermark](http://symfony.com/doc/current/bundles/LiipImagineBundle/filters/general.html#watermark).
+  For more advances transformations, you can easily create your own
+  [custom filters](http://symfony.com/doc/master/bundles/LiipImagineBundle/filters.html#filter-custom).
+
 - [Post-Processors](http://symfony.com/doc/master/bundles/LiipImagineBundle/post-processors.html):
-  This component allows for the modification of the resulting binary file 
-  created by filters. Examples include `jpegoptim`, `optipng`, `cjpeg`, 
-  and `pngquant`. Additionally, [custom post-processors](http://symfony.com/doc/master/bundles/LiipImagineBundle/post-processors.html#post-processors-custom) 
-  are supported.
+  Modification of the resulting binary image file (created from your *filters*) are handled by *post-processors*.
+  Examples include
+  [JPEG Optim](http://symfony.com/doc/current/bundles/LiipImagineBundle/post-processors/jpeg-optim.html),
+  [Moz JPEG](http://symfony.com/doc/current/bundles/LiipImagineBundle/post-processors/jpeg-moz.html),
+  [Opti PNG](http://symfony.com/doc/current/bundles/LiipImagineBundle/post-processors/png-opti.html), and
+  [PNG Quant](http://symfony.com/doc/current/bundles/LiipImagineBundle/post-processors/png-quant.html). Just like filters
+  you can easily create your own
+  [custom post-processors](http://symfony.com/doc/master/bundles/LiipImagineBundle/post-processors.html#post-processors-custom).
 
 
 ### Example

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -45,6 +45,7 @@
         <parameter key="liip_imagine.filter.loader.downscale.class">Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.auto_rotate.class">Liip\ImagineBundle\Imagine\Filter\Loader\AutoRotateFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.rotate.class">Liip\ImagineBundle\Imagine\Filter\Loader\RotateFilterLoader</parameter>
+        <parameter key="liip_imagine.filter.loader.flip.class">Liip\ImagineBundle\Imagine\Filter\Loader\FlipFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.interlace.class">Liip\ImagineBundle\Imagine\Filter\Loader\InterlaceFilterLoader</parameter>
 
         <!-- Data loaders' classes -->
@@ -219,6 +220,10 @@
 
         <service id="liip_imagine.filter.loader.rotate" class="%liip_imagine.filter.loader.rotate.class%">
             <tag name="liip_imagine.filter.loader" loader="rotate" />
+        </service>
+
+        <service id="liip_imagine.filter.loader.flip" class="%liip_imagine.filter.loader.flip.class%">
+            <tag name="liip_imagine.filter.loader" loader="flip" />
         </service>
 
         <service id="liip_imagine.filter.loader.interlace" class="%liip_imagine.filter.loader.interlace.class%">

--- a/Resources/doc/filters/orientation.rst
+++ b/Resources/doc/filters/orientation.rst
@@ -69,6 +69,43 @@ Rotate Options
     Sets the "rotation angle" that defines the degree to rotate the image. Must be a
     positive number.
 
+
+.. _filter-flip:
+
+Flip
+----
+
+The built-in ``flip`` filter performs orientation transformations (specifically
+image flipping). This filter exposes `flip options`_ which may be used to
+configure its behavior.
+
+Example configuration:
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        filter_sets:
+
+            # name our filter set "my_flip_filter"
+            my_flip_filter:
+                filters:
+
+                    # use the "flip" filter
+                    flip:
+
+                        # set the axis to flip on
+                        axis: x
+
+
+Flip Options
+~~~~~~~~~~~~
+
+:strong:`axis:` ``string``
+    Sets the "flip axis" that defines the axis on which to flip the image. Valid values:
+    ``x``, ``horizontal``, ``y``, ``vertical``.
+
+
 .. _`BoxInterface`: http://imagine.readthedocs.io/en/latest/usage/coordinates.html#boxinterface
 .. _`Imagine Library`: http://imagine.readthedocs.io/en/latest/
-

--- a/Tests/Functional/Imagine/Filter/Loader/FlipFilterLoaderTest.php
+++ b/Tests/Functional/Imagine/Filter/Loader/FlipFilterLoaderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter\Loader;
+
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
+
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\FlipFilterLoader
+ */
+class FlipFilterLoaderTest extends AbstractWebTestCase
+{
+    public function testCouldBeGetFromContainerAsService()
+    {
+        $this->createClient();
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Imagine\Filter\Loader\FlipFilterLoader',
+            self::$kernel->getContainer()->get('liip_imagine.filter.loader.flip')
+        );
+    }
+}

--- a/Tests/Imagine/Filter/Loader/FlipFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/FlipFilterLoaderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Filter;
+
+use Liip\ImagineBundle\Imagine\Filter\Loader\FlipFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
+
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\FlipFilterLoader
+ */
+class FlipFilterLoaderTest extends AbstractTest
+{
+    /**
+     * @return array
+     */
+    public static function provideLoadWithAxisXOptionData()
+    {
+        return array(
+            array('x'),
+            array('horizontal'),
+        );
+    }
+
+    /**
+     * @param string $axis
+     *
+     * @dataProvider provideLoadWithAxisXOptionData
+     */
+    public function testLoadWithAxisXOption($axis)
+    {
+        $image = $this->getImageInterfaceMock();
+        $image->expects($this->once())
+            ->method('flipHorizontally')
+            ->willReturn($image);
+
+        $this->createFlipFilterLoaderInstance()->load($image, array('axis' => $axis));
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideLoadWithAxisYOptionData()
+    {
+        return array(
+            array('y'),
+            array('vertical'),
+        );
+    }
+
+    /**
+     * @param string $axis
+     *
+     * @dataProvider provideLoadWithAxisYOptionData
+     */
+    public function testLoadWithAxisYOption($axis)
+    {
+        $image = $this->getImageInterfaceMock();
+        $image->expects($this->once())
+            ->method('flipVertically')
+            ->willReturn($image);
+
+        $this->createFlipFilterLoaderInstance()->load($image, array('axis' => $axis));
+    }
+
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The "axis" option must be set to "x", "horizontal", "y", or "vertical".
+     */
+    public function testThrowsOnInvalidOptions()
+    {
+        $loader = new FlipFilterLoader();
+        $loader->load($this->getImageInterfaceMock(), array(
+            'axis' => 'invalid',
+        ));
+    }
+
+    /**
+     * @return FlipFilterLoader
+     */
+    private function createFlipFilterLoaderInstance()
+    {
+        return new FlipFilterLoader();
+    }
+}

--- a/Tests/Utility/OptionsResolver/OptionsResolverTest.php
+++ b/Tests/Utility/OptionsResolver/OptionsResolverTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Utility\OptionsResolver;
+
+use Liip\ImagineBundle\Utility\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\Options;
+
+/**
+ * @covers \Liip\ImagineBundle\Utility\OptionsResolver\OptionsResolver
+ */
+class OptionsResolverTest extends \PHPUnit_Framework_TestCase
+{
+    public function testOptionsResolver()
+    {
+        $r = static::setupOptionsResolver();
+        $options = $r->resolve(array(
+            'foo' => 'b',
+            'bar' => 100,
+        ));
+
+        $this->assertSame('b', $options['foo']);
+        $this->assertSame(100, $options['bar']);
+    }
+
+    public function testDefaultOptions()
+    {
+        $r = static::setupOptionsResolver();
+        $options = $r->resolve(array(
+            'bar' => 100,
+        ));
+
+        $this->assertSame('a', $options['foo']);
+        $this->assertSame(100, $options['bar']);
+    }
+
+    public function testOptionsNormalizer()
+    {
+        $r = static::setupOptionsResolver();
+        $options = $r->resolve(array(
+            'foo' => 'c',
+            'bar' => 100,
+        ));
+
+        $this->assertSame('z', $options['foo']);
+        $this->assertSame(100, $options['bar']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\ExceptionInterface
+     */
+    public function testInvalidOptions()
+    {
+        $r = static::setupOptionsResolver();
+        $r->resolve(array(
+            'does-not-exist' => 'idk',
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testRequiredTypes()
+    {
+        $r = static::setupOptionsResolver();
+        $r->resolve(array(
+            'bar' => array('not', 'an', 'int'),
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testAllowedValues()
+    {
+        $r = static::setupOptionsResolver();
+        $r->resolve(array(
+            'foo' => 'not-allowed',
+            'bar' => 100,
+        ));
+    }
+
+    /**
+     * @return OptionsResolver
+     */
+    private static function setupOptionsResolver()
+    {
+        $r = new OptionsResolver();
+        $r->setRequired(array('foo', 'bar'));
+        $r->setAllowedValues('foo', array('a', 'b', 'c', 'z'));
+        $r->setDefault('foo', 'a');
+        $r->setAllowedTypes('foo', array('string'));
+        $r->setAllowedTypes('bar', array('integer'));
+        $r->setNormalizer('foo', function (Options $options, $value) {
+            return $value === 'c' ? 'z' : $value;
+        });
+
+        return $r;
+    }
+}

--- a/Utility/OptionsResolver/OptionsResolver.php
+++ b/Utility/OptionsResolver/OptionsResolver.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Utility\OptionsResolver;
+
+use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
+use Symfony\Component\OptionsResolver\OptionsResolver as BaseOptionsResolver;
+
+/**
+ * @deprecated Deprecated in v1.7.x and scheduled for removal in v2.0.x
+ */
+class OptionsResolver
+{
+    /**
+     * @var array
+     */
+    private $required = array();
+
+    /**
+     * @var array
+     */
+    private $defaults = array();
+
+    /**
+     * @var array
+     */
+    private $allowedValues = array();
+
+    /**
+     * @var array
+     */
+    private $allowedTypes = array();
+
+    /**
+     * @var array
+     */
+    private $normalizers = array();
+
+    /**
+     * @param string $option
+     * @param mixed  $value
+     */
+    public function setDefault($option, $value)
+    {
+        $this->defaults[$option] = $value;
+    }
+
+    /**
+     * @param array $options
+     */
+    public function setRequired(array $options)
+    {
+        $this->required = $options;
+    }
+
+    /**
+     * @param string  $option
+     * @param mixed[] $values
+     *
+     * @return $this
+     */
+    public function setAllowedValues($option, array $values)
+    {
+        $this->allowedValues[$option] = $values;
+
+        return $this;
+    }
+
+    /**
+     * @param string  $option
+     * @param mixed[] $types
+     *
+     * @return $this
+     */
+    public function setAllowedTypes($option, array $types)
+    {
+        $this->allowedTypes[$option] = $types;
+
+        return $this;
+    }
+
+    /**
+     * @param string   $option
+     * @param \Closure $normalizer
+     *
+     * @return $this
+     */
+    public function setNormalizer($option, \Closure $normalizer)
+    {
+        $this->normalizers[$option] = $normalizer;
+
+        return $this;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    public function resolve(array $options)
+    {
+        $resolver = new BaseOptionsResolver();
+        $resolver->setDefaults($this->defaults);
+        $resolver->setRequired($this->required);
+
+        if (SymfonyFramework::isKernelGreaterThanOrEqualTo(2, 7)) {
+            $this->setupResolver($resolver);
+        } else {
+            $this->setupResolverLegacy($resolver);
+        }
+
+        return $resolver->resolve($options);
+    }
+
+    /**
+     * @param BaseOptionsResolver $resolver
+     */
+    private function setupResolver(BaseOptionsResolver $resolver)
+    {
+        foreach ($this->allowedValues as $option => $values) {
+            $resolver->setAllowedValues($option, $values);
+        }
+
+        foreach ($this->allowedTypes as $option => $types) {
+            $resolver->setAllowedTypes($option, $types);
+        }
+
+        foreach ($this->normalizers as $option => $normalizer) {
+            $resolver->setNormalizer($option, $normalizer);
+        }
+    }
+
+    /**
+     * @param BaseOptionsResolver $resolver
+     */
+    private function setupResolverLegacy(BaseOptionsResolver $resolver)
+    {
+        $resolver->setAllowedValues($this->allowedValues);
+        $resolver->setAllowedTypes($this->allowedTypes);
+        $resolver->setNormalizers($this->normalizers);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #918 
| License | MIT
| Doc PR | #920

This pull request adds a simple filter implementation to allow for image flipping (both along the `x` and `y` axis). Included are tests and documentation, as well as some general cleanup of the `README.md` file.

The included `OptionsResolver` abstraction was introduced to aid in the API differences between Symfony `=2.3` and `>=2.7`. My long-term intention is to move other filter loader implementations to using the options resolver as well; once this has been done, this abstraction can be removed in the `2.x` branch where it is no longer required without affecting the method calls within filters.