### PR TITLE
Use 307 temporary redirect instead of 301 permanently redirect

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -109,7 +109,7 @@ class ImagineController
                 );
             }
 
-            return new RedirectResponse($this->cacheManager->resolve($path, $filter, $resolver), 301);
+            return new RedirectResponse($this->cacheManager->resolve($path, $filter, $resolver), 307);
         } catch (NonExistingFilterException $e) {
             $message = sprintf('Could not locate filter "%s" for path "%s". Message was "%s"', $filter, $path, $e->getMessage());
 
@@ -177,7 +177,7 @@ class ImagineController
                 $resolver
             );
 
-            return new RedirectResponse($this->cacheManager->resolve($rcPath, $filter, $resolver), 301);
+            return new RedirectResponse($this->cacheManager->resolve($rcPath, $filter, $resolver), 307);
         } catch (NonExistingFilterException $e) {
             $message = sprintf('Could not locate filter "%s" for path "%s". Message was "%s"', $filter, $hash.'/'.$path, $e->getMessage());
 

--- a/Resources/doc/resolve-cache-images-in-background.rst
+++ b/Resources/doc/resolve-cache-images-in-background.rst
@@ -5,7 +5,7 @@ Overview
 --------
 
 By default the LiipImagineBundle processes the image on demand.
-It does in resolve controller and saves the result, does a 301 redirect to the processed static image.
+It does in resolve controller and saves the result, does a 307 redirect to the processed static image.
 The approach has its benefits.
 The most notable is simplicity.
 Though there are some disadvantages:

--- a/Tests/Functional/Controller/ImagineControllerTest.php
+++ b/Tests/Functional/Controller/ImagineControllerTest.php
@@ -37,7 +37,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(307, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -55,7 +55,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(307, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -131,7 +131,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(307, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/'.$expectedCachePath, $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/'.$expectedCachePath);
@@ -166,7 +166,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(307, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache'.'/'.$expectedCachePath, $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/'.$expectedCachePath);
@@ -186,7 +186,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(307, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/foo bar.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/foo bar.jpeg');


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0 
| Bug fix? | yes
| New feature? | no
| BC breaks? | maybe
| Deprecations? | no
| Tests pass? | 
| Fixed tickets | 
| License | MIT
| Doc PR | 

Since Symfony 3.2, RedirectResponse will remove 'cache-control' header from 301 redirect: https://github.com/symfony/symfony/blob/3.2/src/Symfony/Component/HttpFoundation/RedirectResponse.php .

The web server like nginx may cache the image request because it is 301 redirect to the same url (or maybe web browser like Chrome will do the same thing ), and that will causes a  "too many redirects" error.