### PR TITLE
[Templating] Handle uri query strings passed to templating extension and helper

### DIFF
--- a/Templating/Helper/ImagineHelper.php
+++ b/Templating/Helper/ImagineHelper.php
@@ -30,7 +30,10 @@ class ImagineHelper extends Helper
     }
 
     /**
-     * Gets the browser path for the image and filter to apply.
+     * Gets the browser path for the image and filter to apply. If your path inadvertently contains a query string
+     * - which might happen if you use asset versioning - the query string will be stripped from the path, the
+     * URL will be resolved using the path without query string, and the stripped query string will be appended to
+     * the resulting URL.
      *
      * @param string $path
      * @param string $filter
@@ -40,7 +43,13 @@ class ImagineHelper extends Helper
      */
     public function filter($path, $filter, array $runtimeConfig = array())
     {
-        return $this->cacheManager->getBrowserPath($path, $filter, $runtimeConfig);
+        $pathParts = explode('?', $path, 2);
+        $url = $this->cacheManager->getBrowserPath($pathParts[0], $filter, $runtimeConfig);
+        if (empty($pathParts[1])) {
+            return $url;
+        }
+
+        return $url.(strpos($url, '?') ? '&' : '?').$pathParts[1];
     }
 
     /**

--- a/Templating/ImagineExtension.php
+++ b/Templating/ImagineExtension.php
@@ -41,18 +41,27 @@ class ImagineExtension extends \Twig_Extension
     }
 
     /**
-     * Gets the browser path for the image and filter to apply.
+     * Gets the browser path for the image and filter to apply. If your path inadvertently contains a query string
+     * - which might happen if you use asset versioning - the query string will be stripped from the path, the
+     * URL will be resolved using the path without query string, and the stripped query string will be appended to
+     * the resulting URL.
      *
      * @param string $path
      * @param string $filter
      * @param array  $runtimeConfig
      * @param string $resolver
      *
-     * @return \Twig_Markup
+     * @return string
      */
     public function filter($path, $filter, array $runtimeConfig = array(), $resolver = null)
     {
-        return $this->cacheManager->getBrowserPath($path, $filter, $runtimeConfig, $resolver);
+        $pathParts = explode('?', $path, 2);
+        $url = $this->cacheManager->getBrowserPath($pathParts[0], $filter, $runtimeConfig, $resolver);
+        if (empty($pathParts[1])) {
+            return $url;
+        }
+
+        return $url.(strpos($url, '?') ? '&' : '?').$pathParts[1];
     }
 
     /**

--- a/Tests/Templating/Helper/ImagineHelperTest.php
+++ b/Tests/Templating/Helper/ImagineHelperTest.php
@@ -55,4 +55,30 @@ class ImagineHelperTest extends AbstractTest
 
         $this->assertEquals($expectedCachePath, $helper->filter($expectedPath, $expectedFilter));
     }
+
+    public function testStripsQueryStringFromPathAndAppendToFinalUrl()
+    {
+        $cacheManager = $this->createCacheManagerMock();
+
+        $cacheManager
+            ->method('getBrowserPath')
+            ->will($this->returnValue('/resolved/abc.png'));
+
+        $extension = new ImagineHelper($cacheManager);
+
+        $this->assertEquals('/resolved/abc.png?v=123', $extension->filter('abc.png?v=123', 'foo'));
+    }
+
+    public function testAppendsQueryStringToExistingQueryStringInFinalUrl()
+    {
+        $cacheManager = $this->createCacheManagerMock();
+
+        $cacheManager
+            ->method('getBrowserPath')
+            ->will($this->returnValue('/resolved/abc.png?foo=bar'));
+
+        $extension = new ImagineHelper($cacheManager);
+
+        $this->assertEquals('/resolved/abc.png?foo=bar&v=123', $extension->filter('abc.png?v=123', 'foo'));
+    }
 }

--- a/Tests/Templating/ImagineExtensionTest.php
+++ b/Tests/Templating/ImagineExtensionTest.php
@@ -65,4 +65,30 @@ class ImagineExtensionTest extends AbstractTest
         $this->assertInternalType('array', $filters);
         $this->assertCount(1, $filters);
     }
+
+    public function testStripsQueryStringFromPathAndAppendToFinalUrl()
+    {
+        $cacheManager = $this->createCacheManagerMock();
+
+        $cacheManager
+            ->method('getBrowserPath')
+            ->will($this->returnValue('/resolved/abc.png'));
+
+        $extension = new ImagineExtension($cacheManager);
+
+        $this->assertEquals('/resolved/abc.png?v=123', $extension->filter('abc.png?v=123', 'foo'));
+    }
+
+    public function testAppendsQueryStringToExistingQueryStringInFinalUrl()
+    {
+        $cacheManager = $this->createCacheManagerMock();
+
+        $cacheManager
+            ->method('getBrowserPath')
+            ->will($this->returnValue('/resolved/abc.png?foo=bar'));
+
+        $extension = new ImagineExtension($cacheManager);
+
+        $this->assertEquals('/resolved/abc.png?foo=bar&v=123', $extension->filter('abc.png?v=123', 'foo'));
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | https://github.com/liip/LiipImagineBundle/issues/903
| License | MIT

Gracefully handle any query strings in paths passed to the templating filters.
See added tests for behaviour.