### PR TITLE
Fix User Deprecated: The "liip_imagine.cache.manager" service is private

### DIFF
--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -48,7 +48,7 @@
             <argument>%liip_imagine.default_image%</argument>
         </service>
 
-        <service id="liip_imagine.cache.manager" class="Liip\ImagineBundle\Imagine\Cache\CacheManager">
+        <service id="liip_imagine.cache.manager" class="Liip\ImagineBundle\Imagine\Cache\CacheManager" public="true">
             <argument type="service" id="liip_imagine.filter.configuration" />
             <argument type="service" id="router" />
             <argument type="service" id="liip_imagine.cache.signer" />


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Tests pass? | yes
| Fixed tickets | 
| License | MIT
| Doc PR | 

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->

Fix deprecation in order to call a private service in controller

```php
/** @var CacheManager */
$imagineCacheManager = $this->get('liip_imagine.cache.manager');
```

Last command is deprecated since Symfony 3.2 and will fail in 4.0