### PR TITLE
Use simplified Symfony version comparison operation and CS fixes

### DIFF
--- a/Async/CacheResolved.php
+++ b/Async/CacheResolved.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Liip\ImagineBundle\Async;
 
 use Enqueue\Util\JSON;
@@ -14,9 +15,9 @@ class CacheResolved implements \JsonSerializable
      * @var \string[]
      */
     private $uris;
-    
+
     /**
-     * @param string $path
+     * @param string        $path
      * @param string[]|null $uris
      */
     public function __construct($path, array $uris)

--- a/Async/ResolveCache.php
+++ b/Async/ResolveCache.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Liip\ImagineBundle\Async;
 
 use Enqueue\Util\JSON;
@@ -21,9 +22,9 @@ class ResolveCache implements \JsonSerializable
     private $force;
 
     /**
-     * @param string $path
+     * @param string        $path
      * @param string[]|null $filters
-     * @param bool $force
+     * @param bool          $force
      */
     public function __construct($path, array $filters = null, $force = false)
     {

--- a/Async/ResolveCacheProcessor.php
+++ b/Async/ResolveCacheProcessor.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Liip\ImagineBundle\Async;
 
 use Enqueue\Client\ProducerInterface;
@@ -35,9 +36,9 @@ class ResolveCacheProcessor implements PsrProcessor, TopicSubscriberInterface, Q
     private $producer;
 
     /**
-     * @param CacheManager $cacheManager
-     * @param FilterManager $filterManager
-     * @param DataManager $dataManager
+     * @param CacheManager      $cacheManager
+     * @param FilterManager     $filterManager
+     * @param DataManager       $dataManager
      * @param ProducerInterface $producer
      */
     public function __construct(

--- a/Async/Topics.php
+++ b/Async/Topics.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Liip\ImagineBundle\Async;
 
 class Topics

--- a/LiipImagineBundle.php
+++ b/LiipImagineBundle.php
@@ -62,5 +62,5 @@ class LiipImagineBundle extends Bundle
                 ->add(Topics::CACHE_RESOLVED, 'The topic contains messages about resolved image\'s caches')
             );
         }
-     }
+    }
 }

--- a/Tests/Async/CacheResolvedTest.php
+++ b/Tests/Async/CacheResolvedTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Liip\ImagineBundle\Tests\Async;
 
 use Liip\ImagineBundle\Async\CacheResolved;

--- a/Tests/Async/ResolveCacheProcessorTest.php
+++ b/Tests/Async/ResolveCacheProcessorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Liip\ImagineBundle\Tests\Async;
 
 use Enqueue\Client\ProducerInterface;
@@ -260,7 +261,7 @@ class ResolveCacheProcessorTest extends \PHPUnit_Framework_TestCase
         $cacheManagerMock
             ->expects($this->atLeastOnce())
             ->method('resolve')
-            ->willReturnCallback(function($path, $filter) {
+            ->willReturnCallback(function ($path, $filter) {
                 return $path.$filter.'Uri';
             })
         ;
@@ -278,7 +279,7 @@ class ResolveCacheProcessorTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('send')
             ->with(Topics::CACHE_RESOLVED, $this->isInstanceOf('Liip\ImagineBundle\Async\CacheResolved'))
-        ->willReturnCallback(function($topic, CacheResolved $message) use ($testCase) {
+        ->willReturnCallback(function ($topic, CacheResolved $message) use ($testCase) {
             $testCase->assertEquals('theImagePath', $message->getPath());
             $testCase->assertEquals(array(
                 'fooFilter' => 'theImagePathfooFilterUri',

--- a/Tests/Async/ResolveCacheTest.php
+++ b/Tests/Async/ResolveCacheTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Liip\ImagineBundle\Tests\Async;
 
 use Liip\ImagineBundle\Async\ResolveCache;

--- a/Utility/Framework/SymfonyFramework.php
+++ b/Utility/Framework/SymfonyFramework.php
@@ -13,6 +13,9 @@ namespace Liip\ImagineBundle\Utility\Framework;
 
 use Symfony\Component\HttpKernel\Kernel;
 
+/**
+ * @internal
+ */
 class SymfonyFramework
 {
     /**
@@ -75,19 +78,6 @@ class SymfonyFramework
      */
     private static function kernelVersionCompare($operator, $major, $minor = null, $patch = null)
     {
-        $vernum = $major;
-        $kernel = Kernel::MAJOR_VERSION;
-
-        if ($minor) {
-            $vernum .= '.'.$minor;
-            $kernel .= '.'.Kernel::MINOR_VERSION;
-
-            if ($patch) {
-                $vernum .= '.'.$patch;
-                $kernel .= '.'.Kernel::RELEASE_VERSION;
-            }
-        }
-
-        return version_compare($kernel, $vernum, $operator);
+        return version_compare(Kernel::VERSION_ID, sprintf("%d%'.02d%'.02d", $major, $minor ?: 0, $patch ?: 0), $operator);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

This changes the internal behavior of `SymfonyFramework::kernelVersionCompare()` by using the `Kernel::VERSION_ID` constant instead of the separated version numbers (major, minor, patch). The resulting API behavior is identical. To see only these changes, reference commit [39d820](https://github.com/robfrawley/LiipImagineBundle/commit/46c7db19ea639b7ea952dd8a1e8bbd4339d820c1).

The second commit contains automated CS fixes from a PHP CS Fixer run.

Also of interest, I added the internal docblock to the `SymfonyFramework` class, which I suggest we more regularly adopt for code we don't intend to be used by consuming projects.