### PR TITLE
[Data Loader] [Data Locator] [Dependency Injection] Pass root paths to FileSystemLocator during construction

### DIFF
--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -37,18 +37,15 @@ class FileSystemLoader implements LoaderInterface
      * @param MimeTypeGuesserInterface  $mimeGuesser
      * @param ExtensionGuesserInterface $extensionGuesser
      * @param LocatorInterface          $locator
-     * @param string[]                  $rootPaths
      */
     public function __construct(
         MimeTypeGuesserInterface $mimeGuesser,
         ExtensionGuesserInterface $extensionGuesser,
-        LocatorInterface $locator,
-        array $rootPaths = []
+        LocatorInterface $locator
     ) {
         $this->mimeTypeGuesser = $mimeGuesser;
         $this->extensionGuesser = $extensionGuesser;
         $this->locator = $locator;
-        $this->locator->setOptions(['roots' => $rootPaths]);
     }
 
     /**

--- a/Binary/Locator/FileSystemInsecureLocator.php
+++ b/Binary/Locator/FileSystemInsecureLocator.php
@@ -17,16 +17,17 @@ class FileSystemInsecureLocator extends FileSystemLocator
      * @param string $root
      * @param string $path
      *
-     * @return string|false
+     * @return string|null
      */
-    protected function generateAbsolutePath($root, $path)
+    protected function generateAbsolutePath(string $root, string $path): ?string
     {
-        if (false !== mb_strpos($path, '..'.DIRECTORY_SEPARATOR) ||
-            false !== mb_strpos($path, DIRECTORY_SEPARATOR.'..') ||
-            false === file_exists($absolute = $root.DIRECTORY_SEPARATOR.$path)) {
-            return false;
+        if (false === mb_strpos($path, '..'.DIRECTORY_SEPARATOR) &&
+            false === mb_strpos($path, DIRECTORY_SEPARATOR.'..') &&
+            false !== file_exists($absolute = $root.DIRECTORY_SEPARATOR.$path)
+        ) {
+            return $absolute;
         }
 
-        return $absolute;
+        return null;
     }
 }

--- a/Binary/Locator/FileSystemLocator.php
+++ b/Binary/Locator/FileSystemLocator.php
@@ -24,20 +24,11 @@ class FileSystemLocator implements LocatorInterface
     private $roots = [];
 
     /**
-     * @param array[] $options
+     * @param string[] $roots
      */
-    public function setOptions(array $options = [])
+    public function __construct(array $roots = [])
     {
-        $resolver = new OptionsResolver();
-        $resolver->setDefaults(['roots' => []]);
-
-        try {
-            $options = $resolver->resolve($options);
-        } catch (ExceptionInterface $e) {
-            throw new InvalidArgumentException(sprintf('Invalid options provided to %s()', __METHOD__), null, $e);
-        }
-
-        $this->roots = array_map([$this, 'sanitizeRootPath'], (array) $options['roots']);
+        $this->roots = array_map([$this, 'sanitizeRootPath'], $roots);
     }
 
     /**

--- a/Binary/Locator/FileSystemLocator.php
+++ b/Binary/Locator/FileSystemLocator.php
@@ -13,8 +13,6 @@ namespace Liip\ImagineBundle\Binary\Locator;
 
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Exception\InvalidArgumentException;
-use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FileSystemLocator implements LocatorInterface
 {

--- a/Binary/Locator/LocatorInterface.php
+++ b/Binary/Locator/LocatorInterface.php
@@ -18,5 +18,5 @@ interface LocatorInterface
      *
      * @return string
      */
-    public function locate($path);
+    public function locate(string $path): string;
 }

