### PR TITLE
[enqueue] Upgrade to enqueue v5. Use its features

### DIFF
--- a/Async/Commands.php
+++ b/Async/Commands.php
@@ -11,10 +11,10 @@
 
 namespace Liip\ImagineBundle\Async;
 
-class Topics
+class Commands
 {
     /**
      * @var string
      */
-    const CACHE_RESOLVED = 'liip_imagine_cache_resolved';
+    const RESOLVE_CACHE = 'liip_imagine_resolve_cache';
 }

--- a/Async/ResolveCacheProcessor.php
+++ b/Async/ResolveCacheProcessor.php
@@ -11,18 +11,19 @@
 
 namespace Liip\ImagineBundle\Async;
 
+use Enqueue\Client\CommandSubscriberInterface;
 use Enqueue\Client\ProducerInterface;
-use Enqueue\Client\TopicSubscriberInterface;
 use Enqueue\Consumption\QueueSubscriberInterface;
 use Enqueue\Consumption\Result;
 use Enqueue\Psr\PsrContext;
 use Enqueue\Psr\PsrMessage;
 use Enqueue\Psr\PsrProcessor;
+use Enqueue\Util\JSON;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Imagine\Data\DataManager;
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
 
-class ResolveCacheProcessor implements PsrProcessor, TopicSubscriberInterface, QueueSubscriberInterface
+class ResolveCacheProcessor implements PsrProcessor, CommandSubscriberInterface, QueueSubscriberInterface
 {
     /**
      * @var CacheManager
@@ -69,42 +70,52 @@ class ResolveCacheProcessor implements PsrProcessor, TopicSubscriberInterface, Q
     {
         try {
             $message = ResolveCache::jsonDeserialize($psrMessage->getBody());
+
+            $filters = $message->getFilters() ?: array_keys($this->filterManager->getFilterConfiguration()->all());
+            $path = $message->getPath();
+            $results = [];
+            foreach ($filters as $filter) {
+                if ($this->cacheManager->isStored($path, $filter) && $message->isForce()) {
+                    $this->cacheManager->remove($path, $filter);
+                }
+
+                if (false == $this->cacheManager->isStored($path, $filter)) {
+                    $binary = $this->dataManager->find($filter, $path);
+                    $this->cacheManager->store(
+                        $this->filterManager->applyFilter($binary, $filter),
+                        $path,
+                        $filter
+                    );
+                }
+
+                $results[$filter] = $this->cacheManager->resolve($path, $filter);
+            }
+
+            $this->producer->sendEvent(Topics::CACHE_RESOLVED, new CacheResolved($path, $results));
+
+            return Result::reply($psrContext->createMessage(JSON::encode([
+                'status' => true,
+                'results' => $results,
+            ])));
+
         } catch (\Exception $e) {
-            return Result::reject($e->getMessage());
+            return Result::reply($psrContext->createMessage(JSON::encode([
+                'status' => false,
+                'exception' => $e->getMessage(),
+            ])), Result::REJECT, $e->getMessage());
         }
-
-        $filters = $message->getFilters() ?: array_keys($this->filterManager->getFilterConfiguration()->all());
-        $path = $message->getPath();
-        $results = [];
-        foreach ($filters as $filter) {
-            if ($this->cacheManager->isStored($path, $filter) && $message->isForce()) {
-                $this->cacheManager->remove($path, $filter);
-            }
-
-            if (false == $this->cacheManager->isStored($path, $filter)) {
-                $binary = $this->dataManager->find($filter, $path);
-                $this->cacheManager->store(
-                    $this->filterManager->applyFilter($binary, $filter),
-                    $path,
-                    $filter
-                );
-            }
-
-            $results[$filter] = $this->cacheManager->resolve($path, $filter);
-        }
-
-        $this->producer->send(Topics::CACHE_RESOLVED, new CacheResolved($path, $results));
-
-        return self::ACK;
     }
 
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedTopics(): array
+    public static function getSubscribedCommand(): array
     {
         return [
-            Topics::RESOLVE_CACHE => ['queueName' => Topics::RESOLVE_CACHE,  'queueNameHardcoded' => true],
+            'processorName' => Commands::RESOLVE_CACHE,
+            'queueName' => Commands::RESOLVE_CACHE,
+            'queueNameHardcoded' => true,
+            'exclusive' => true,
         ];
     }
 
@@ -113,6 +124,6 @@ class ResolveCacheProcessor implements PsrProcessor, TopicSubscriberInterface, Q
      */
     public static function getSubscribedQueues(): array
     {
-        return [Topics::RESOLVE_CACHE];
+        return [Commands::RESOLVE_CACHE];
     }
 }

