### PR TITLE
Allow to configure the HTTP response code for redirects

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -52,23 +52,32 @@ class ImagineController
     protected $logger;
 
     /**
-     * @param DataManager     $dataManager
-     * @param FilterManager   $filterManager
-     * @param CacheManager    $cacheManager
-     * @param SignerInterface $signer
+     * @var int
+     */
+    protected $redirectResponseCode;
+
+    /**
+     * @param DataManager          $dataManager
+     * @param FilterManager        $filterManager
+     * @param CacheManager         $cacheManager
+     * @param SignerInterface      $signer
+     * @param LoggerInterface|null $logger
+     * @param int                  $redirectResponseCode
      */
     public function __construct(
         DataManager $dataManager,
         FilterManager $filterManager,
         CacheManager $cacheManager,
         SignerInterface $signer,
-        LoggerInterface $logger = null
+        LoggerInterface $logger = null,
+        $redirectResponseCode = 301
     ) {
         $this->dataManager = $dataManager;
         $this->filterManager = $filterManager;
         $this->cacheManager = $cacheManager;
         $this->signer = $signer;
         $this->logger = $logger;
+        $this->redirectResponseCode = $redirectResponseCode;
     }
 
     /**
@@ -109,7 +118,7 @@ class ImagineController
                 );
             }
 
-            return new RedirectResponse($this->cacheManager->resolve($path, $filter, $resolver), 301);
+            return new RedirectResponse($this->cacheManager->resolve($path, $filter, $resolver), $this->redirectResponseCode);
         } catch (NonExistingFilterException $e) {
             $message = sprintf('Could not locate filter "%s" for path "%s". Message was "%s"', $filter, $path, $e->getMessage());
 
@@ -177,7 +186,7 @@ class ImagineController
                 $resolver
             );
 
-            return new RedirectResponse($this->cacheManager->resolve($rcPath, $filter, $resolver), 301);
+            return new RedirectResponse($this->cacheManager->resolve($rcPath, $filter, $resolver), $this->redirectResponseCode);
         } catch (NonExistingFilterException $e) {
             $message = sprintf('Could not locate filter "%s" for path "%s". Message was "%s"', $filter, $hash.'/'.$path, $e->getMessage());
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -124,6 +124,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('filter_action')->defaultValue('liip_imagine.controller:filterAction')->end()
                         ->scalarNode('filter_runtime_action')->defaultValue('liip_imagine.controller:filterRuntimeAction')->end()
+                        ->scalarNode('redirect_response_code')->defaultValue(301)->end()
                     ->end()
                 ->end()
                 ->arrayNode('filter_sets')

--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -95,6 +95,7 @@ class LiipImagineExtension extends Extension
 
         $container->setParameter('liip_imagine.controller.filter_action', $config['controller']['filter_action']);
         $container->setParameter('liip_imagine.controller.filter_runtime_action', $config['controller']['filter_runtime_action']);
+        $container->setParameter('liip_imagine.controller.redirect_response_code', $config['controller']['redirect_response_code']);
 
         $resources = $container->hasParameter('twig.form.resources') ? $container->getParameter('twig.form.resources') : array();
         $resources[] = 'LiipImagineBundle:Form:form_div_layout.html.twig';

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -134,6 +134,7 @@
             <argument type="service" id="liip_imagine.cache.manager" />
             <argument type="service" id="liip_imagine.cache.signer" />
             <argument type="service" id="logger" on-invalid="ignore" />
+            <argument>%liip_imagine.controller.redirect_response_code%</argument>
         </service>
 
         <service id="liip_imagine.meta_data.reader" class="%liip_imagine.meta_data.reader.class%" public="false" />

--- a/Tests/Controller/ImagineControllerTest.php
+++ b/Tests/Controller/ImagineControllerTest.php
@@ -13,6 +13,7 @@ namespace Liip\ImagineBundle\Tests\Controller;
 
 use Liip\ImagineBundle\Controller\ImagineController;
 use Liip\ImagineBundle\Tests\AbstractTest;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @covers \Liip\ImagineBundle\Controller\ImagineController
@@ -26,7 +27,59 @@ class ImagineControllerTest extends AbstractTest
             $this->createFilterManagerMock(),
             $this->createCacheManagerMock(),
             $this->createSignerInterfaceMock(),
-            $this->createLoggerInterfaceMock()
+            $this->createLoggerInterfaceMock(),
+            301
         );
+    }
+
+    public function testRedirectCodeIsConfigurable()
+    {
+        $redirectResponseCode = 307;
+        $path = '/foo';
+        $filter = 'filter';
+        $binary = $this->createObjectMock('\Liip\ImagineBundle\Model\Binary');
+        $hash = 'hash';
+
+        $dataManager = $this->createDataManagerMock();
+        $dataManager
+            ->method('find')
+            ->with($filter, $path)
+            ->willReturn($binary);
+
+        $filterManager = $this->createFilterManagerMock();
+        $filterManager
+            ->method('applyFilter')
+            ->with($binary, $filter)
+            ->willReturn($binary);
+
+        $cacheManager = $this->createCacheManagerMock();
+        $cacheManager
+            ->method('resolve')
+            ->willReturn($path, $filter)
+            ->willReturn('/target');
+
+        $signer = $this->createSignerInterfaceMock();
+        $signer
+            ->expects($this->once())
+            ->method('check')
+            ->with($hash, $path, array())
+            ->willReturn(true);
+
+        $controller = new ImagineController(
+            $dataManager,
+            $filterManager,
+            $cacheManager,
+            $signer,
+            $this->createLoggerInterfaceMock(),
+            $redirectResponseCode
+        );
+
+        $response = $controller->filterAction(new Request(), $path, $filter);
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertSame($redirectResponseCode, $response->getStatusCode());
+
+        $response = $controller->filterRuntimeAction(new Request(), $hash, $path, $filter);
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertSame($redirectResponseCode, $response->getStatusCode());
     }
 }

--- a/Tests/DependencyInjection/LiipImagineExtensionTest.php
+++ b/Tests/DependencyInjection/LiipImagineExtensionTest.php
@@ -57,6 +57,7 @@ class LiipImagineExtensionTest extends AbstractTest
                 new Reference('liip_imagine.cache.manager'),
                 new Reference('liip_imagine.cache.signer'),
                 new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+                '%liip_imagine.controller.redirect_response_code%'
             )
         );
     }

--- a/Tests/Functional/Controller/ImagineControllerTest.php
+++ b/Tests/Functional/Controller/ImagineControllerTest.php
@@ -37,7 +37,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -55,7 +55,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -131,7 +131,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/'.$expectedCachePath, $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/'.$expectedCachePath);
@@ -166,7 +166,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache'.'/'.$expectedCachePath, $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/'.$expectedCachePath);
@@ -186,7 +186,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/foo bar.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/foo bar.jpeg');

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -84,4 +84,6 @@ liip_imagine:
             filters:
                 thumbnail: { size: [223, 223], mode: inset }
 
-...
+
+    controller:
+        redirect_response_code: 302


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #969
| License | MIT

Makes redirect code configurable.