### PR TITLE
Move to trusty for travis except for php 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
 ---
 
 sudo: false
+dist: trusty
 
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 cache:
   directories:
@@ -26,6 +25,7 @@ matrix:
   include:
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+      dist: precise
     - php: 5.6
       env: SYMFONY_VERSION=2.3.x-dev
     - php: 5.6
@@ -42,6 +42,7 @@ matrix:
       env: SYMFONY_VERSION=3.3.x-dev WITH_ENQUEUE=true
     - php: 7.1
       env: SYMFONY_VERSION=dev-master
+    - php: hhvm
   allow_failures:
     - php: 7.1
       env: SYMFONY_VERSION=3.3.x-dev


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | [travis-build#1512@1.0](https://travis-ci.org/liip/LiipImagineBundle/builds/238667700)
| License | MIT
| Doc PR | <!--highly recommended for new features-->

You may have noticed that [our latest build](https://travis-ci.org/liip/LiipImagineBundle) on Travis for the `1.x` branch has been stuck in failure for the past few weeks. **First**, it was the Twig bug twigphp/Twig#2499, but this was fixed upstream quickly once I reported it. **Now** the issue is that the Travis Ubuntu Precise container has dropped support for HHVM. The advertised resolution is to upgrade to the Ubuntu Trusty container, which is great, except it doesn't support PHP 5.3 anymore.

So, the **resolution** here is to upgrade all builds to the Trusty container, except for PHP 5.3, which will continue using the Precise container. The only other change is, due to the removal of PHP 5.3 from the main `php` array in `.travis.yml`, we don't test this bundle with Symfony 2.8 using PHP 5.3, but _only_ with the lowest dependencies. In short, PHP 5.3 is tested once instead of twice.

This removes one additional build that I don't think is particularly necessary. Any objections?