--- a/Binary/Locator/LocatorInterface.php
+++ b/Binary/Locator/LocatorInterface.php
@@ -14,11 +14,6 @@ namespace Liip\ImagineBundle\Binary\Locator;
 interface LocatorInterface
 {
     /**
-     * @param array $options[]
-     */
-    public function setOptions(array $options = []);
-
-    /**
      * @param string $path
      *
      * @return string

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -14,8 +14,8 @@ namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
 use Liip\ImagineBundle\Exception\InvalidArgumentException;
 use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 
 class FileSystemLoaderFactory extends AbstractLoaderFactory
 {
@@ -24,9 +24,11 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
      */
     public function create(ContainerBuilder $container, $loaderName, array $config)
     {
+        $locatorDefinition = new ChildDefinition(sprintf('liip_imagine.binary.locator.%s', $config['locator']));
+        $locatorDefinition->replaceArgument(0, $this->resolveDataRoots($config['data_root'], $config['bundle_resources'], $container));
+
         $definition = $this->getChildLoaderDefinition();
-        $definition->replaceArgument(2, new Reference(sprintf('liip_imagine.binary.locator.%s', $config['locator'])));
-        $definition->replaceArgument(3, $this->resolveDataRoots($config['data_root'], $config['bundle_resources'], $container));
+        $definition->replaceArgument(2, $locatorDefinition);
 
         return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
     }

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -176,7 +176,6 @@
             <argument type="service" id="liip_imagine.mime_type_guesser" />
             <argument type="service" id="liip_imagine.extension_guesser" />
             <argument><!-- will be injected by FileSystemLoaderFactory --></argument>
-            <argument><!-- will be injected by FileSystemLoaderFactory --></argument>
         </service>
 
         <service id="liip_imagine.binary.loader.prototype.stream" class="Liip\ImagineBundle\Binary\Loader\StreamLoader">
@@ -192,10 +191,12 @@
         <!-- Data loader locators -->
 
         <service id="liip_imagine.binary.locator.filesystem" class="Liip\ImagineBundle\Binary\Locator\FileSystemLocator" public="false" shared="false">
+            <argument><!-- will be injected by FilesystemLoaderFactory --></argument>
             <tag name="liip_imagine.binary.locator" shared="false" />
         </service>
 
         <service id="liip_imagine.binary.locator.filesystem_insecure" class="Liip\ImagineBundle\Binary\Locator\FileSystemInsecureLocator" public="false" shared="false">
+            <argument><!-- will be injected by FilesystemLoaderFactory --></argument>
             <tag name="liip_imagine.binary.locator" shared="false" />
         </service>
 

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -192,7 +192,7 @@ class FileSystemLoaderTest extends TestCase
      *
      * @return FileSystemLoader
      */
-    private function getFileSystemLoader(array $roots = array(), LocatorInterface $locator = null)
+    private function getFileSystemLoader(array $roots = [], LocatorInterface $locator = null)
     {
         return new FileSystemLoader(
             MimeTypeGuesser::getInstance(),

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -84,7 +84,7 @@ class FileSystemLoaderTest extends TestCase
     }
 
     /**
-     * @return array[]
+     * @return string[][]
      */
     public static function provideMultipleRootLoadCases()
     {
@@ -102,12 +102,12 @@ class FileSystemLoaderTest extends TestCase
     /**
      * @dataProvider provideMultipleRootLoadCases
      *
-     * @param string $root
-     * @param string $path
+     * @param string[] $roots
+     * @param string   $path
      */
-    public function testMultipleRootLoadCases($root, $path)
+    public function testMultipleRootLoadCases($roots, $path)
     {
-        $this->assertValidLoaderFindReturn($this->getFileSystemLoader($root)->find($path));
+        $this->assertValidLoaderFindReturn($this->getFileSystemLoader($roots)->find($path));
     }
 
     public function testAllowsEmptyRootPath()
@@ -169,11 +169,13 @@ class FileSystemLoaderTest extends TestCase
     }
 
     /**
+     * @param string[] $roots
+     *
      * @return FileSystemLocator
      */
-    private function getFileSystemLocator()
+    private function getFileSystemLocator(array $roots)
     {
-        return new FileSystemLocator();
+        return new FileSystemLocator($roots);
     }
 
     /**
@@ -185,18 +187,17 @@ class FileSystemLoaderTest extends TestCase
     }
 
     /**
-     * @param string|array|null     $root
+     * @param array                 $roots
      * @param LocatorInterface|null $locator
      *
      * @return FileSystemLoader
      */
-    private function getFileSystemLoader($root = null, LocatorInterface $locator = null)
+    private function getFileSystemLoader(array $roots = array(), LocatorInterface $locator = null)
     {
         return new FileSystemLoader(
             MimeTypeGuesser::getInstance(),
             ExtensionGuesser::getInstance(),
-            null !== $locator ? $locator : $this->getFileSystemLocator(),
-            null !== $root ? $root : $this->getDefaultDataRoots()
+            null !== $locator ? $locator : $this->getFileSystemLocator(count($roots) ? $roots : $this->getDefaultDataRoots())
         );
     }
 

--- a/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
@@ -46,14 +46,6 @@ abstract class AbstractFileSystemLocatorTest extends TestCase
         $this->getFileSystemLocator(__DIR__)->locate('fileNotExist');
     }
 
-    public function testThrowsIfInvalidOptionProvided()
-    {
-        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid options provided to');
-
-        $this->getFileSystemLocator(__DIR__)->setOptions(['foo' => 'bar']);
-    }
-
     public function testThrowsIfRootPlaceholderInvalid()
     {
         $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);

--- a/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
@@ -49,7 +49,7 @@ abstract class AbstractFileSystemLocatorTest extends TestCase
     public function testThrowsIfRootPlaceholderInvalid()
     {
         $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
-        $this->expectExceptionMessage('Invalid root placeholder "invalid-placeholder" for path');
+        $this->expectExceptionMessage('Invalid root placeholder "@invalid-placeholder" for path');
 
         $this->getFileSystemLocator(__DIR__)->locate('@invalid-placeholder:file.ext');
     }

--- a/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
@@ -86,9 +86,6 @@ class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
      */
     protected function getFileSystemLocator($paths)
     {
-        $locator = new FileSystemInsecureLocator();
-        $locator->setOptions(['roots' => (array) $paths]);
-
-        return $locator;
+        return new FileSystemInsecureLocator((array) $paths);
     }
 }

