### PR TITLE
[Filter] Add "fixed-size" filter implementation

### DIFF
--- a/Imagine/Filter/Loader/FixedFilterLoader.php
+++ b/Imagine/Filter/Loader/FixedFilterLoader.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Imagine\Filter\Loader;
+
+use Imagine\Filter\Basic\Crop;
+use Imagine\Filter\Basic\Resize;
+use Imagine\Image\Box;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\Point;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Fixed size filter.
+ *
+ * @author Robbe Clerckx <https://github.com/robbeman>
+ */
+class FixedFilterLoader implements LoaderInterface
+{
+    /**
+     * @param ImageInterface $image
+     * @param array          $options
+     *
+     * @return ImageInterface
+     */
+    public function load(ImageInterface $image, array $options = [])
+    {
+        $optionsResolver = new OptionsResolver();
+        $optionsResolver->setRequired(['width', 'height']);
+        $options = $optionsResolver->resolve($options);
+
+        // get the original image size and create a crop box
+        $size = $image->getSize();
+        $box = new Box($options['width'], $options['height']);
+
+        // determine scale
+        if ($size->getWidth() / $size->getHeight() > $box->getWidth() / $box->getHeight()) {
+            $size = $size->heighten($box->getHeight());
+        } else {
+            $size = $size->widen($box->getWidth());
+        }
+
+        // define filters
+        $resize = new Resize($size);
+        $origin = new Point(
+            floor(($size->getWidth() - $box->getWidth()) / 2),
+            floor(($size->getHeight() - $box->getHeight()) / 2)
+        );
+        $crop = new Crop($origin, $box);
+
+        // apply filters to image
+        $image = $resize->apply($image);
+        $image = $crop->apply($image);
+
+        return $image;
+    }
+}

--- a/Imagine/Filter/Loader/FixedFilterLoader.php
+++ b/Imagine/Filter/Loader/FixedFilterLoader.php
@@ -31,10 +31,10 @@ class FixedFilterLoader implements LoaderInterface
      *
      * @return ImageInterface
      */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = array())
     {
         $optionsResolver = new OptionsResolver();
-        $optionsResolver->setRequired(['width', 'height']);
+        $optionsResolver->setRequired(array('width', 'height'));
         $options = $optionsResolver->resolve($options);
 
         // get the original image size and create a crop box

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -48,6 +48,7 @@
         <parameter key="liip_imagine.filter.loader.flip.class">Liip\ImagineBundle\Imagine\Filter\Loader\FlipFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.interlace.class">Liip\ImagineBundle\Imagine\Filter\Loader\InterlaceFilterLoader</parameter>
         <parameter key="liip_imagine.filter.loader.resample.class">Liip\ImagineBundle\Imagine\Filter\Loader\ResampleFilterLoader</parameter>
+        <parameter key="liip_imagine.filter.loader.fixed.class">Liip\ImagineBundle\Imagine\Filter\Loader\FixedFilterLoader</parameter>
 
         <!-- Data loaders' classes -->
 
@@ -236,6 +237,10 @@
         <service id="liip_imagine.filter.loader.resample" class="%liip_imagine.filter.loader.resample.class%">
             <argument type="service" id="liip_imagine" />
             <tag name="liip_imagine.filter.loader" loader="resample" />
+        </service>
+
+        <service id="liip_imagine.filter.loader.fixed" class="%liip_imagine.filter.loader.fixed.class%">
+            <tag name="liip_imagine.filter.loader" loader="fixed" />
         </service>
 
         <!-- Data loaders -->

--- a/Resources/doc/filters/sizing.rst
+++ b/Resources/doc/filters/sizing.rst
@@ -58,6 +58,49 @@ Thumbnail Options
     thumbnail size.
 
 
+.. _filter-fixed:
+
+Fixed size
+----------
+
+The built-in ``fixed`` filter performs thumbnail transformations (which includes scaling
+and potentially cropping operations). This filter exposed a number of `fixed options`_
+which may be used to configure its behavior. Unlike the ``thumbnail`` filter, the
+``fixed`` filter supports upscale and you always get a fixed-size image.
+
+Example configuration:
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        filter_sets:
+
+            # name our filter set "my_fixed_filter"
+            my_fixed_filter:
+                filters:
+
+                    # use and setup the "fixed" filter
+                    fixed:
+
+                        # set the fixed size to "120x90" pixels
+                        width: 120
+                        height: 90
+
+
+Fixed Options
+~~~~~~~~~~~~~
+
+:strong:`width:` ``int``
+    Sets the "desired width" which initiates a proportional scale operation that up- or
+    down-scales until the image width matches this value.
+
+:strong:`height:` ``int``
+    Sets the "desired height" which initiates a proportional scale operation that up- or
+    down-scales until the image height matches this value.
+
+
 .. _filter-crop:
 
 Cropping Images

--- a/Tests/Imagine/Filter/Loader/FixedFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/FixedFilterLoaderTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Filter;
+
+use Imagine\Image\Box;
+use Imagine\Image\Point;
+use Liip\ImagineBundle\Imagine\Filter\Loader\FixedFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
+
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\FixedFilterLoader
+ */
+class FixedFilterLoaderTest extends AbstractTest
+{
+    /**
+     * @var int
+     */
+    const DUMMY_IMAGE_WIDTH = 500;
+
+    /**
+     * @var int
+     */
+    const DUMMY_IMAGE_HEIGHT = 600;
+
+    /**
+     * @param int $width
+     * @param int $height
+     * @param Box $expected
+     *
+     * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\FixedFilterLoader::load
+     *
+     * @dataProvider heightWidthProvider
+     */
+    public function testLoad($width, $height, $expected)
+    {
+        $loader = new FixedFilterLoader();
+
+        $mockImageSize = new Box(
+            self::DUMMY_IMAGE_WIDTH,
+            self::DUMMY_IMAGE_HEIGHT
+        );
+
+        if ($mockImageSize->getWidth() / $mockImageSize->getHeight() > $expected->getWidth() / $expected->getHeight()) {
+            $resize = $mockImageSize->heighten($expected->getHeight());
+        } else {
+            $resize = $mockImageSize->widen($expected->getWidth());
+        }
+        $origin = new Point(
+            floor(($resize->getWidth() - $expected->getWidth()) / 2),
+            floor(($resize->getHeight() - $expected->getHeight()) / 2)
+        );
+
+        $image = $this->getImageInterfaceMock();
+        $image->method('getSize')->willReturn($mockImageSize);
+        $image->expects($this->once())
+            ->method('resize')
+            ->with($resize)
+            ->willReturn($image);
+        $image->expects($this->once())
+            ->method('crop')
+            ->with($origin, $expected)
+            ->willReturn($image);
+
+        $options = array();
+        $options['width'] = $width;
+        $options['height'] = $height;
+
+        $result = $loader->load($image, $options);
+    }
+
+    /**
+     * @returns array Array containing width/height pairs and an expected size.
+     */
+    public function heightWidthProvider()
+    {
+        return array(
+            array(200, 129, new Box(200, 129)),
+            array(50, 50, new Box(50, 50)),
+            array(1, 30, new Box(1, 30)),
+            array(1280, 720, new Box(1280, 720)),
+        );
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #560
| License | MIT
| Doc PR | -

At the moment there is no way to create a fixed-size image.
This is a new filter that does this.

See https://github.com/liip/LiipImagineBundle/issues/560#issuecomment-275694967 for more details.

Usage
-------

```yml
liip_imagine:
    filter_sets:
        my_thumb:
            filters:
                fixed: { width: 120, height: 90 }
```