### PR TITLE
remove unused php-cs-fixer from require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "doctrine/cache": "^1.1",
         "doctrine/orm": "^2.3",
         "enqueue/enqueue-bundle": "^0.7|^0.8",
-        "friendsofphp/php-cs-fixer": "^1.0|^2.0",
         "league/flysystem": "^1.0",
         "psr/log": "^1.0",
         "satooshi/php-coveralls": "^1.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | see travis-ci
| Fixed tickets | -
| License | MIT
| Doc PR | -

This dependency is not used since we use styleci instead (which is php-cs-fixer as a service). The cs fixer does not install with PHP 7.3, making the PHP nightly build error.