### PR TITLE
Make liip_imagine.controller service public (Symfony 3.4 / 4.0 compatibility)

### DIFF
--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -69,7 +69,7 @@
 
         <!-- Controller -->
 
-        <service id="liip_imagine.controller" class="Liip\ImagineBundle\Controller\ImagineController">
+        <service id="liip_imagine.controller" class="Liip\ImagineBundle\Controller\ImagineController" public="true">
             <argument type="service" id="liip_imagine.service.filter" />
             <argument type="service" id="liip_imagine.data.manager" />
             <argument type="service" id="liip_imagine.cache.signer" />


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

This fixes compatibility with Symfony 3.4+ where services are private by default, and avoids errors like this:

> The "liip_imagine.controller" service or alias has been removed or inlined when the container was compiled.