### PR TITLE
[Data Loader] Pass root paths to file system locator constructor (instead of loader)

### DIFF
--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -38,55 +38,47 @@ class FileSystemLoader implements LoaderInterface
     /**
      * @param MimeTypeGuesserInterface  $mimeGuesser
      * @param ExtensionGuesserInterface $extensionGuesser
-     * @param string[]                  $locatorOrDataRoots
-     * @param LocatorInterface          $locator
+     * @param string[]|LocatorInterface $locator
      */
-    public function __construct(
-        MimeTypeGuesserInterface $mimeGuesser,
-        ExtensionGuesserInterface $extensionGuesser,
-        $locatorOrDataRoots
-        /* LocatorInterface $locator */
-    ) {
+    public function __construct(MimeTypeGuesserInterface $mimeGuesser, ExtensionGuesserInterface $extensionGuesser, $locator)
+    {
         $this->mimeTypeGuesser = $mimeGuesser;
         $this->extensionGuesser = $extensionGuesser;
 
-        if (is_array($locatorOrDataRoots) || is_string($locatorOrDataRoots)) { // pre-1.9.0 behaviour
-            if (count((array) $locatorOrDataRoots) === 0) {
+        if ($locator instanceof LocatorInterface) { // post-1.9.0 behavior
+            $this->locator = $locator;
+        } elseif (is_array($locator) || is_string($locator)) { // pre-1.9.0 behaviour
+            if (count((array) $locator) === 0) {
                 throw new InvalidArgumentException('One or more data root paths must be specified.');
             }
 
             if (func_num_args() >= 4) {
                 if (func_get_arg(3) instanceof LocatorInterface) {
-                    @trigger_error(
-                        sprintf(
-                            'Passing a LocatorInterface as fourth parameter to %s() is deprecated. It needs to be the third parameter. ' .
-                            'The previous third parameter (data roots) is removed and the data roots must now be passed as a constructor argument ' .
-                            'to the LocatorInterface passed to this method.',
-                            __METHOD__
-                        ),
-                        E_USER_DEPRECATED
-                    );
+                    @trigger_error(sprintf(
+                        'Passing a LocatorInterface as fourth parameter to %s() is deprecated. It needs to be the '.
+                        'third parameter. The previous third parameter (data roots) is removed and the data roots must '.
+                        'now be passed as a constructor argument to the LocatorInterface passed to this method.', __METHOD__
+                    ), E_USER_DEPRECATED);
 
                     $this->locator = func_get_arg(3);
-                    $this->locator->setOptions(array('roots' => (array) $locatorOrDataRoots));
+                    $this->locator->setOptions(array('roots' => (array) $locator));
                 } else {
-                    throw new \InvalidArgumentException(sprintf('Unknown call to %s(). Please check the method signature.', __METHOD__));
+                    throw new \InvalidArgumentException(sprintf(
+                        'Unknown call to %s(). Please check the method signature.', __METHOD__
+                    ));
                 }
             } else {
-                @trigger_error(
-                    sprintf(
-                        'Method %s() will expect the third parameter to be a LocatorInterface in version 2.0. Defining dataroots instead is deprecated since version 1.9.0',
-                        __METHOD__
-                    ),
-                    E_USER_DEPRECATED
-                );
+                @trigger_error(sprintf(
+                    'Method %s() will expect the third parameter to be a LocatorInterface in version 2.0. Defining '.
+                    'data roots instead is deprecated since version 1.9.0', __METHOD__
+                ), E_USER_DEPRECATED);
 
-                $this->locator = new FileSystemLocator((array) $locatorOrDataRoots);
+                $this->locator = new FileSystemLocator((array) $locator);
             }
-        } elseif ($locatorOrDataRoots instanceof LocatorInterface) {
-            $this->locator = $locatorOrDataRoots;
-        } else {
-            throw new \InvalidArgumentException(sprintf('Method %s() expects a LocatorInterface for the third argument.', __METHOD__));
+        } else { // invalid behavior
+            throw new \InvalidArgumentException(sprintf(
+                'Method %s() expects a LocatorInterface for the third argument.', __METHOD__
+            ));
         }
     }
 

--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -38,30 +38,56 @@ class FileSystemLoader implements LoaderInterface
     /**
      * @param MimeTypeGuesserInterface  $mimeGuesser
      * @param ExtensionGuesserInterface $extensionGuesser
-     * @param string[]                  $dataRoots
+     * @param string[]                  $locatorOrDataRoots
      * @param LocatorInterface          $locator
      */
     public function __construct(
         MimeTypeGuesserInterface $mimeGuesser,
         ExtensionGuesserInterface $extensionGuesser,
-        $dataRoots
+        $locatorOrDataRoots
         /* LocatorInterface $locator */
     ) {
         $this->mimeTypeGuesser = $mimeGuesser;
         $this->extensionGuesser = $extensionGuesser;
 
-        if (count($dataRoots) === 0) {
-            throw new InvalidArgumentException('One or more data root paths must be specified.');
-        }
+        if (is_array($locatorOrDataRoots) || is_string($locatorOrDataRoots)) { // pre-1.9.0 behaviour
+            if (count((array) $locatorOrDataRoots) === 0) {
+                throw new InvalidArgumentException('One or more data root paths must be specified.');
+            }
 
-        if (func_num_args() >= 4 && false === ($this->locator = func_get_arg(3)) instanceof LocatorInterface) {
-            throw new \InvalidArgumentException(sprintf('Method %s() expects a LocatorInterface for the forth argument.', __METHOD__));
-        } elseif (func_num_args() < 4) {
-            @trigger_error(sprintf('Method %s() will have a forth `LocatorInterface $locator` argument in version 2.0. Not defining it is deprecated since version 1.7.2', __METHOD__), E_USER_DEPRECATED);
-            $this->locator = new FileSystemLocator();
-        }
+            if (func_num_args() >= 4) {
+                if (func_get_arg(3) instanceof LocatorInterface) {
+                    @trigger_error(
+                        sprintf(
+                            'Passing a LocatorInterface as fourth parameter to %s() is deprecated. It needs to be the third parameter. ' .
+                            'The previous third parameter (data roots) is removed and the data roots must now be passed as a constructor argument ' .
+                            'to the LocatorInterface passed to this method.',
+                            __METHOD__
+                        ),
+                        E_USER_DEPRECATED
+                    );
 
-        $this->locator->setOptions(array('roots' => (array) $dataRoots));
+                    $this->locator = func_get_arg(3);
+                    $this->locator->setOptions(array('roots' => (array) $locatorOrDataRoots));
+                } else {
+                    throw new \InvalidArgumentException(sprintf('Unknown call to %s(). Please check the method signature.', __METHOD__));
+                }
+            } else {
+                @trigger_error(
+                    sprintf(
+                        'Method %s() will expect the third parameter to be a LocatorInterface in version 2.0. Defining dataroots instead is deprecated since version 1.9.0',
+                        __METHOD__
+                    ),
+                    E_USER_DEPRECATED
+                );
+
+                $this->locator = new FileSystemLocator((array) $locatorOrDataRoots);
+            }
+        } elseif ($locatorOrDataRoots instanceof LocatorInterface) {
+            $this->locator = $locatorOrDataRoots;
+        } else {
+            throw new \InvalidArgumentException(sprintf('Method %s() expects a LocatorInterface for the third argument.', __METHOD__));
+        }
     }
 
     /**

--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -36,9 +36,13 @@ class FileSystemLoader implements LoaderInterface
     protected $locator;
 
     /**
+     * This method will continue to support two prior, deprecated signitures for the duration of the 1.x
+     * release. The currently documented signiture will be the only valid usage once 2.0 is release. You
+     * can reference PR-963 {@see https://github.com/liip/LiipImagineBundle/pull/963} for more information.
+     *
      * @param MimeTypeGuesserInterface  $mimeGuesser
      * @param ExtensionGuesserInterface $extensionGuesser
-     * @param string[]|LocatorInterface $locator
+     * @param LocatorInterface          $locator
      */
     public function __construct(MimeTypeGuesserInterface $mimeGuesser, ExtensionGuesserInterface $extensionGuesser, $locator)
     {

--- a/Binary/Locator/FileSystemLocator.php
+++ b/Binary/Locator/FileSystemLocator.php
@@ -23,12 +23,17 @@ class FileSystemLocator implements LocatorInterface
      */
     private $roots = array();
 
-    public function __construct(array $dataRoots = array())
+    /**
+     * @param string[] $roots
+     */
+    public function __construct(array $roots = array())
     {
-        $this->roots = array_map(array($this, 'sanitizeRootPath'), (array) $dataRoots);
+        $this->roots = array_map(array($this, 'sanitizeRootPath'), $roots);
     }
 
     /**
+     * @deprecated Since version 0.9.0, use __construct(array $roots) instead
+     *
      * @param array[] $options
      */
     public function setOptions(array $options = array())
@@ -43,7 +48,7 @@ class FileSystemLocator implements LocatorInterface
         }
 
         @trigger_error(
-            sprintf('%s() is deprecated. Pass the dataroots to the constuctor instead.', __METHOD__),
+            sprintf('%s() is deprecated. Pass the data roots to the constructor instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 

--- a/Binary/Locator/FileSystemLocator.php
+++ b/Binary/Locator/FileSystemLocator.php
@@ -23,6 +23,11 @@ class FileSystemLocator implements LocatorInterface
      */
     private $roots = array();
 
+    public function __construct(array $dataRoots = array())
+    {
+        $this->roots = array_map(array($this, 'sanitizeRootPath'), (array) $dataRoots);
+    }
+
     /**
      * @param array[] $options
      */
@@ -36,6 +41,11 @@ class FileSystemLocator implements LocatorInterface
         } catch (ExceptionInterface $e) {
             throw new InvalidArgumentException(sprintf('Invalid options provided to %s()', __METHOD__), null, $e);
         }
+
+        @trigger_error(
+            sprintf('%s() is deprecated. Pass the dataroots to the constuctor instead.', __METHOD__),
+            E_USER_DEPRECATED
+        );
 
         $this->roots = array_map(array($this, 'sanitizeRootPath'), (array) $options['roots']);
     }

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -257,10 +257,12 @@
         <!-- Data loader locators -->
 
         <service id="liip_imagine.binary.locator.filesystem" class="%liip_imagine.binary.locator.filesystem.class%" public="false">
+            <argument><!-- will be injected by FileSystemLoaderFactory --></argument>
             <tag name="liip_imagine.binary.locator" shared="false" />
         </service>
 
         <service id="liip_imagine.binary.locator.filesystem_insecure" class="%liip_imagine.binary.locator.filesystem_insecure.class%" public="false">
+            <argument><!-- will be injected by FileSystemLoaderFactory --></argument>
             <tag name="liip_imagine.binary.locator" shared="false" />
         </service>
 

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -128,7 +128,7 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp {Method .+ expects a LocatorInterface for the forth argument}
+     * @expectedExceptionMessageRegExp {Unknown call to [^(]+__construct\(\)\. Please check the method signature\.}
      */
     public function testThrowsIfConstructionArgumentsInvalid()
     {
@@ -146,7 +146,7 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsIfZeroCountRootPathArray()
     {
-        $this->getFileSystemLoader(array());
+        new FileSystemLoader(MimeTypeGuesser::getInstance(), ExtensionGuesser::getInstance(), array());
     }
 
     /**
@@ -206,9 +206,9 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @return FileSystemLocator
      */
-    private function getFileSystemLocator()
+    private function getFileSystemLocator($dataRoots)
     {
-        return new FileSystemLocator();
+        return new FileSystemLocator((array) $dataRoots);
     }
 
     /**
@@ -230,8 +230,7 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
         return new FileSystemLoader(
             MimeTypeGuesser::getInstance(),
             ExtensionGuesser::getInstance(),
-            null !== $root ? $root : $this->getDefaultDataRoots(),
-            null !== $locator ? $locator : $this->getFileSystemLocator()
+            null !== $locator ? $locator : $this->getFileSystemLocator(null !== $root ? $root : $this->getDefaultDataRoots())
         );
     }
 

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -204,14 +204,6 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return FileSystemLocator
-     */
-    private function getFileSystemLocator($dataRoots)
-    {
-        return new FileSystemLocator((array) $dataRoots);
-    }
-
-    /**
      * @return string[]
      */
     private function getDefaultDataRoots()
@@ -232,6 +224,16 @@ class FileSystemLoaderTest extends \PHPUnit_Framework_TestCase
             ExtensionGuesser::getInstance(),
             null !== $locator ? $locator : $this->getFileSystemLocator(null !== $root ? $root : $this->getDefaultDataRoots())
         );
+    }
+
+    /**
+     * @param string|string[] $roots
+     *
+     * @return FileSystemLocator
+     */
+    private function getFileSystemLocator($roots)
+    {
+        return new FileSystemLocator((array) $roots);
     }
 
     /**

--- a/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
@@ -17,11 +17,11 @@ use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
 abstract class AbstractFileSystemLocatorTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @param string[]|string $paths
+     * @param string[]|string $roots
      *
      * @return LocatorInterface
      */
-    abstract protected function getFileSystemLocator($paths);
+    abstract protected function getFileSystemLocator($roots);
 
     public function testImplementsLocatorInterface()
     {

--- a/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
@@ -19,14 +19,6 @@ use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
  */
 class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
 {
-    /**
-     * @return LocatorInterface
-     */
-    protected function getFileSystemLocator($paths)
-    {
-        return new FileSystemInsecureLocator((array) $paths);
-    }
-
     public function testLoadsOnSymbolicLinks()
     {
         $loader = $this->getFileSystemLocator($root = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02'));
@@ -86,5 +78,15 @@ class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
         return array_map(function ($params) use ($prepend) {
             return array(array($prepend[mt_rand(0, count($prepend) - 1)], $params[0]), $params[1]);
         }, static::provideLoadCases());
+    }
+
+    /**
+     * @param string|string[] $roots
+     *
+     * @return LocatorInterface
+     */
+    protected function getFileSystemLocator($roots)
+    {
+        return new FileSystemInsecureLocator((array) $roots);
     }
 }

--- a/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
@@ -24,10 +24,7 @@ class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
      */
     protected function getFileSystemLocator($paths)
     {
-        $locator = new FileSystemInsecureLocator();
-        $locator->setOptions(array('roots' => (array) $paths));
-
-        return $locator;
+        return new FileSystemInsecureLocator((array) $paths);
     }
 
     public function testLoadsOnSymbolicLinks()

--- a/Tests/Binary/Locator/FileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemLocatorTest.php
@@ -24,10 +24,7 @@ class FileSystemLocatorTest extends AbstractFileSystemLocatorTest
      */
     protected function getFileSystemLocator($paths)
     {
-        $locator = new FileSystemLocator();
-        $locator->setOptions(array('roots' => (array) $paths));
-
-        return $locator;
+        return new FileSystemLocator((array) $paths);
     }
 
     /**

--- a/Tests/Binary/Locator/FileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemLocatorTest.php
@@ -20,14 +20,6 @@ use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
 class FileSystemLocatorTest extends AbstractFileSystemLocatorTest
 {
     /**
-     * @return LocatorInterface
-     */
-    protected function getFileSystemLocator($paths)
-    {
-        return new FileSystemLocator((array) $paths);
-    }
-
-    /**
      * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
      * @expectedExceptionMessage Source image invalid
      */
@@ -81,5 +73,15 @@ class FileSystemLocatorTest extends AbstractFileSystemLocatorTest
         return array_map(function ($params) use ($prepend) {
             return array(array($prepend[mt_rand(0, count($prepend) - 1)], $params[0]), $params[1]);
         }, static::provideLoadCases());
+    }
+
+    /**
+     * @param string|string[] $roots
+     *
+     * @return LocatorInterface
+     */
+    protected function getFileSystemLocator($roots)
+    {
+        return new FileSystemLocator((array) $roots);
     }
 }

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -63,7 +63,8 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $this->assertInstanceOfChildDefinition($loaderDefinition);
         $this->assertEquals('liip_imagine.binary.loader.prototype.filesystem', $loaderDefinition->getParent());
 
-        $this->assertEquals(array('theDataRoot'), $loaderDefinition->getArgument(2));
+        $locatorReference = $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2);
+        $this->assertEquals(array('theDataRoot'), $container->getDefinition((string) $locatorReference)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadata()
@@ -98,7 +99,8 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
         );
 
-        $this->assertEquals($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2));
+        $locatorReference = $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2);
+        $this->assertEquals($expected, $container->getDefinition((string) $locatorReference)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadataAndBlacklisting()
@@ -134,7 +136,8 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
         );
 
