### PR TITLE
[Composer] [Travis] Require PHP 7.1, remove HHVM support, and remove unsupported Symfony version testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ sudo: false
 
 language: php
 
+php:
+  - 7.1
+  - nightly
+
 cache:
   directories:
     - $HOME/.composer/cache/files
@@ -11,26 +15,14 @@ cache:
 env:
   global:
     - SYMFONY_DEPRECATIONS_HELPER=weak
+    - SYMFONY_VERSION=3.2.x-dev
 
 matrix:
   include:
-    - php:  hhvm-stable
-      sudo: required
-      dist: trusty
-      env:  SYMFONY_VERSION=3.0.x-dev
-    - php: 7.0
-      env: SYMFONY_VERSION=3.0.x-dev
-    - php: 7.1
-      env: SYMFONY_VERSION=3.1.x-dev
-    - php: 7.1
-      env: SYMFONY_VERSION=3.2.x-dev
-    - php: 7.1
-      env: SYMFONY_VERSION=3.3.x-dev
-    - php: 7.1
-      env: SYMFONY_VERSION=dev-master
+    - env: SYMFONY_VERSION=3.3.x-dev
+    - env: SYMFONY_VERSION=3.4.x-dev
   allow_failures:
-    - php: hhvm-stable
-    - env: SYMFONY_VERSION=dev-master
+    - php: nightly
   fast_finish: true
 
 before_install:

--- a/.travis/exec-before.bash
+++ b/.travis/exec-before.bash
@@ -17,14 +17,6 @@ function main()
 {
   out_main "Running 'exec-before' operations"
 
-  if [[ ! ${TRAVIS_PHP_VERSION} = hhvm* ]]; then
-    disable_php_memory_limit
-  fi
-
-  if [[ ${TRAVIS_PHP_VERSION} = hhvm* ]]; then
-    enable_hhvm_php7_mode
-  fi
-
   initialize_prestissimo
 }
 

--- a/.travis/inc-functions.bash
+++ b/.travis/inc-functions.bash
@@ -17,29 +17,6 @@ function out_main()
 }
 
 #
-# disable the php memory limit by setting it to "-1"
-#
-function disable_php_memory_limit()
-{
-  if [[ ! -d "$(dirname ${CONF_PATH_PHP7})" ]]; then
-    return
-  fi
-
-  out_line "Disabling PHP memory limit in '${CONF_PATH_PHP7}'"
-  echo "memory_limit = -1" >> "${CONF_PATH_PHP7}";
-}
-
-#
-# enable the hhvm php7 mode by setting it to "1"
-#
-function enable_hhvm_php7_mode()
-{
-  out_line "Enabling HHVM PHP7 mode in '${CONF_PATH_HHVM}'"
-  echo "hhvm.php7.all = 1" >> "${CONF_PATH_HHVM}"
-  echo "hhvm.php7.scalar_types = 0" >> "${CONF_PATH_HHVM}"
-}
-
-#
 # configure the prestissimo package
 #
 function configure_prestissimo()

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "exclude-from-classmap": [ "/Tests/" ]
     },
     "require": {
-        "php": "~7.0",
+        "php": "~7.1",
         "imagine/Imagine": "^0.6.3,<0.7",
         "symfony/asset": "~3.0",
         "symfony/filesystem": "~3.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

This PR amends our `composer.json` PHP requirement to require PHP `7.1` (as previously discussed to level our requirements with that of the upcoming Symfony release) and removes unsupported Symfony versions [3.0](https://symfony.com/roadmap?version=3.0#checker) and [3.1](https://symfony.com/roadmap?version=3.1#checker) (they were dropped from both feature and bug fixes in January 2017 and July 2017, respectively). Additionally, `hhvm` has been dropped (this was already done on the `1.x` branch and was forgotten on the `2.x` branch). Moreover, `hhvm`-specific build functions have been removed from our travis bash scripts.