### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Change Log
 
 ## [Unreleased](https://github.com/liip/LiipImagineBundle/tree/HEAD) (2017-xx-xx)
-[Full Changelog](https://github.com/liip/LiipImagineBundle/compare/1.7.4...HEAD)
+[Full Changelog](https://github.com/liip/LiipImagineBundle/compare/1.8.0...HEAD)
+
+## [1.8.0](https://github.com/liip/LiipImagineBundle/tree/1.8.0) (2017-05-08)
+[Full Changelog](https://github.com/liip/LiipImagineBundle/compare/1.7.4...1.8.0)
+
+- \[Minor\] \[Bug\] Revert to php-cs-fixer 1.x and run fixer [\#927](https://github.com/liip/LiipImagineBundle/pull/927) ([robfrawley](https://github.com/robfrawley))
+- \[Routing\] Deprecate XML routing file in favor of YAML [\#925](https://github.com/liip/LiipImagineBundle/pull/925) ([robfrawley](https://github.com/robfrawley))
+- \[Filter\] Add flip filter implementation to core [\#920](https://github.com/liip/LiipImagineBundle/pull/920) ([robfrawley](https://github.com/robfrawley))
+- \[Queue\] Resolve image caches in background using message queue. [\#919](https://github.com/liip/LiipImagineBundle/pull/919) ([makasim](https://github.com/makasim))
 
 ## [1.7.4](https://github.com/liip/LiipImagineBundle/tree/1.7.4) (2017-03-01)
 [Full Changelog](https://github.com/liip/LiipImagineBundle/compare/1.7.3...1.7.4)


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | yes
| Tests pass? | yes
| Fixed tickets | #919 #920 #924 #925 #927
| License | MIT
| Doc PR | <!--highly recommended for new features-->

# Overview

This pull request updates the `CHANGELOG.md` file for the `1.8.0` release version of `liip/imagine-bundle`.

The minor version bump is because of [point 7 of the semvar spec](http://semver.org/#spec-item-7), which requires that the minor version is changed when any _non-bug_ deprecations are introduced. Specifically, #925 deprecates the XML routing file in favor of YAML to get us ready for symfony/recipes-contrib#14, the Symfony Flex recipe (see also #924):

## Changelog Notes

- __[Minor] [Bug]__ Revert to php-cs-fixer 1.x and run fixer [\#927](https://github.com/liip/LiipImagineBundle/pull/927) ([robfrawley](https://github.com/robfrawley))
- __[Routing]__ Deprecate XML routing file in favor of YAML [\#925](https://github.com/liip/LiipImagineBundle/pull/925) ([robfrawley](https://github.com/robfrawley))
- __[Filter]__ Add flip filter implementation to core [\#920](https://github.com/liip/LiipImagineBundle/pull/920) ([robfrawley](https://github.com/robfrawley))
- __[Queue]__ Resolve image caches in background using message queue. [\#919](https://github.com/liip/LiipImagineBundle/pull/919) ([makasim](https://github.com/makasim))

## Upgrade Notes

 - __[Routing]__ The `Resources/config/routing.xml` file has been deprecated and will be removed in `2.0`. Use the new YAML variant moving forward `Resources/config/routing.yaml`.
