### PR TITLE
[Console] Add forced resolve to command and prittify and detail output

### DIFF
--- a/Command/ResolveCacheCommand.php
+++ b/Command/ResolveCacheCommand.php
@@ -27,67 +27,177 @@ class ResolveCacheCommand extends ContainerAwareCommand
         $this
             ->setName('liip:imagine:cache:resolve')
             ->setDescription('Resolve cache for given path and set of filters.')
-            ->addArgument('paths', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'Image paths')
-            ->addOption(
-                'filters',
-                'f',
-                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-                'Filters list'
-            )->setHelp(<<<'EOF'
-The <info>%command.name%</info> command resolves cache by specified parameters.
-It returns list of urls.
+            ->addArgument('paths', InputArgument::REQUIRED | InputArgument::IS_ARRAY,
+                'Any number of image paths to act on.')
+            ->addOption('filters', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                'List of filters to apply to passed images (Deprecated, use "filter").')
+            ->addOption('filter', 'f', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                'List of filters to apply to passed images.')
+            ->addOption('force', 'F', InputOption::VALUE_NONE,
+                'Force image resolution regardless of cache.')
+            ->addOption('as-script', 's', InputOption::VALUE_NONE,
+                'Only print machine-parseable results.')
+            ->setHelp(<<<'EOF'
+The <comment>%command.name%</comment> command resolves the passed image(s) for the resolved
+filter(s), outputting results using the following basic format:
+  <info>- "image.ext[filter]" (resolved|cached|failed) as "path/to/cached/image.ext"</>
 
-<info>php app/console %command.name% path1 path2 --filters=thumb1</info>
-Cache for this two paths will be resolved with passed filter.
-As a result you will get<info>
-    http://localhost/media/cache/thumb1/path1
-    http://localhost/media/cache/thumb1/path2</info>
+<comment># bin/console %command.name% --filter=thumb1 foo.ext bar.ext</comment>
+Resolve <options=bold>both</> <comment>foo.ext</comment> and <comment>bar.ext</comment> using <comment>thumb1</comment> filter, outputting:
+  <info>- "foo.ext[thumb1]" resolved as "http://localhost/media/cache/thumb1/foo.ext"</>
+  <info>- "bar.ext[thumb1]" resolved as "http://localhost/media/cache/thumb1/bar.ext"</>
 
-You can pass few filters:
-<info>php app/console %command.name% path1 --filters=thumb1 --filters=thumb2</info>
-As a result you will get<info>
-    http://localhost/media/cache/thumb1/path1
-    http://localhost/media/cache/thumb2/path1</info>
+<comment># bin/console %command.name% --filter=thumb1 --filter=thumb2 foo.ext</comment>
+Resolve <comment>foo.ext</comment> using <options=bold>both</> <comment>thumb1</comment> and <comment>thumb2</comment> filters, outputting:
+  <info>- "foo.ext[thumb1]" resolved as "http://localhost/media/cache/thumb1/foo.ext"</>
+  <info>- "foo.ext[thumb2]" resolved as "http://localhost/media/cache/thumb2/foo.ext"</>
 
-If you omit --filters parameter then to resolve given paths will be used all configured and available filters in application:
-<info>php app/console %command.name% path1</info>
-As a result you will get<info>
-    http://localhost/media/cache/thumb1/path1
-    http://localhost/media/cache/thumb2/path1</info>
+<comment># bin/console %command.name% foo.ext</comment>
+Resolve <comment>foo.ext</comment> using <options=bold>all configured filters</> (as none are specified), outputting:
+  <info>- "foo.ext[thumb1]" resolved as "http://localhost/media/cache/thumb1/foo.ext"</>
+  <info>- "foo.ext[thumb2]" resolved as "http://localhost/media/cache/thumb2/foo.ext"</>
+
+<comment># bin/console %command.name% --force --filter=thumb1 foo.ext</comment>
+Resolve <comment>foo.ext</comment> using <comment>thumb1</comment> and <options=bold>force creation</> regardless of cache, outputting:
+  <info>- "foo.ext[thumb1]" resolved as "http://localhost/media/cache/thumb1/foo.ext"</>
+
 EOF
             );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $force = $input->getOption('force');
         $paths = $input->getArgument('paths');
-        $filters = $input->getOption('filters');
+        $filters = $this->resolveInputFilters($input);
+        $machine = $input->getOption('as-script');
+        $failed = 0;
 
-        /* @var FilterManager filterManager */
-        $filterManager = $this->getContainer()->get('liip_imagine.filter.manager');
-        /* @var CacheManager cacheManager */
-        $cacheManager = $this->getContainer()->get('liip_imagine.cache.manager');
-        /* @var DataManager dataManager */
-        $dataManager = $this->getContainer()->get('liip_imagine.data.manager');
+        $filterManager = $this->getFilterManager();
+        $dataManager = $this->getDataManager();
+        $cacheManager = $this->getCacheManager();
 
-        if (empty($filters)) {
+        if (0 === count($filters)) {
             $filters = array_keys($filterManager->getFilterConfiguration()->all());
         }
 
+        $this->outputTitle($output, $machine);
+
         foreach ($paths as $path) {
             foreach ($filters as $filter) {
-                if (!$cacheManager->isStored($path, $filter)) {
-                    $binary = $dataManager->find($filter, $path);
+                $output->write(sprintf('- %s[%s] ', $path, $filter));
 
-                    $cacheManager->store(
-                        $filterManager->applyFilter($binary, $filter),
-                        $path,
-                        $filter
-                    );
+                try {
+                    if ($force || !$cacheManager->isStored($path, $filter)) {
+                        $cacheManager->store($filterManager->applyFilter($dataManager->find($filter, $path), $filter), $path, $filter);
+                        $output->write('resolved: ');
+                    } else {
+                        $output->write('cached: ');
+                    }
+
+                    $output->writeln($cacheManager->resolve($path, $filter));
+                } catch (\Exception $e) {
+                    $output->writeln(sprintf('failed: %s', $e->getMessage()));
+                    ++$failed;
                 }
-
-                $output->writeln($cacheManager->resolve($path, $filter));
             }
         }
+
+        $this->outputSummary($output, $machine, count($filters), count($paths), $failed);
+
+        return 0 === $failed ? 0 : 255;
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param bool            $machine
+     */
+    private function outputTitle(OutputInterface $output, $machine)
+    {
+        if (!$machine) {
+            $title = '[liip/imagine-bundle] Image Resolver';
+
+            $output->writeln(sprintf('<info>%s</info>', $title));
+            $output->writeln(str_repeat('=', strlen($title)));
+            $output->writeln('');
+        }
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param bool            $machine
+     * @param int             $filters
+     * @param int             $paths
+     * @param int             $failed
+     */
+    private function outputSummary(OutputInterface $output, $machine, $filters, $paths, $failed)
+    {
+        if (!$machine) {
+            $operations = ($filters * $paths) - $failed;
+
+            $output->writeln('');
+            $output->writeln(vsprintf('Completed %d %s (%d %s on %d %s) <fg=red;options=bold>%s</>', array(
+                $operations,
+                $this->pluralizeWord($operations, 'operation'),
+                $filters,
+                $this->pluralizeWord($filters, 'filter'),
+                $paths,
+                $this->pluralizeWord($paths, 'image'),
+                0 === $failed ? '' : sprintf('[encountered %d %s]', $failed, $this->pluralizeWord($failed, 'failure')),
+            )));
+        }
+    }
+
+    /**
+     * @param int    $count
+     * @param string $singular
+     * @param string $pluralEnding
+     *
+     * @return string
+     */
+    private function pluralizeWord($count, $singular, $pluralEnding = 's')
+    {
+        return 1 === $count ? $singular : $singular.$pluralEnding;
+    }
+
+    /**
+     * @param InputInterface $input
+     *
+     * @return array|mixed
+     */
+    private function resolveInputFilters(InputInterface $input)
+    {
+        $filters = $input->getOption('filter');
+
+        if (count($filtersDeprecated = $input->getOption('filters'))) {
+            $filters = array_merge($filters, $filtersDeprecated);
+            @trigger_error('As of 1.9, use of the "--filters" option has been deprecated in favor of "--filter" and will be removed in 2.0.', E_USER_DEPRECATED);
+        }
+
+        return $filters;
+    }
+
+    /**
+     * @return FilterManager
+     */
+    private function getFilterManager()
+    {
+        return $this->getContainer()->get('liip_imagine.filter.manager');
+    }
+
+    /**
+     * @return DataManager
+     */
+    private function getDataManager()
+    {
+        return $this->getContainer()->get('liip_imagine.data.manager');
+    }
+
+    /**
+     * @return CacheManager
+     */
+    private function getCacheManager()
+    {
+        return $this->getContainer()->get('liip_imagine.cache.manager');
     }
 }

--- a/Tests/Functional/Command/AbstractCommandTestCase.php
+++ b/Tests/Functional/Command/AbstractCommandTestCase.php
@@ -22,11 +22,11 @@ class AbstractCommandTestCase extends AbstractSetupWebTestCase
     /**
      * @param Command $command
      * @param array   $arguments
-     * @param array   $options
+     * @param int     $return
      *
      * @return string
      */
-    protected function executeConsole(Command $command, array $arguments = array(), array $options = array())
+    protected function executeConsole(Command $command, array $arguments = array(), &$return = null)
     {
         $command->setApplication(new Application($this->createClient()->getKernel()));
         if ($command instanceof ContainerAwareCommand) {
@@ -34,10 +34,9 @@ class AbstractCommandTestCase extends AbstractSetupWebTestCase
         }
 
         $arguments = array_replace(array('command' => $command->getName()), $arguments);
-        $options = array_replace(array('--env' => 'test'), $options);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute($arguments, $options);
+        $return = $commandTester->execute($arguments, array('--env' => 'test'));
 
         return $commandTester->getDisplay();
     }

--- a/Tests/Functional/Command/RemoveCacheTest.php
+++ b/Tests/Functional/Command/RemoveCacheTest.php
@@ -33,7 +33,7 @@ class RemoveCacheTest extends AbstractCommandTestCase
             new RemoveCacheCommand(),
             array(
                 'paths' => array('images/cats.jpeg'),
-                '--filters' => array('thumbnail_web_path'),
+                '--filter' => array('thumbnail_web_path'),
         ));
     }
 
@@ -53,7 +53,7 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             new RemoveCacheCommand(),
-            array('--filters' => array('thumbnail_web_path', 'thumbnail_default'))
+            array('--filter' => array('thumbnail_web_path', 'thumbnail_default'))
         );
     }
 