--- a/LiipImagineBundle.php
+++ b/LiipImagineBundle.php
@@ -45,7 +45,6 @@ class LiipImagineBundle extends Bundle
 
         if (class_exists(AddTopicMetaPass::class)) {
             $container->addCompilerPass(AddTopicMetaPass::create()
-                ->add(Topics::RESOLVE_CACHE, 'Send message to this topic when you want to resolve image\'s cache.')
                 ->add(Topics::CACHE_RESOLVED, 'The topic contains messages about resolved image\'s caches')
             );
         }

--- a/Resources/doc/resolve-cache-images-in-background.rst
+++ b/Resources/doc/resolve-cache-images-in-background.rst
@@ -32,9 +32,7 @@ It is based on `filesystem transport`_.
 
     enqueue:
         transport:
-            default: fs
-            fs:
-                store_dir: '%kernel.root_dir%/../var/queues'
+            default: 'file://%kernel.root_dir%/../var/queues'
         client: ~
 
 Step 2: Configure LiipImagineBundle
@@ -73,7 +71,7 @@ You can force cache to be recreated and in this case the cached image is removed
     <?php
 
     use Enqueue\Client\ProducerInterface;
-    use Liip\ImagineBundle\Async\Topics;
+    use Liip\ImagineBundle\Async\Commands;
     use Liip\ImagineBundle\Async\ResolveCache;
     use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -84,13 +82,18 @@ You can force cache to be recreated and in this case the cached image is removed
     $producer = $container->get('enqueue.producer');
 
     // resolve all caches
-    $producer->send(Topics::RESOLVE_CACHE, new ResolveCache('the/path/img.png'));
+    $producer->sendCommand(Commands::RESOLVE_CACHE, new ResolveCache('the/path/img.png'));
 
     // resolve specific cache
-    $producer->send(Topics::RESOLVE_CACHE, new ResolveCache('the/path/img.png', array('fooFilter')));
+    $producer->sendCommand(Commands::RESOLVE_CACHE, new ResolveCache('the/path/img.png', array('fooFilter')));
 
     // force resolve (removes the cache if exists)
-    $producer->send(Topics::RESOLVE_CACHE, new ResolveCache('the/path/img.png', null, true));
+    $producer->sendCommand(Commands::RESOLVE_CACHE, new ResolveCache('the/path/img.png', null, true));
+
+    // send command and wait for reply
+    $reply = $producer->sendCommand(Commands::RESOLVE_CACHE, new ResolveCache('the/path/img.png', null, true), true);
+
+    $replyMessage = $reply->receive(20000); // wait for 20 sec
 
 
 .. _`enqueue library`: https://github.com/php-enqueue/enqueue-dev

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -51,6 +51,18 @@
       TRAVIS_PHP_VERSION=7.0.0     # the installed PHP version
 
     ```
+    
+  - __[Enqueue]__ You have to replace the given code with a new one If use enqueue to resolve images in background.
+
+    ```php
+    <?php
+
+      // 1.0
+      $producer->send(\Liip\ImagineBundle\Async\Topics::RESOLVE_CACHE /* ... */);
+
+      // 2.0
+      $producer->sendCommand(\Liip\ImagineBundle\Async\Commands::RESOLVE_CACHE /* ... */);
+    ```
 
 ## 1.8.0
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -52,7 +52,7 @@
 
     ```
     
-  - __[Enqueue]__ You have to replace the given code with a new one If use enqueue to resolve images in background.
+  - __[Enqueue]__ Enqueue's producer send() method has been deprecated and will be removed, use sendCommand() instead. When interacting with the producer to resolve images in the background you must make the following changes to your code:
 
     ```php
     <?php

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "aws/aws-sdk-php": "~2.4",
         "doctrine/cache": "~1.1",
         "doctrine/orm": "~2.3",
-        "enqueue/enqueue-bundle": "^0.3.7",
+        "enqueue/enqueue-bundle": "^0.5",
         "friendsofphp/php-cs-fixer": "~1.0",
         "league/flysystem": "~1.0",
         "phpunit/phpunit": "~5.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes if you are migration from 1.0
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | 
| License | MIT
| Doc PR | docs are updated in this same PR


* Send a command (one-to-one) instead of an event as it was before.
* Send a reply to sender (optional)
* Make command exclusive. Means it is the only one processor on the given
queue. The message could be sent without any enqueue specific properties
and will still work.