--- a/Tests/Binary/Locator/FileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemLocatorTest.php
@@ -81,9 +81,6 @@ class FileSystemLocatorTest extends AbstractFileSystemLocatorTest
      */
     protected function getFileSystemLocator($paths)
     {
-        $locator = new FileSystemLocator();
-        $locator->setOptions(['roots' => (array) $paths]);
-
-        return $locator;
+        return new FileSystemLocator((array) $paths);
     }
 }

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -215,29 +215,29 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $container = new ContainerBuilder();
 
         $loader = new FileSystemLoaderFactory();
-        $loader->create($container, 'first_loader', array(
-            'data_root' => array('firstLoaderDataroot'),
+        $loader->create($container, 'first_loader', [
+            'data_root' => ['firstLoaderDataroot'],
             'locator' => 'filesystem',
-            'bundle_resources' => array(
+            'bundle_resources' => [
                 'enabled' => false,
-            ),
-        ));
+            ],
+        ]);
 
-        $loader->create($container, 'second_loader', array(
-            'data_root' => array('secondLoaderDataroot'),
+        $loader->create($container, 'second_loader', [
+            'data_root' => ['secondLoaderDataroot'],
             'locator' => 'filesystem',
-            'bundle_resources' => array(
+            'bundle_resources' => [
                 'enabled' => false,
-            ),
-        ));
+            ],
+        ]);
 
-        $this->assertEquals(
-            array('firstLoaderDataroot'),
+        $this->assertSame(
+            ['firstLoaderDataroot'],
             $container->getDefinition('liip_imagine.binary.loader.first_loader')->getArgument(2)->getArgument(0)
         );
 
-        $this->assertEquals(
-            array('secondLoaderDataroot'),
+        $this->assertSame(
+            ['secondLoaderDataroot'],
             $container->getDefinition('liip_imagine.binary.loader.second_loader')->getArgument(2)->getArgument(0)
         );
     }

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -69,7 +69,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $this->assertInstanceOfChildDefinition($loaderDefinition);
         $this->assertSame('liip_imagine.binary.loader.prototype.filesystem', $loaderDefinition->getParent());
 
-        $this->assertSame(['theDataRoot'], $loaderDefinition->getArgument(3));
+        $this->assertSame(['theDataRoot'], $loaderDefinition->getArgument(2)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadata()
@@ -104,7 +104,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
         ];
 
-        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadataAndBlacklisting()
@@ -140,7 +140,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
         ];
 
-        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadataAndWhitelisting()
@@ -176,7 +176,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipFooBundle' => $fooBundleRootPath.'/Resources/public',
         ];
 
-        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingNamedObj()
@@ -207,7 +207,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
         ];
 
-        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2)->getArgument(0));
     }
 
     public function testThrowsExceptionOnCreateWithBundlesEnabledUsingInvalidNamedObj()

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -210,6 +210,38 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2)->getArgument(0));
     }
 
+    public function testAbleToCreateTwoDistinctLoaders()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new FileSystemLoaderFactory();
+        $loader->create($container, 'first_loader', array(
+            'data_root' => array('firstLoaderDataroot'),
+            'locator' => 'filesystem',
+            'bundle_resources' => array(
+                'enabled' => false,
+            ),
+        ));
+
+        $loader->create($container, 'second_loader', array(
+            'data_root' => array('secondLoaderDataroot'),
+            'locator' => 'filesystem',
+            'bundle_resources' => array(
+                'enabled' => false,
+            ),
+        ));
+
+        $this->assertEquals(
+            array('firstLoaderDataroot'),
+            $container->getDefinition('liip_imagine.binary.loader.first_loader')->getArgument(2)->getArgument(0)
+        );
+
+        $this->assertEquals(
+            array('secondLoaderDataroot'),
+            $container->getDefinition('liip_imagine.binary.loader.second_loader')->getArgument(2)->getArgument(0)
+        );
+    }
+
     public function testThrowsExceptionOnCreateWithBundlesEnabledUsingInvalidNamedObj()
     {
         $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | discussion in https://github.com/liip/LiipImagineBundle/pull/908#issuecomment-299718198
| License | MIT

The point of this PR is to require a fully instantiated Locator in FileSystemLoader.
Before, you would need to pass a LocatorInterface and rootpaths to the FilesystemLoader, and the FilesystemLoader would then pass the rootpaths to the LocatorInterface, making the FilesystemLoader aware of the inner workings of LocatorInterface which it should not be.

By requiring a LocatorInterface with rootpaths set, this knowledge about inner workings of the LocatorInterface is removed.

This also removed the need for setOptions on the LocatorInterface, which did not really belong the main purpose of the interface (locating files) anyway.

It also removed the dependency on OptionsResolver from FileSystemLocator since the rootpaths can now be passed directly to the constructor, making the rootpaths a hard dependency instead of an optional one - which was incorrect.

**Update by @robfrawley:** Ran `php-cs-fixer` using new style rules and added types to locator interface/class method signatures.