@@ -160,7 +160,7 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             new RemoveCacheCommand(),
-            array('--filters' => array('thumbnail_default'))
+            array('--filter' => array('thumbnail_default'))
         );
 
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_default/images/cats.jpeg');
@@ -190,7 +190,7 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             new RemoveCacheCommand(),
-            array('--filters' => array('thumbnail_default', 'thumbnail_web_path'))
+            array('--filter' => array('thumbnail_default', 'thumbnail_web_path'))
         );
 
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -218,7 +218,7 @@ class RemoveCacheTest extends AbstractCommandTestCase
             new RemoveCacheCommand(),
             array(
                 'paths' => array('images/cats.jpeg'),
-                '--filters' => array('thumbnail_default', 'thumbnail_web_path'), )
+                '--filter' => array('thumbnail_default', 'thumbnail_web_path'), )
         );
 
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -245,11 +245,25 @@ class RemoveCacheTest extends AbstractCommandTestCase
             new RemoveCacheCommand(),
             array(
                 'paths' => array('images/cats.jpeg', 'images/cats2.jpeg'),
-                '--filters' => array('thumbnail_web_path'), )
+                '--filter' => array('thumbnail_web_path'), )
         );
 
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats2.jpeg');
         $this->assertFileExists($this->cacheRoot.'/thumbnail_default/images/cats.jpeg');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation As of 1.9, use of the "--filters" option has been deprecated in favor of "--filter" and will be removed in 2.0.
