### PR TITLE
Fix nested level of bucket parameter

### DIFF
--- a/Resources/doc/cache-resolver/aws_s3.rst
+++ b/Resources/doc/cache-resolver/aws_s3.rst
@@ -54,12 +54,12 @@ Create Resolver from a Factory
         resolvers:
             profile_photos:
                 aws_s3:
+                    bucket: "%amazon.s3.cache_bucket%"
                     client_config:
                         credentials:
                             key:    "%amazon.s3.key%"
                             secret: "%amazon.s3.secret%"
                         region: "%amazon.s3.region%"
-                        bucket: "%amazon.s3.cache_bucket%"
                     get_options:
                         Scheme: https
                     put_options:


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | no
| License | MIT
| Doc PR | yes

Otherwise I get `InvalidConfigurationException`:
> The child node "bucket" at path "liip_imagine.resolvers.default.aws_s3" must be configured.
