### PR TITLE
Remove Symfony 3.3 from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,6 @@ matrix:
       env: SYMFONY_VERSION=dev-master
   allow_failures:
     - php: 7.1
-      env: SYMFONY_VERSION=3.3.x-dev
-    - php: 7.1
       env: SYMFONY_VERSION=dev-master
 
 before_install:


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Now that Symfony `3.3` has a beta and, most recently, a release candidate, it's time we remove it from our Travis test suite allowed failures matrix. (It was actually already accidentally removed from the allowed failure by changing the environment variables in #919; this simply removes the now ignored allowed failure entry).