-        $this->assertEquals($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2));
+        $locatorReference = $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2);
+        $this->assertEquals($expected, $container->getDefinition((string) $locatorReference)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadataAndWhitelisting()
@@ -170,7 +173,8 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipFooBundle' => $fooBundleRootPath.'/Resources/public',
         );
 
-        $this->assertEquals($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2));
+        $locatorReference = $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2);
+        $this->assertEquals($expected, $container->getDefinition((string) $locatorReference)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingNamedObj()
@@ -201,7 +205,8 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
         );
 
-        $this->assertEquals($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2));
+        $locatorReference = $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2);
+        $this->assertEquals($expected, $container->getDefinition((string) $locatorReference)->getArgument(0));
     }
 
     /**

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,17 @@
 # Upgrade
 
+## 1.8.1
+
+ - __[Data Loader]__ The arguments for the `FileSystemLoader` class constructor have changed. Instead of passing data
+ roots as third parameter and optionally a `LocatorInterace` as fourth parameter, a `LocatorInterface`
+ should now be passed as third parameter. The data roots no longer need to be passed to the `FileSystemLoader` class
+ constructor but need to be passed to `LocatorInterface` class constructor instead.
+ Passing data roots as a third parameter to the `FileSystemLoader` class constructor is still allowed, but deprecated
+ and will be removed in `2.0`.
+ Passing both data roots as well as a `LocatorInterface` instance to the `FileSystemLoader` class constructor is still
+ supported but deprecated and will be removed in `2.0` as well. Note that when you this, any data root that was already
+ set in the `LocatorInteface` will be overwritten by de data roots passed to the `FileSystemLoader`.
+ 
 ## 1.8.0
 
  - __[Routing]__ The `Resources/config/routing.xml` file has been deprecated and will be removed in `2.0`. Use the new

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,17 +1,12 @@
 # Upgrade
 
-## 1.8.1
+## 1.9.0
 
- - __[Data Loader]__ The arguments for the `FileSystemLoader` class constructor have changed. Instead of passing data
- roots as third parameter and optionally a `LocatorInterace` as fourth parameter, a `LocatorInterface`
- should now be passed as third parameter. The data roots no longer need to be passed to the `FileSystemLoader` class
- constructor but need to be passed to `LocatorInterface` class constructor instead.
- Passing data roots as a third parameter to the `FileSystemLoader` class constructor is still allowed, but deprecated
- and will be removed in `2.0`.
- Passing both data roots as well as a `LocatorInterface` instance to the `FileSystemLoader` class constructor is still
- supported but deprecated and will be removed in `2.0` as well. Note that when you this, any data root that was already
- set in the `LocatorInteface` will be overwritten by de data roots passed to the `FileSystemLoader`.
- 
+ - __[Data Loader]__ The arguments for the `FileSystemLoader` class constructor have changed. Passing an array of roots
+ as the third parameter and an (optional) `LocatorInterace` as the fourth parameter is deprecated. A `LocatorInterface`
+ should now be passed as third parameter, and the array of data roots to the `LocatorInterface::__construct()` method
+ directly. All prior signatures will continue to work until `2.0` is release.
+
 ## 1.8.0
 
  - __[Routing]__ The `Resources/config/routing.xml` file has been deprecated and will be removed in `2.0`. Use the new


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Tests pass? | yes
| Fixed tickets | #930
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Continuation of #937 to pass roots directly to `LocatorInterface` instead of to `FileSystemLoader`, in preparation for breaking changes in `2.0`.