### PR TITLE
Add chain loader implementation

### DIFF
--- a/Binary/Loader/ChainLoader.php
+++ b/Binary/Loader/ChainLoader.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Binary\Loader;
+
+use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
+
+class ChainLoader implements LoaderInterface
+{
+    /**
+     * @var LoaderInterface[]
+     */
+    private $loaders;
+
+    /**
+     * @param LoaderInterface[] $loaders
+     */
+    public function __construct(array $loaders)
+    {
+        $this->loaders = array_filter($loaders, function ($loader) {
+            return $loader instanceof LoaderInterface;
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($path)
+    {
+        foreach ($this->loaders as $loader) {
+            try {
+                return $loader->find($path);
+            } catch (\Exception $loaderException) {
+                // handle exception later
+            }
+        }
+
+        throw new NotLoadableException(vsprintf('Source image not resolvable "%s" using "%s" loaders.', array(
+            $path,
+            $this->getLoaderNamesString(),
+        )));
+    }
+
+    /**
+     * @return string
+     */
+    private function getLoaderNamesString()
+    {
+        $names = array();
+        foreach ($this->loaders as $n => $l) {
+            $names[] = sprintf('%s=[%s]', $n, get_class($l));
+        }
+
+        return implode(':', $names);
+    }
+}

--- a/DependencyInjection/Factory/Loader/ChainLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/ChainLoaderFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\DependencyInjection\Factory\Loader;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ChainLoaderFactory extends AbstractLoaderFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function create(ContainerBuilder $container, $loaderName, array $config)
+    {
+        $definition = $this->getChildLoaderDefinition();
+        $definition->replaceArgument(0, $this->createLoaderReferences($config['loaders']));
+
+        return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'chain';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addConfiguration(ArrayNodeDefinition $builder)
+    {
+        $builder
+            ->children()
+                ->arrayNode('loaders')
+                    ->isRequired()
+                    ->prototype('scalar')
+                        ->cannotBeEmpty()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * @param string[] $loaders
+     *
+     * @return string[]
+     */
+    private function createLoaderReferences(array $loaders)
+    {
+        return array_combine($loaders, array_map(function ($name) {
+            return new Reference(sprintf('liip_imagine.binary.loader.%s', $name));
+        }, $loaders));
+    }
+}

--- a/LiipImagineBundle.php
+++ b/LiipImagineBundle.php
@@ -19,6 +19,7 @@ use Liip\ImagineBundle\DependencyInjection\Compiler\LocatorsCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\PostProcessorsCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\ResolversCompilerPass;
+use Liip\ImagineBundle\DependencyInjection\Factory\Loader\ChainLoaderFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory;
@@ -55,6 +56,7 @@ class LiipImagineBundle extends Bundle
         $extension->addLoaderFactory(new StreamLoaderFactory());
         $extension->addLoaderFactory(new FileSystemLoaderFactory());
         $extension->addLoaderFactory(new FlysystemLoaderFactory());
+        $extension->addLoaderFactory(new ChainLoaderFactory());
 
         if (class_exists('Enqueue\Bundle\DependencyInjection\Compiler\AddTopicMetaPass')) {
             $container->addCompilerPass(AddTopicMetaPass::create()

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -53,6 +53,7 @@
         <parameter key="liip_imagine.binary.loader.filesystem.class">Liip\ImagineBundle\Binary\Loader\FileSystemLoader</parameter>
         <parameter key="liip_imagine.binary.loader.stream.class">Liip\ImagineBundle\Binary\Loader\StreamLoader</parameter>
         <parameter key="liip_imagine.binary.loader.flysystem.class">Liip\ImagineBundle\Binary\Loader\FlysystemLoader</parameter>
+        <parameter key="liip_imagine.binary.loader.chain.class">Liip\ImagineBundle\Binary\Loader\ChainLoader</parameter>
 
         <!-- Data loader loaders' classes -->
 
@@ -247,6 +248,10 @@
         <service id="liip_imagine.binary.loader.prototype.flysystem" class="%liip_imagine.binary.loader.flysystem.class%" abstract="true">
             <argument type="service" id="liip_imagine.extension_guesser" />
             <argument><!-- will be injected by FlysystemLoaderFactory --></argument>
+        </service>
+
+        <service id="liip_imagine.binary.loader.prototype.chain" class="%liip_imagine.binary.loader.chain.class%" abstract="true">
+            <argument><!-- will be injected by ChainLoaderFactory --></argument>
         </service>
 
         <!-- Data loader locators -->

--- a/Tests/Binary/Loader/ChainLoaderTest.php
+++ b/Tests/Binary/Loader/ChainLoaderTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Binary\Loader;
+
+use Liip\ImagineBundle\Binary\Loader\ChainLoader;
+use Liip\ImagineBundle\Binary\Loader\FileSystemLoader;
+use Liip\ImagineBundle\Binary\Locator\FileSystemLocator;
+use Liip\ImagineBundle\Model\FileBinary;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
+use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
+
+/**
+ * @covers \Liip\ImagineBundle\Binary\Loader\ChainLoader
+ */
+class ChainLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstruction()
+    {
+        $this->getChainLoader();
+    }
+
+    public function testImplementsLoaderInterface()
+    {
+        $this->assertInstanceOf('\Liip\ImagineBundle\Binary\Loader\LoaderInterface', $this->getChainLoader());
+    }
+
+    /**
+     * @return array[]
+     */
+    public static function provideLoadCases()
+    {
+        $file = pathinfo(__FILE__, PATHINFO_BASENAME);
+
+        return array(
+            array(
+                __DIR__,
+                $file,
+            ),
+            array(
+                __DIR__.'/',
+                $file,
+            ),
+            array(
+                __DIR__, '/'.
+                $file,
+            ),
+            array(
+                __DIR__.'/../../Binary/Loader',
+                '/'.$file,
+            ),
+            array(
+                realpath(__DIR__.'/..'),
+                'Loader/'.$file,
+            ),
+            array(
+                __DIR__.'/../',
+                '/Loader/../../Binary/Loader/'.$file,
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideLoadCases
+     *
+     * @param string $root
+     * @param string $path
+     */
+    public function testLoad($root, $path)
+    {
+        $this->assertValidLoaderFindReturn($this->getChainLoader(array($root))->find($path));
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideInvalidPathsData()
+    {
+        return array(
+            array('../Loader/../../Binary/Loader/../../../Resources/config/routing.yaml'),
+            array('../../Binary/'),
+        );
+    }
+
+    /**
+     * @dataProvider provideInvalidPathsData
+     *
+     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
+     * @expectedExceptionMessage Source image not resolvable
+     */
+    public function testThrowsIfFileDoesNotExist($path)
+    {
+        $this->getChainLoader()->find($path);
+    }
+
+    /**
+     * @return FileSystemLocator
+     */
+    private function getFileSystemLocator()
+    {
+        return new FileSystemLocator();
+    }
+
+    /**
+     * @param string[] $paths
+     *
+     * @return ChainLoader
+     */
+    private function getChainLoader(array $paths = array())
+    {
+        return new ChainLoader(array(
+            'foo' => new FileSystemLoader(
+                MimeTypeGuesser::getInstance(),
+                ExtensionGuesser::getInstance(),
+                $paths ?: array(__DIR__),
+                $this->getFileSystemLocator()
+            ),
+        ));
+    }
+
+    /**
+     * @param FileBinary|mixed $return
+     * @param string|null      $message
+     */
+    private function assertValidLoaderFindReturn($return, $message = null)
+    {
+        $this->assertInstanceOf('\Liip\ImagineBundle\Model\FileBinary', $return, $message);
+        $this->assertStringStartsWith('text/', $return->getMimeType(), $message);
+    }
+}

--- a/Tests/DependencyInjection/Factory/Loader/ChainLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/ChainLoaderFactoryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory\Loader;
+
+use Liip\ImagineBundle\DependencyInjection\Factory\Loader\ChainLoaderFactory;
+use Liip\ImagineBundle\Tests\DependencyInjection\Factory\FactoryTestCase;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\ChainLoaderFactory
+ */
+class ChainLoaderFactoryTest extends FactoryTestCase
+{
+    public function testCouldBeConstructedWithoutAnyArguments()
+    {
+        new ChainLoaderFactory();
+    }
+
+    public function testImplementsLoaderFactoryInterface()
+    {
+        $this->assertInstanceOf('\Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface', new ChainLoaderFactory());
+    }
+
+    public function testReturnsExpectedName()
+    {
+        $loader = new ChainLoaderFactory();
+
+        $this->assertEquals('chain', $loader->getName());
+    }
+
+    public function testCreateLoaderDefinition()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new ChainLoaderFactory();
+        $loader->create($container, 'the_loader_name', array(
+            'loaders' => array(
+                'foo',
+                'bar',
+                'baz',
+            ),
+        ));
+
+        $this->assertTrue($container->hasDefinition('liip_imagine.binary.loader.the_loader_name'));
+
+        $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.the_loader_name');
+
+        $this->assertInstanceOfChildDefinition($loaderDefinition);
+        $this->assertEquals('liip_imagine.binary.loader.prototype.chain', $loaderDefinition->getParent());
+
+        foreach ($loaderDefinition->getArgument(0) as $reference) {
+            $this->assertInstanceOf('\Symfony\Component\DependencyInjection\Reference', $reference);
+        }
+    }
+
+    public function testProcessOptionsOnAddConfiguration()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('chain', 'array');
+
+        $loader = new ChainLoaderFactory();
+        $loader->addConfiguration($rootNode);
+
+        $config = $this->processConfigTree($treeBuilder, array(
+            'chain' => array(
+                'loaders' => array(
+                    'foo',
+                    'bar',
+                ),
+            ),
+        ));
+
+        $this->assertArrayHasKey('loaders', $config);
+        $this->assertSame(array('foo', 'bar'), $config['loaders']);
+    }
+
+    /**
+     * @param TreeBuilder $treeBuilder
+     * @param array       $configs
+     *
+     * @return array
+     */
+    private function processConfigTree(TreeBuilder $treeBuilder, array $configs)
+    {
+        $processor = new Processor();
+
+        return $processor->process($treeBuilder->buildTree(), $configs);
+    }
+}

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory<extended>
+ * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory
  */
 class FileSystemLoaderFactoryTest extends FactoryTestCase
 {

--- a/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * @requires PHP 5.4
  *
- * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory<extended>
+ * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory
  */
 class FlysystemLoaderFactoryTest extends \Phpunit_Framework_TestCase
 {

--- a/Tests/Functional/Binary/Loader/ChainLoaderTest.php
+++ b/Tests/Functional/Binary/Loader/ChainLoaderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Functional\Binary\Loader;
+
+use Liip\ImagineBundle\Binary\Loader\ChainLoader;
+use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
+
+/**
+ * @covers \Liip\ImagineBundle\Binary\Loader\ChainLoader
+ */
+class ChainLoaderTest extends AbstractWebTestCase
+{
+    /**
+     * @param string $name
+     *
+     * @return ChainLoader|object
+     */
+    private function getLoader($name)
+    {
+        return $this->getService(sprintf('liip_imagine.binary.loader.%s', $name));
+    }
+
+    public function testFind()
+    {
+        static::createClient();
+
+        $loader = $this->getLoader('baz');
+
+        foreach (array('images/cats.jpeg', 'images/cats2.jpeg', 'file.ext', 'bar-bundle-file.ext', 'foo-bundle-file.ext') as $file) {
+            $this->assertNotNull($loader->find($file));
+        }
+    }
+}

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -37,6 +37,14 @@ liip_imagine:
             filesystem:
                 data_root: "%kernel.root_dir%/../../Fixtures/FileSystemLocator/root-02"
 
+        baz:
+            chain:
+                loaders:
+                    - foo
+                    - bar
+                    - default
+                    - bundles_all
+
         bundles_all:
             filesystem:
                 data_root: ~

--- a/Tests/LiipImagineBundleTest.php
+++ b/Tests/LiipImagineBundleTest.php
@@ -224,6 +224,25 @@ class LiipImagineBundleTest extends AbstractTest
         $bundle->build($containerMock);
     }
 
+    public function testAddChainLoaderFactoryOnBuild()
+    {
+        $extensionMock = $this->createLiipImagineExtensionMock();
+        $extensionMock
+            ->expects($this->at(6))
+            ->method('addLoaderFactory')
+            ->with($this->isInstanceOf('Liip\ImagineBundle\DependencyInjection\Factory\Loader\ChainLoaderFactory'));
+
+        $containerMock = $this->createContainerBuilderMock();
+        $containerMock
+            ->expects($this->atLeastOnce())
+            ->method('getExtension')
+            ->with('liip_imagine')
+            ->will($this->returnValue($extensionMock));
+
+        $bundle = new LiipImagineBundle();
+        $bundle->build($containerMock);
+    }
+
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|ContainerBuilder
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #948
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Chain data loader implementation. This allows one to define one "filter set" that searches multiple loader configurations (for example, this allows you to check both a Gaufrette stream loader and a file system loader simultaneously). 

Here is an example configuration for the loader:

```yaml
liip_imagine:

    loaders:

        foo:
            filesystem:
                # setup this loader here

        bar:
            flysystem:
                # setup this loader here

        baz:
            chain:
                # name the loaders to chain
                loaders: [foo, bar]

    filter_sets:

        my_custom_filter_set:
            data_loader: baz
            filters:
                # define your filters here
```

This implementation simply loops through the available loaders and selects the first valid result, so if the file exists in multiple loaders, the first defined in your configuration will be selected. For example, if `file.ext` exists in both the `foo` and `bar` loader, the one found via the `foo` loader will be returned because it is defined first for `baz.chain.loaders`.