### PR TITLE
[Composer] Allow imagine-library version 0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 matrix:
   include:
     - php: 5.3
-      env: COMPOSER_FLAGS="--prefer-lowest"
+      env: COMPOSER_FLAGS="--prefer-lowest" IMAGINE_VERSION=^0.6.3
       dist: precise
     - php: 5.6
       env: SYMFONY_VERSION=2.3.x-dev
@@ -53,6 +53,7 @@ before_install:
   - if [ "${TRAVIS_PHP_VERSION}" == "5.3" ]; then composer remove --no-update --dev satooshi/php-coveralls; fi;
   - if [ "${SYMFONY_VERSION:0:3}" == "2.3" ]; then composer remove --no-update --dev friendsofphp/php-cs-fixer; fi;
   - if [ "${SYMFONY_VERSION:-x}" != "x" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - if [ "${IMAGINE_VERSION:-x}" != "x" ]; then composer require "imagine/Imagine:${IMAGINE_VERSION}" --no-update; fi;
   - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION:0:3}" != "5.3" ]; then composer require --no-update --dev league/flysystem:~1.0; fi;
   - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION:0:1}" != "7" ]; then yes "" | pecl -q install -f mongo; composer require --no-update --dev doctrine/mongodb-odm:~1.0; fi;
   - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ] && [ "${TRAVIS_PHP_VERSION:0:1}" == "7" ]; then yes "" | pecl -q install -f mongodb; travis_retry composer require --dev alcaeus/mongo-php-adapter:~1.0; composer require --no-update --dev doctrine/mongodb-odm:~1.0; fi

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^5.3.9|^7.0",
-        "imagine/Imagine": "^0.6.3,<0.7",
+        "imagine/Imagine": "^0.6.3|^0.7.0,<0.8",
         "symfony/asset": "~2.3|~3.0",
         "symfony/filesystem": "~2.3|~3.0",
         "symfony/finder": "~2.3|~3.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #935
| License | MIT
| Doc PR | <!--highly recommended for new features-->

This pull request adds the ability to utalize version `0.7.0` of the Imagine Library, and raises our upper limit constraint to `0.8.0`. By default, this will actually cause most people to upgrade from `0.6.0` to `0.7.0` of Imagine Library, but it allows those who explicitly constrain their project to Imagine Library `0.6.0` to remain on that version, as well. It provides a cleaner, alternate approach to #935 with passing tests. Fixes an important issue introduced by `3.4.3` of the `imagick` extension; see avalanche123/Imagine#547.