### PR TITLE
update twig template path to namespaced path

### DIFF
--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -94,7 +94,7 @@ class LiipImagineExtension extends Extension
 
         $container->setParameter('twig.form.resources', array_merge(
             $container->hasParameter('twig.form.resources') ? $container->getParameter('twig.form.resources') : [],
-            ['LiipImagineBundle:Form:form_div_layout.html.twig']
+            ['@LiipImagine/Form/form_div_layout.html.twig']
         ));
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | 
| License | MIT
| Doc PR | 

Updates the syntax of the template path to twig namespaces which is required for use with Symfony 3.3+