### PR TITLE
[Filter] Add resolution filter loader

### DIFF
--- a/Exception/Imagine/Filter/LoadFilterException.php
+++ b/Exception/Imagine/Filter/LoadFilterException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Exception\Imagine\Filter;
+
+use Liip\ImagineBundle\Exception\ExceptionInterface;
+
+class LoadFilterException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/Imagine/Filter/Loader/ResampleFilterLoader.php
+++ b/Imagine/Filter/Loader/ResampleFilterLoader.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Imagine\Filter\Loader;
+
+use Imagine\Image\ImageInterface;
+use Imagine\Image\ImagineInterface;
+use Liip\ImagineBundle\Exception\Imagine\Filter\LoadFilterException;
+use Liip\ImagineBundle\Utility\OptionsResolver\OptionsResolver;
+use Liip\ImagineBundle\Exception\InvalidArgumentException;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
+
+class ResampleFilterLoader implements LoaderInterface
+{
+    /**
+     * @var ImagineInterface
+     */
+    private $imagine;
+
+    /**
+     * @param ImagineInterface $imagine
+     */
+    public function __construct(ImagineInterface $imagine)
+    {
+        $this->imagine = $imagine;
+    }
+
+    /**
+     * @param ImageInterface $image
+     * @param array          $options
+     *
+     * @throws LoadFilterException
+     *
+     * @return ImageInterface
+     */
+    public function load(ImageInterface $image, array $options = array())
+    {
+        $options = $this->resolveOptions($options);
+        $tmpFile = $this->getTemporaryFile($options['temp_dir']);
+
+        try {
+            $image->save($tmpFile, $this->getImagineSaveOptions($options));
+            $image = $this->imagine->open($tmpFile);
+            $this->delTemporaryFile($tmpFile);
+        } catch (\Exception $exception) {
+            $this->delTemporaryFile($tmpFile);
+            throw new LoadFilterException('Unable to save/open file in resample filter loader.', null, $exception);
+        }
+
+        return $image;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @throws \RuntimeException
+     *
+     * @return string
+     */
+    private function getTemporaryFile($path)
+    {
+        if (!is_dir($path) || false === $file = tempnam($path, 'liip-imagine-bundle')) {
+            throw new \RuntimeException(sprintf('Unable to create temporary file in "%s" base path.', $path));
+        }
+
+        return $file;
+    }
+
+    /**
+     * @param $file
+     *
+     * @throws \RuntimeException
+     */
+    private function delTemporaryFile($file)
+    {
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    private function getImagineSaveOptions(array $options)
+    {
+        $saveOptions = array(
+            'resolution-units' => $options['unit'],
+            'resolution-x' => $options['x'],
+            'resolution-y' => $options['y'],
+        );
+
+        if (isset($options['filter'])) {
+            $saveOptions['resampling-filter'] = $options['filter'];
+        }
+
+        return $saveOptions;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    private function resolveOptions(array $options)
+    {
+        $resolver = new OptionsResolver();
+
+        $resolver->setRequired(array('x', 'y', 'unit', 'temp_dir'));
+        $resolver->setDefined(array('filter'));
+        $resolver->setDefault('temp_dir', sys_get_temp_dir());
+        $resolver->setDefault('filter', 'UNDEFINED');
+
+        $resolver->setAllowedTypes('x', array('int', 'float'));
+        $resolver->setAllowedTypes('y', array('int', 'float'));
+        $resolver->setAllowedTypes('temp_dir', array('string'));
+        $resolver->setAllowedTypes('filter', array('string'));
+
+        $resolver->setAllowedValues('unit', array(
+            ImageInterface::RESOLUTION_PIXELSPERINCH,
+            ImageInterface::RESOLUTION_PIXELSPERCENTIMETER
+        ));
+
+        $resolver->setNormalizer('filter', function (Options $options, $value) {
+            foreach (array('\Imagine\Image\ImageInterface::FILTER_%s', '\Imagine\Image\ImageInterface::%s', '%s') as $format) {
+                if (defined($constant = sprintf($format, strtoupper($value))) || defined($constant = sprintf($format, $value))) {
+                    return constant($constant);
+                }
+            }
+
+            throw new InvalidArgumentException(
+                'Invalid value for "filter" option: must be a valid constant resolvable using one of formats '.
+                '"\Imagine\Image\ImageInterface::FILTER_%s", "\Imagine\Image\ImageInterface::%s", or "%s".'
+            );
+        });
+
+        try {
+            return $resolver->resolve($options);
+        } catch (ExceptionInterface $exception) {
+            throw new InvalidArgumentException(sprintf('Invalid option(s) passed to %s::load().', __CLASS__), null, $exception);
+        }
+    }
+}

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -47,6 +47,7 @@
         <parameter key="liip_imagine.filter.loader.rotate.class">Liip\ImagineBundle\Imagine\Filter\Loader\RotateFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.flip.class">Liip\ImagineBundle\Imagine\Filter\Loader\FlipFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.interlace.class">Liip\ImagineBundle\Imagine\Filter\Loader\InterlaceFilterLoader</parameter>
+        <parameter key="liip_imagine.filter.loader.resample.class">Liip\ImagineBundle\Imagine\Filter\Loader\ResampleFilterLoader</parameter>
 
         <!-- Data loaders' classes -->
 
@@ -228,6 +229,11 @@
 
         <service id="liip_imagine.filter.loader.interlace" class="%liip_imagine.filter.loader.interlace.class%">
             <tag name="liip_imagine.filter.loader" loader="interlace" />
+        </service>
+
+        <service id="liip_imagine.filter.loader.resample" class="%liip_imagine.filter.loader.resample.class%">
+            <argument type="service" id="liip_imagine" />
+            <tag name="liip_imagine.filter.loader" loader="resample" />
         </service>
 
         <!-- Data loaders -->

--- a/Resources/doc/filters/general.rst
+++ b/Resources/doc/filters/general.rst
@@ -61,6 +61,7 @@ Background Options
     values: ``topleft``, ``top``, ``topright``, ``left``, ``center``, ``right``, ``bottomleft``,
     ``bottom``, and ``bottomright``.
 
+
 .. _filter-grayscale:
 
 Grayscale
@@ -124,6 +125,82 @@ Interlace Options
 :strong:`mode:` ``string``
     Sets the interlace mode to encode the file with. Valid values: ``none``, ``line``,
     ``plane``, and ``partition``.
+
+
+.. _filter-resample:
+
+Resample
+--------
+
+The built-in ``resample`` filter provides a resampling transformation by allows you to
+change the resolution of an image. This filter exposes a number of `resample options`_ which
+may be used to configure its behavior.
+
+.. tip::
+
+    Resampling changes the image resolution (also known as "pixel density") of an image
+    and is useful when you need to present different versions of an image dependent on
+    the user's screen density. For example, you may need to provide a "normal" and a
+    "retina" variant.
+
+    The use of "resolution" is not to be confused with "dimensions". This filter does not
+    affect the dimentions of an image, only the pixel density.
+
+
+Example configuration:
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        filter_sets:
+
+            # name our filter set "my_resample_filter"
+            my_resample_filter:
+                filters:
+
+                    # use and setup the "resample" filter
+                    resample:
+
+                        # set the unit to use for pixel density
+                        unit: ppi
+
+                        # set the horizontal pixel density
+                        x: 72
+
+                        # set the vertical pixel density
+                        y: 72
+
+                        # set the resampling filter
+                        filter: lanczos
+
+                        # set the temporary path to use for resampling work
+                        tmp_dir: /my/custom/temporary/directory/path
+
+
+Resample Options
+~~~~~~~~~~~~~~~~
+
+:strong:`unit:` ``string``
+    Sets the unit to use for pixel density, either "pixels per inch" or "pixels per centimeter".
+    Valid values: ``ppi`` and ``ppc``.
+
+:strong:`x:` ``int|float``
+    Sets the horizontal (x) pixel density to resample the image to.
+
+:strong:`y:` ``int|float``
+    Sets the vertical (y) pixel density to resample the image to.
+
+:strong:`filter:` ``string``
+    Sets the optional filter to use during the resampling operation. It must be a string resolvable
+    as a constant from `Imagine\Image\ImageInterface`_ (you may omit the ``FILTER_`` prefix)
+    or a valid fully qualified constant. By default it is set to ``FILTER_UNDEFINED``.
+
+:strong:`tmp_dir:` ``string``
+    Sets the optional temporary work directory. This filter requires a temporary location to save
+    out and read back in the image binary, as these operations are requires to resample an image.
+    By default, it is set to the value of the `sys_get_temp_dir()`_ function.
 
 
 .. _filter-strip:
@@ -211,3 +288,7 @@ Watermark Options
     The **position** option and **ordering** for this filter is significant.
     For example, calling a ``crop`` after this filter could unintentionally
     remove the watermark entirely from the final image.
+
+
+.. _`Imagine\Image\ImageInterface`: https://imagine.readthedocs.io/en/master/_static/API/Imagine/Image/ImageInterface.html
+.. _`sys_get_temp_dir()`: http://php.net/manual/en/function.sys-get-temp-dir.php

--- a/Tests/Functional/Imagine/Filter/Loader/ResampleFilterLoaderTest.php
+++ b/Tests/Functional/Imagine/Filter/Loader/ResampleFilterLoaderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Functional\Imagine\Filter\Loader;
+
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
+
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ResampleFilterLoader
+ */
+class ResampleFilterLoaderTest extends AbstractWebTestCase
+{
+    public function testContainerHasService()
+    {
+        $this->createClient();
+
+        $this->assertInstanceOf(
+            '\Liip\ImagineBundle\Imagine\Filter\Loader\ResampleFilterLoader',
+            self::$kernel->getContainer()->get('liip_imagine.filter.loader.resample')
+        );
+    }
+}

--- a/Tests/Imagine/Filter/Loader/ResampleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ResampleFilterLoaderTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Filter;
+
+use Imagine\Imagick\Imagine;
+use Imagine\Image\ImagineInterface;
+use Liip\ImagineBundle\Imagine\Filter\Loader\ResampleFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
+
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ResampleFilterLoader
+ */
+class ResampleFilterLoaderTest extends AbstractTest
+{
+    public function testResample()
+    {
+        if (!class_exists('\Imagick')) {
+            $this->markTestSkipped('Requires \Imagick class (`imagick` extension) to be available.');
+        }
+
+        $imgPath = realpath(__DIR__.'/../../../Fixtures/assets/cats.png');
+        $tmpPath = tempnam(sys_get_temp_dir(), 'liip-imagine-bundle-test');
+        $imagine = new Imagine();
+        $ppc     = 240.0;
+
+        $image = $imagine->open($imgPath);
+        $image = $this->createResampleFilterLoaderInstance($imagine)->load($image, array(
+            'x' => $ppc,
+            'y' => $ppc,
+            'unit' => 'ppc',
+        ));
+        $image->save($tmpPath);
+
+        $imagick = new \Imagick($tmpPath);
+        $this->assertSame(array('x' => $ppc, 'y' => $ppc), $imagick->getImageResolution());
+
+        @unlink($tmpPath);
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideOptionsData()
+    {
+        return array(
+            array(array('x' => 500, 'y' => 500, 'unit' => 'ppi')),
+            array(array('x' => 500, 'y' => 500, 'unit' => 'ppc')),
+            array(array('x' => 120, 'y' => 120, 'unit' => 'ppi', 'filter' => 'undefined')),
+            array(array('x' => 120, 'y' => 120, 'unit' => 'ppi', 'filter' => 'filter_undefined')),
+            array(array('x' => 120, 'y' => 120, 'unit' => 'ppi', 'filter' => 'lanczos')),
+            array(array('x' => 120, 'y' => 120, 'unit' => 'ppi', 'filter' => 'filter_lanczos')),
+        );
+    }
+
+    /**
+     * @param array $options
+     *
+     * @dataProvider provideOptionsData
+     */
+    public function testOptions(array $options)
+    {
+        $image = $this->getImageInterfaceMock();
+        $image->expects($this->once())
+            ->method('save')
+            ->willReturn($image);
+
+        $imagine = $this->createImagineInterfaceMock();
+        $imagine->expects($this->once())
+            ->method('open')
+            ->willReturn($image);
+
+        $this->createResampleFilterLoaderInstance($imagine)->load($image, $options);
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideInvalidOptionsData()
+    {
+        return array(
+            array(array()),
+            array(array(
+                'x' => 'string-is-invalid-type',
+                'y' => 120,
+                'unit' => 'ppi',
+            )),
+            array(array(
+                'x' => 120,
+                'y' => array('is', 'invalid', 'type'),
+                'unit' => 'ppi',
+            )),
+            array(array(
+                'x' => 120,
+                'y' => 120,
+                'unit' => 'invalid-value',
+            )),
+        );
+    }
+
+    /**
+     * @dataProvider provideInvalidOptionsData
+     *
+     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid option(s) passed to Liip\ImagineBundle\Imagine\Filter\Loader\ResampleFilterLoader::load().
+     */
+    public function testThrowsOnInvalidOptions(array $options)
+    {
+        $loader = $this->createResampleFilterLoaderInstance();
+        $loader->load($this->getImageInterfaceMock(), $options);
+    }
+
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid value for "filter" option: must be a valid constant resolvable using one of formats "\Imagine\Image\ImageInterface::FILTER_%s", "\Imagine\Image\ImageInterface::%s", or "%s".
+     */
+    public function testThrowsOnInvalidFilterOption()
+    {
+        $loader = $this->createResampleFilterLoaderInstance();
+        $loader->load($this->getImageInterfaceMock(), array(
+            'x' => 120,
+            'y' => 120,
+            'unit' => 'ppi',
+            'filter' => 'invalid-filter',
+        ));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegExp {Unable to create temporary file in ".+" base path.}
+     */
+    public function testThrowsOnInvalidTemporaryPathOption()
+    {
+        $loader = $this->createResampleFilterLoaderInstance();
+        $loader->load($this->getImageInterfaceMock(), array(
+            'x' => 120,
+            'y' => 120,
+            'unit' => 'ppi',
+            'temp_dir' => '/this/path/does/not/exist/foo/bar/baz/qux',
+        ));
+    }
+
+    /**
+     * @expectedException \Liip\ImagineBundle\Exception\Imagine\Filter\LoadFilterException
+     */
+    public function testThrowsOnSaveOrOpenError()
+    {
+        $image = $this->getImageInterfaceMock();
+        $image->expects($this->once())
+            ->method('save')
+            ->willThrowException(new \Exception('Error saving file!'));
+
+        $this->createResampleFilterLoaderInstance()->load($image, array('x' => 120, 'y' => 120, 'unit' => 'ppi'));
+    }
+
+    /**
+     * @param ImagineInterface $imagine
+     *
+     * @return ResampleFilterLoader
+     */
+    private function createResampleFilterLoaderInstance(ImagineInterface $imagine = null)
+    {
+        return new ResampleFilterLoader($imagine ?: $this->createImagineInterfaceMock());
+    }
+}

--- a/Tests/Utility/OptionsResolver/OptionsResolverTest.php
+++ b/Tests/Utility/OptionsResolver/OptionsResolverTest.php
@@ -31,6 +31,20 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(100, $options['bar']);
     }
 
+    public function testDefinedOptions()
+    {
+        $r = static::setupOptionsResolver();
+        $options = $r->resolve(array(
+            'foo' => 'a',
+            'bar' => 100,
+            'baz' => 'a-string',
+            'qux' => 1000,
+        ));
+
+        $this->assertSame('a-string', $options['baz']);
+        $this->assertSame(1000, $options['qux']);
+    }
+
     public function testDefaultOptions()
     {
         $r = static::setupOptionsResolver();
@@ -56,6 +70,7 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\ExceptionInterface
+     * @expectedExceptionMessageRegExp {.+"bar", "baz", "foo", "qux"+}
      */
     public function testInvalidOptions()
     {
@@ -67,6 +82,7 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage expected to be of type "integer"
      */
     public function testRequiredTypes()
     {
@@ -93,16 +109,18 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
      */
     private static function setupOptionsResolver()
     {
-        $r = new OptionsResolver();
-        $r->setRequired(array('foo', 'bar'));
-        $r->setAllowedValues('foo', array('a', 'b', 'c', 'z'));
-        $r->setDefault('foo', 'a');
-        $r->setAllowedTypes('foo', array('string'));
-        $r->setAllowedTypes('bar', array('integer'));
-        $r->setNormalizer('foo', function (Options $options, $value) {
+        $resolver = new OptionsResolver();
+        $resolver->setRequired(array('foo', 'bar'));
+        $resolver->setDefined(array('baz', 'qux'));
+        $resolver->setAllowedValues('foo', array('a', 'b', 'c', 'z'));
+        $resolver->setDefault('foo', 'a');
+        $resolver->setAllowedTypes('foo', array('string'));
+        $resolver->setAllowedTypes('bar', array('integer'));
+        $resolver->setAllowedTypes('baz', array('string'));
+        $resolver->setNormalizer('foo', function (Options $options, $value) {
             return $value === 'c' ? 'z' : $value;
         });
 
-        return $r;
+        return $resolver;
     }
 }

--- a/Utility/OptionsResolver/OptionsResolver.php
+++ b/Utility/OptionsResolver/OptionsResolver.php
@@ -15,10 +15,20 @@ use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
 use Symfony\Component\OptionsResolver\OptionsResolver as BaseOptionsResolver;
 
 /**
- * @deprecated Deprecated in v1.7.x and scheduled for removal in v2.0.x
+ * Provides a compatible interface for Symfony's newest OptionsResolver implementation, while internally supporting
+ * legacy variants of the interface. This allows for a clean migration plan in our 2.x branch where any classes
+ * implementing this must simple "use" the real "Symfony\Component\OptionsResolver\OptionsResolver" class without any
+ * changes to usage within the code (once support for Symfony <2.7 is dropped).
+ *
+ * @deprecated Deprecated in v1.7 and scheduled for removal in v2.0.x
  */
 class OptionsResolver
 {
+    /**
+     * @var array
+     */
+    private $defined = array();
+
     /**
      * @var array
      */
@@ -45,20 +55,40 @@ class OptionsResolver
     private $normalizers = array();
 
     /**
+     * @param array $defined
+     *
+     * @return $this
+     */
+    public function setDefined(array $defined)
+    {
+        $this->defined = $defined;
+
+        return $this;
+    }
+
+    /**
      * @param string $option
      * @param mixed  $value
+     *
+     * @return $this
      */
     public function setDefault($option, $value)
     {
         $this->defaults[$option] = $value;
+
+        return $this;
     }
 
     /**
      * @param array $options
+     *
+     * @return $this
      */
     public function setRequired(array $options)
     {
         $this->required = $options;
+
+        return $this;
     }
 
     /**
@@ -125,6 +155,8 @@ class OptionsResolver
      */
     private function setupResolver(BaseOptionsResolver $resolver)
     {
+        $resolver->setDefined($this->defined);
+
         foreach ($this->allowedValues as $option => $values) {
             $resolver->setAllowedValues($option, $values);
         }
@@ -143,6 +175,7 @@ class OptionsResolver
      */
     private function setupResolverLegacy(BaseOptionsResolver $resolver)
     {
+        $resolver->setOptional($this->defined);
         $resolver->setAllowedValues($this->allowedValues);
         $resolver->setAllowedTypes($this->allowedTypes);
         $resolver->setNormalizers($this->normalizers);


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #123, #938
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Many questions have been asked about "retina support" including #123 and #938. While I do not believe this bundle needs to enable any retina-specific functionality, as it already allows users to define any number of "filter sets" to generate any number of variations required, we should expose a filter to properly handle changing the image resolution, or "resampling".

This PR adds a `ResampleFilterLoader` that allows for creating different "filter sets" with different resulting image resolution (not to be confused with dimensions). Included is the ability to set `x` and `y` resolution integers, a corresponding `unit` (one of "inch" or "centimeter"), and an optional resampling `filter` (one of `\Imagine\Image\ImageInterface::FILTER_%s`).

This is a first-pass at adding resampling support, and as such I'm looking for comments about the manner in which this is implemented, specifically [ResampleFilterLoader.php:45](https://github.com/liip/LiipImagineBundle/pull/941/files#diff-3dd9a8ba39966e3e29eaa3ceccfe0a43R45). The `imagine-library` package this bundle leverages for image transformations _doesn't offer any means for resampling outside of **saving out the file and reading it back in**_, which isn't the most straightforward manner to handle this operation. 

**Any thought on this implementation or ideas for an alternate?**

This PR also introduces the following items intrinsically need for the filter loader implemented:
- `\Liip\ImagineBundle\Exception\Imagine\Filter\LoadFilterException`
  Added for exceptions thrown from within filters loader implementations
- `Utility/OptionsResolver/OptionsResolver:setDefined()`
  Added to allow for setting optional options that should not have a corresponding default value

Tests for all added functionality have now been implemented, as well. ~Additions to the documentation are now yet implemented.~