### PR TITLE
Use new Twig notation

### DIFF
--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -94,7 +94,7 @@ class LiipImagineExtension extends Extension
 
         $container->setParameter('twig.form.resources', array_merge(
             $container->hasParameter('twig.form.resources') ? $container->getParameter('twig.form.resources') : [],
-            ['LiipImagineBundle:Form:form_div_layout.html.twig']
+            ['@LiipImagine/Form/form_div_layout.html.twig']
         ));
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

~~After the removal of the Symfony Templating component, templates can no longer be referenced with `MyBundle:Foo:bar.html.twig`.~~ When Symfony is installed without the Templating component, bundle references like `MyBundle:Foo:bar.html.twig` are not resolved. This PR updates all occurrences of the old syntax to use the new native Twig prefix syntax. This allows the bundle to be used even when the Templating component is not present.