### PR TITLE
Add needed alias

### DIFF
--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -13,6 +13,7 @@ namespace Liip\ImagineBundle\DependencyInjection;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -81,6 +82,7 @@ class LiipImagineExtension extends Extension
         ]);
 
         $container->setAlias('liip_imagine', new Alias('liip_imagine.'.$config['driver']));
+        $container->setAlias(CacheManager::class, new Alias('liip_imagine.cache.manager', false));
 
         $container->setParameter('liip_imagine.cache.resolver.default', $config['cache']);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? |  2.0 
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Tests pass? | yes
| Fixed tickets | none
| License | MIT
| Doc PR | none

Without proposed alias, this bundle is not working on Symfony 4.0, and logging a deprecation notice on Symfony 3.4
>Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "liip_imagine.cache.manager" service to "Liip\ImagineBundle\Imagine\Cache\CacheManager" instead.