+     */
+    public function testDeprecatedFiltersOption()
+    {
+        $this->executeConsole(
+            new RemoveCacheCommand(),
+            array(
+                'paths' => array('images/cats.jpeg', 'images/cats2.jpeg'),
+                '--filters' => array('thumbnail_web_path'), )
+        );
     }
 }

--- a/Tests/Functional/Command/ResolveCacheTest.php
+++ b/Tests/Functional/Command/ResolveCacheTest.php
@@ -20,100 +20,350 @@ class ResolveCacheTest extends AbstractCommandTestCase
 {
     public function testShouldResolveWithEmptyCache()
     {
-        $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
+        $images = array('images/cats.jpeg', 'images/cats2.jpeg');
+        $filters = array('thumbnail_web_path');
 
-        $output = $this->executeConsole(
-            new ResolveCacheCommand(),
-            array(
-                'paths' => array('images/cats.jpeg'),
-                '--filters' => array('thumbnail_web_path'), )
-        );
+        $this->assertImagesNotExist($images, $filters);
 
-        $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
-        $this->assertFileNotExists($this->cacheRoot.'/thumbnail_default/images/cats.jpeg');
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
+        $return = null;
+        $output = $this->executeResolveCacheCommand($images, $filters, array(), $return);
+
+        $this->assertSame(0, $return);
+        $this->assertImagesExist($images, $filters);
+        $this->assertImagesNotExist($images, array('thumbnail_default'));
+        $this->assertOutputContainsResolvedImages($output, $images, $filters);
+        $this->assertOutputContainsSummary($output, $images, $filters);
+
+        $this->delResolvedImages($images, $filters);
     }
 
     public function testShouldResolveWithCacheExists()
     {
-        $this->filesystem->dumpFile(
-            $this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg',
-            'anImageContent'
-        );
+        $images = array('images/cats.jpeg');
+        $filters = array('thumbnail_web_path');
 
-        $output = $this->executeConsole(
-            new ResolveCacheCommand(),
-            array(
-                'paths' => array('images/cats.jpeg'),
-                '--filters' => array('thumbnail_web_path'), )
-        );
+        $this->putResolvedImages($images, $filters);
 
-        $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
-        $this->assertFileNotExists($this->cacheRoot.'/thumbnail_default/images/cats.jpeg');
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
+        $output = $this->executeResolveCacheCommand($images, $filters);
+
+        $this->assertImagesExist($images, $filters);
+        $this->assertImagesNotExist($images, array('thumbnail_default'));
+        $this->assertOutputContainsCachedImages($output, $images, $filters);
+        $this->assertOutputContainsSummary($output, $images, $filters);
+
+        $this->delResolvedImages($images, $filters);
     }
 
     public function testShouldResolveWithFewPathsAndSingleFilter()
     {
-        $output = $this->executeConsole(
-            new ResolveCacheCommand(),
-            array(
-                'paths' => array('images/cats.jpeg', 'images/cats2.jpeg'),
-                '--filters' => array('thumbnail_web_path'), )
-        );
+        $images = array('images/cats.jpeg', 'images/cats2.jpeg');
+        $filters = array('thumbnail_web_path');
 
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
+        $output = $this->executeResolveCacheCommand($images, $filters);
+
+        $this->assertImagesExist($images, $filters);
+        $this->assertOutputContainsResolvedImages($output, $images, $filters);
+
+        $output = $this->executeResolveCacheCommand($images, $filters);
+
+        $this->assertImagesExist($images, $filters);
+        $this->assertOutputContainsCachedImages($output, $images, $filters);
+        $this->assertOutputContainsSummary($output, $images, $filters);
+
+        $this->delResolvedImages($images, $filters);
     }
 
     public function testShouldResolveWithFewPathsSingleFilterAndPartiallyFullCache()
     {
-        $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
+        $imagesResolved = array('images/cats.jpeg');
+        $imagesCached = array('images/cats2.jpeg');
+        $images = array_merge($imagesResolved, $imagesCached);
+        $filters = array('thumbnail_web_path');
 
-        $this->filesystem->dumpFile(
-            $this->cacheRoot.'/thumbnail_web_path/images/cats2.jpeg',
-            'anImageContent'
-        );
+        $this->putResolvedImages($imagesCached, $filters);
 
-        $output = $this->executeConsole(
-            new ResolveCacheCommand(),
-            array(
-                'paths' => array('images/cats.jpeg', 'images/cats2.jpeg'),
-                '--filters' => array('thumbnail_web_path'), )
-        );
+        $this->assertImagesNotExist($imagesResolved, $filters);
+        $this->assertImagesExist($imagesCached, $filters);
 
-        $this->assertFileNotExists($this->cacheRoot.'/thumbnail_default/images/cats.jpeg');
-        $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
-        $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats2.jpeg');
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
+        $output = $this->executeResolveCacheCommand($images, $filters);
+
+        $this->assertImagesExist($images, $filters);
+        $this->assertOutputContainsResolvedImages($output, $imagesResolved, $filters);
+        $this->assertOutputContainsCachedImages($output, $imagesCached, $filters);
+        $this->assertOutputContainsSummary($output, $images, $filters);
+
+        $this->delResolvedImages($images, $filters);
     }
 
     public function testShouldResolveWithFewPathsAndFewFilters()
     {
-        $output = $this->executeConsole(
-            new ResolveCacheCommand(),
-            array(
-                'paths' => array('images/cats.jpeg', 'images/cats2.jpeg'),
-                '--filters' => array('thumbnail_web_path', 'thumbnail_default'), )
-        );
+        $images = array('images/cats.jpeg', 'images/cats2.jpeg');
+        $filters = array('thumbnail_web_path', 'thumbnail_default');
 
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_default/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_default/images/cats2.jpeg', $output);
+        $output = $this->executeResolveCacheCommand($images, $filters);
+
+        $this->assertImagesExist($images, $filters);
+        $this->assertOutputContainsResolvedImages($output, $images, $filters);
+        $this->assertOutputContainsSummary($output, $images, $filters);
+
+        $this->delResolvedImages($images, $filters);
     }
 
     public function testShouldResolveWithFewPathsAndWithoutFilters()
     {
-        $output = $this->executeConsole(
-            new ResolveCacheCommand(),
-            array('paths' => array('images/cats.jpeg', 'images/cats2.jpeg'))
-        );
+        $images = array('images/cats.jpeg', 'images/cats2.jpeg');
+        $filters = array('thumbnail_web_path', 'thumbnail_default');
 
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats2.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_default/images/cats.jpeg', $output);
-        $this->assertContains('http://localhost/media/cache/thumbnail_default/images/cats2.jpeg', $output);
+        $output = $this->executeResolveCacheCommand($images);
+
+        $this->assertImagesExist($images, $filters);
+        $this->assertOutputContainsResolvedImages($output, $images, $filters);
+        $this->assertOutputContainsSummary($output, $images, $filters);
+
+        $this->delResolvedImages($images, $filters);
+    }
+
+    public function testCachedAndForceResolve()
+    {
+        $images = array('images/cats.jpeg', 'images/cats2.jpeg');
+        $filters = array('thumbnail_web_path', 'thumbnail_default');
+
+        $this->assertImagesNotExist($images, $filters);
+        $this->putResolvedImages($images, $filters);
+        $this->assertImagesExist($images, $filters);
+
+        $output = $this->executeResolveCacheCommand($images, $filters);
+
+        $this->assertImagesExist($images, $filters);
+        $this->assertOutputContainsCachedImages($output, $images, $filters);
+
+        $output = $this->executeResolveCacheCommand($images, $filters, array('--force' => true));
+
+        $this->assertImagesExist($images, $filters);
+        $this->assertOutputContainsResolvedImages($output, $images, $filters);
+        $this->assertOutputContainsSummary($output, $images, $filters);
+
+        $this->delResolvedImages($images, $filters);
+    }
+
+    public function testFailedResolve()
+    {
+        $images = array('images/cats.jpeg', 'images/cats2.jpeg');
+        $filters = array('does_not_exist');
+
+        $this->assertImagesNotExist($images, $filters);
+
+        $return = null;
+        $output = $this->executeResolveCacheCommand($images, $filters, array(), $return);
+
+        $this->assertSame(255, $return);
+        $this->assertImagesNotExist($images, $filters);
+        $this->assertOutputContainsFailedImages($output, $images, $filters);
+        $this->assertOutputContainsSummary($output, $images, $filters, 2);
+
+        $this->delResolvedImages($images, $filters);
+    }
+
+    public function testMachineOption()
+    {
+        $images = array('images/cats.jpeg', 'images/cats2.jpeg');
+        $filters = array('does_not_exist');
+
+        $this->assertImagesNotExist($images, $filters);
+
+        $output = $this->executeResolveCacheCommand($images, $filters, array('--as-script' => true));
+
+        $this->assertImagesNotExist($images, $filters);
+        $this->assertNotContains('liip/imagine-bundle (cache resolver)', $output);
+        $this->assertNotContains('====================================', $output);
+        $this->assertOutputContainsFailedImages($output, $images, $filters);
+        $this->assertOutputNotContainsSummary($output, $images, $filters, 2);
+
+        $this->delResolvedImages($images, $filters);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation As of 1.9, use of the "--filters" option has been deprecated in favor of "--filter" and will be removed in 2.0.
+     */
+    public function testDeprecatedFiltersOption()
+    {
+        $images = array('images/cats.jpeg');
+        $filters = array('thumbnail_web_path');
+
+        $this->assertImagesNotExist($images, $filters);
+
+        $output = $this->executeConsole(new ResolveCacheCommand(), array('paths' => $images, '--filters' => $filters));
+
+        $this->assertImagesExist($images, $filters);
+        $this->assertOutputContainsResolvedImages($output, $images, $filters);
+
+        $this->delResolvedImages($images, $filters);
+    }
+
+    /**
+     * @param string[] $paths
+     * @param string[] $filters
+     * @param string[] $additionalOptions
+     * @param int      $return
+     *
+     * @return string
+     */
+    private function executeResolveCacheCommand(array $paths, array $filters = array(), array $additionalOptions = array(), &$return = null)
+    {
+        $options = array_merge(array('paths' => $paths), $additionalOptions);
+
+        if (0 < count($filters)) {
+            $options['--filter'] = $filters;
+        }
+
+        return $this->executeConsole(new ResolveCacheCommand(), $options, $return);
+    }
+
+    /**
+     * @param string[] $images
+     * @param string[] $filters
+     */
+    private function assertImagesNotExist($images, $filters)
+    {
+        foreach ($images as $i) {
+            foreach ($filters as $f) {
+                $this->assertFileNotExists(sprintf('%s/%s/%s', $this->cacheRoot, $f, $i));
+            }
+        }
+    }
+
+    /**
+     * @param string[] $images
+     * @param string[] $filters
+     */
+    private function assertImagesExist($images, $filters)
+    {
+        foreach ($images as $i) {
+            foreach ($filters as $f) {
+                $this->assertFileExists(sprintf('%s/%s/%s', $this->cacheRoot, $f, $i));
+            }
+        }
+    }
+
+    /**
+     * @param string $output
+     * @param array  $images
+     * @param array  $filters
+     */
+    private function assertOutputContainsResolvedImages($output, array $images, array $filters)
+    {
+        foreach ($images as $i) {
+            foreach ($filters as $f) {
+                $this->assertOutputContainsImage($output, $i, $f, 'resolved');
+            }
+        }
+    }
+
+    /**
+     * @param string $output
+     * @param array  $images
+     * @param array  $filters
+     */
+    private function assertOutputContainsCachedImages($output, array $images, array $filters)
+    {
+        foreach ($images as $i) {
+            foreach ($filters as $f) {
+                $this->assertOutputContainsImage($output, $i, $f, 'cached');
+            }
+        }
+    }
+
+    /**
+     * @param string $output
+     * @param array  $images
+     * @param array  $filters
+     */
+    private function assertOutputContainsFailedImages($output, array $images, array $filters)
+    {
+        foreach ($images as $i) {
+            foreach ($filters as $f) {
+                $this->assertContains(sprintf('%s[%s] failed: ', $i, $f), $output);
+            }
+        }
+    }
+
+    /**
+     * @param string $output
+     * @param string $image
+     * @param string $filter
+     * @param string $type
+     */
+    private function assertOutputContainsImage($output, $image, $filter, $type)
+    {
+        $expected = vsprintf('%s[%s] %s: http://localhost/media/cache/%s/%s', array(
+            $image,
+            $filter,
+            $type,
+            $filter,
+            $image,
+        ));
+        $this->assertContains($expected, $output);
+    }
+
+    /**
+     * @param string   $output
+     * @param string[] $images
+     * @param string[] $filters
+     * @param int      $failures
+     */
+    private function assertOutputContainsSummary($output, array $images, array $filters, $failures = 0)
+    {
+        $this->assertContains(sprintf('Completed %d operation', (count($images) * count($filters)) - $failures), $output);
+        $this->assertContains(sprintf('%d image', count($images)), $output);
+        $this->assertContains(sprintf('%d filter', count($filters)), $output);
+        if (0 !== $failures) {
+            $this->assertContains(sprintf('%d failure', $failures), $output);
+        }
+    }
+
+    /**
+     * @param string   $output
+     * @param string[] $images
+     * @param string[] $filters
+     * @param int      $failures
+     */
+    private function assertOutputNotContainsSummary($output, array $images, array $filters, $failures = 0)
+    {
+        $this->assertNotContains(sprintf('Completed %d operation', (count($images) * count($filters)) - $failures), $output);
+        $this->assertNotContains(sprintf('%d image', count($images)), $output);
+        $this->assertNotContains(sprintf('%d filter', count($filters)), $output);
+        if (0 !== $failures) {
+            $this->assertNotContains(sprintf('%d failure', $failures), $output);
+        }
+    }
+
+    /**
+     * @param string[] $images
+     * @param string[] $filters
+     */
+    private function delResolvedImages(array $images, array $filters)
+    {
+        foreach ($images as $i) {
+            foreach ($filters as $f) {
+                if (file_exists($f = sprintf('%s/%s/%s', $this->cacheRoot, $f, $i))) {
+                    @unlink($f);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param string[] $images
+     * @param string[] $filters
+     * @param string   $content
+     */
+    private function putResolvedImages(array $images, array $filters, $content = 'anImageContent')
+    {
+        foreach ($images as $i) {
+            foreach ($filters as $f) {
+                $this->filesystem->dumpFile(sprintf('%s/%s/%s', $this->cacheRoot, $f, $i), $content);
+            }
+        }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #966
| License | MIT
| Doc PR | <!--highly recommended for new features-->

The PR changes the following aspects of the `liip:imagine:cache:resolve` command:
- Adds a `--force` option that forces re-resolution an image, regardless of cache.
- Expands the output to provide more detailed information on the actions executed.
- Allows resolution failures and continues with the other passed images and filters.
- Amends the `--help` output to make it easier to follow and clearer at a glance.
- A `--machine` option has been added that removed the title and summary from the output and only outputs machine-parsable lines.
- Deprecates the `--filters` option in favor of a `--filter` option (you only pass one filter per call to it, so it should not be plural).

Here is the new `--help` output:

![liip-imagine-bundle-resolve-command-help](https://user-images.githubusercontent.com/3967713/28668546-5693c2ae-729e-11e7-8c03-f9585157b2bc.png)

Here is the output with errors:

![liip-imagine-bundle-cache-resolve-errors](https://user-images.githubusercontent.com/3967713/28668558-614b9eec-729e-11e7-82f4-c555f89de93f.png)

Here is the new default behavior output (showing the image name, filter name, and resolved path):

![liip-imagine-bundle-cache-resolve-cached-output](https://user-images.githubusercontent.com/3967713/28668577-7a5a1134-729e-11e7-9589-6fd29054f00e.png)

Here is the output when forcing resolution, ignoring the cache:

![liip-imagine-cache-resolve-resolved-output](https://user-images.githubusercontent.com/3967713/28668590-89fa37b8-729e-11e7-94cb-1a1080e95ff6.png)

Here is the output with `--machine` enabled:

![liip-imagine-bundle-cache-resolve-machine](https://user-images.githubusercontent.com/3967713/28668703-200ef950-729f-11e7-80a8-a378eaf694de.png)

And finally, here is the output showing `cached`, `resolved`, and `failed` items from one invocation:

![liip-imagine-bundle-cache-resolve-complete](https://user-images.githubusercontent.com/3967713/28703694-c6debc36-7333-11e7-8d3f-c983a6f136c5.png)
