### PR TITLE
Upscale Thumbnail is not work

### DIFF
--- a/Imagine/Filter/Loader/ThumbnailFilterLoader.php
+++ b/Imagine/Filter/Loader/ThumbnailFilterLoader.php
@@ -49,9 +49,7 @@ class ThumbnailFilterLoader implements LoaderInterface
             }
         }
 
-        if (($origWidth > $width || $origHeight > $height)
-            || (!empty($options['allow_upscale']) && ($origWidth !== $width || $origHeight !== $height))
-        ) {
+        if ($origWidth > $width || $origHeight > $height) {
             $filter = new Thumbnail(new Box($width, $height), $mode, $filter);
             $image = $filter->apply($image);
         }

--- a/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
@@ -51,7 +51,6 @@ class ThumbnailFilterLoaderTest extends AbstractTest
         );
         $image = $this->getImageInterfaceMock();
         $image->method('getSize')->willReturn($mockImageSize);
-        $image->method('copy')->willReturn($image);
         $image->expects($this->once())
             ->method('thumbnail')
             ->with($expected)
@@ -59,7 +58,6 @@ class ThumbnailFilterLoaderTest extends AbstractTest
 
         $options = array();
         $options['size'] = array($width, $height);
-        $options['allow_upscale'] = true;
 
         $result = $loader->load($image, $options);
     }
@@ -75,7 +73,27 @@ class ThumbnailFilterLoaderTest extends AbstractTest
             array(1, 30, new Box(1, 30)),
             array(null, 60, new Box(50, 60)),
             array(50, null, new Box(50, 60)),
-            array(1000, 1000, new Box(1000, 1000)),
         );
+    }
+
+    /**
+     * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader::load
+     */
+    public function testLoadUpscale()
+    {
+        $loader = new ThumbnailFilterLoader();
+
+        $mockImageSize = new Box(
+            self::DUMMY_IMAGE_WIDTH,
+            self::DUMMY_IMAGE_HEIGHT
+        );
+        $image = $this->getImageInterfaceMock();
+        $image->method('getSize')->willReturn($mockImageSize);
+
+        $options = array();
+        $options['size'] = array(1000, 1000);
+        $image->expects($this->never())->method('thumbnail');
+
+        $result = $loader->load($image, $options);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | -
| License | MIT
| Doc PR | -

`allow_upscale` is not work in Thumbnail filter #560

I propose to solve this problem by creating a separate filter #1015, because this filter is already [very complex](https://scrutinizer-ci.com/g/liip/LiipImagineBundle/code-structure/master/operation/Liip%5CImagineBundle%5CImagine%5CFilter%5CLoader%5CThumbnailFilterLoader%3A%3Aload).