### PR TITLE
Deprecate XML routing file in favor of YAML

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -5,15 +5,6 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="liip_imagine_filter_runtime" path="/media/cache/resolve/{filter}/rc/{hash}/{path}" methods="GET">
-        <default key="_controller">%liip_imagine.controller.filter_runtime_action%</default>
-        <requirement key="filter">[A-z0-9_\-]*</requirement>
-        <requirement key="path">.+</requirement>
-    </route>
+    <import resource="@LiipImagineBundle/Resources/config/routing.yaml" />
 
-    <route id="liip_imagine_filter" path="/media/cache/resolve/{filter}/{path}" methods="GET">
-        <default key="_controller">%liip_imagine.controller.filter_action%</default>
-        <requirement key="filter">[A-z0-9_\-]*</requirement>
-        <requirement key="path">.+</requirement>
-    </route>
 </routes>

--- a/Resources/config/routing.yaml
+++ b/Resources/config/routing.yaml
@@ -1,0 +1,19 @@
+liip_imagine_filter_runtime:
+    path: /media/cache/resolve/{filter}/rc/{hash}/{path}
+    defaults:
+        _controller: '%liip_imagine.controller.filter_runtime_action%'
+    methods:
+        - GET
+    requirements:
+        filter: '[A-z0-9_-]*'
+        path: .+
+
+liip_imagine_filter:
+    path: /media/cache/resolve/{filter}/{path}
+    defaults:
+        _controller: '%liip_imagine.controller.filter_action%'
+    methods:
+        - GET
+    requirements:
+        filter: '[A-z0-9_-]*'
+        path: .+

--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -61,11 +61,11 @@ routing file:
 
         # app/config/routing.yml
         _liip_imagine:
-            resource: "@LiipImagineBundle/Resources/config/routing.xml"
+            resource: "@LiipImagineBundle/Resources/config/routing.yaml"
 
     .. code-block:: xml
 
-        <import resource="@LiipImagineBundle/Resources/config/routing.xml"/>
+        <import resource="@LiipImagineBundle/Resources/config/routing.yaml"/>
 
 Congratulations; you are ready to rock your images!
 

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -173,7 +173,7 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
     public function provideOutsideRootPathsData()
     {
         return array(
-            array('../Loader/../../Binary/Loader/../../../Resources/config/routing.xml'),
+            array('../Loader/../../Binary/Loader/../../../Resources/config/routing.yaml'),
             array('../../Binary/'),
         );
     }

--- a/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
@@ -117,7 +117,7 @@ abstract class AbstractFileSystemLocatorTest extends \PHPUnit_Framework_TestCase
     public function provideOutsideRootPathsData()
     {
         return array(
-            array('../Loader/../../Binary/Loader/../../../Resources/config/routing.xml'),
+            array('../Loader/../../Binary/Loader/../../../Resources/config/routing.yaml'),
             array('../../Binary/'),
         );
     }

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade
 
+## 1.8.0
+
+ - __[Routing]__ The `Resources/config/routing.xml` file has been deprecated and will be removed in `2.0`. Use the new
+ YAML variant moving forward `Resources/config/routing.yaml`.
+
 ## 1.7.3
 
   - __[Data Loader]__ The `FileSystemLoader` now allows you to assign keys to data roots, and directly reference them when


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | yes
| Tests pass? | yes
| Fixed tickets | #924 
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Deprecating the XML routing file in favor of YAML enables providing a more user-friendly format for the Symfony Flex recipe, and YAML is, IMHO, generally more user-friendly for this bundle as a stand-alone package, as well.

The old `routing.xml` file remains, to provide backward compatibility for users, but instead of containing routes it simply imports the new `routing.yaml` file. The XML file is deprecation in the `UPGRADE.md` file and can be safely removed from the `2.x` branch entirely.

The installation RST documentation has been updated to use the YAML routing varient, as well.