### PR TITLE
change the default from web to public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 /composer.lock
 /composer.phar
 /vendor/
-/Tests/Functional/app/web/media/cache
+/Tests/Functional/app/public/media/cache
 /.idea/
 /var/

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -59,7 +59,7 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
                     ->end()
                     ->treatNullLike([])
                     ->treatFalseLike([])
-                    ->defaultValue(['%kernel.root_dir%/../web'])
+                    ->defaultValue(['%kernel.root_dir%/../public'])
                     ->prototype('scalar')
                         ->cannotBeEmpty()
                     ->end()

--- a/DependencyInjection/Factory/Resolver/WebPathResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/WebPathResolverFactory.php
@@ -50,7 +50,7 @@ class WebPathResolverFactory extends AbstractResolverFactory
         $builder
             ->children()
                 ->scalarNode('web_root')
-                    ->defaultValue('%kernel.root_dir%/../web')
+                    ->defaultValue('%kernel.root_dir%/../public')
                     ->cannotBeEmpty()
                 ->end()
                 ->scalarNode('cache_prefix')

--- a/Resources/doc/cache-resolver/web_path.rst
+++ b/Resources/doc/cache-resolver/web_path.rst
@@ -35,16 +35,17 @@ Configuration
         resolvers:
            profile_photos:
               web_path:
-                web_root: "%kernel.root_dir%/../web"
+                # For Symfony versions below 4.x, use "web" instead of "public"
+                web_root: "%kernel.root_dir%/../public"
                 cache_prefix: "media/cache"
 
 There are several configuration options available:
 
 * ``web_root`` - must be the absolute path to you application's web root. This
   is used to determine where to put generated image files, so that apache
-  will pick them up before handing the request to Symfony2 next time they
+  will pick them up before handing the request to Symfony next time they
   are requested.
-  Default value: ``%kernel.root_dir%/../web``
+  Default value: ``%kernel.root_dir%/../public``
 * ``cache_prefix`` - this is also used in the path for image generation, so
   as to not clutter your web root with cached images. For example by default,
   the images would be written to the ``web/media/cache/`` directory.

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -13,13 +13,15 @@ The default configuration for the bundle looks like this:
         resolvers:
             default:
                 web_path:
-                    web_root: ~ # %kernel.root_dir%/../web
+                    # For Symfony versions below 4.x, use "web" instead of "public"
+                    web_root: ~ # %kernel.root_dir%/../public
                     cache_prefix: ~ # media/cache
 
         loaders:
             default:
                 filesystem:
-                    data_root: ~  # %kernel.root_dir%/../web/
+                    # For Symfony versions below 4.x, use "web" instead of "public"
+                    data_root: ~  # %kernel.root_dir%/../public/
 
         driver:               gd
         cache:                default

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -252,7 +252,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
 
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
     {
-        $expectedDataRoot = array('%kernel.root_dir%/../web');
+        $expectedDataRoot = array('%kernel.root_dir%/../public');
 
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('filesystem', 'array');
@@ -270,7 +270,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
 
     public function testAddAsScalarExpectingArrayNormalizationOfConfiguration()
     {
-        $expectedDataRoot = array('%kernel.root_dir%/../web');
+        $expectedDataRoot = array('%kernel.root_dir%/../public');
 
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('filesystem', 'array');

--- a/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
@@ -103,7 +103,7 @@ class WebPathResolverFactoryTest extends \PHPUnit\Framework\TestCase
         ));
 
         $this->assertArrayHasKey('web_root', $config);
-        $this->assertEquals('%kernel.root_dir%/../web', $config['web_root']);
+        $this->assertEquals('%kernel.root_dir%/../public', $config['web_root']);
 
         $this->assertArrayHasKey('cache_prefix', $config);
         $this->assertEquals('media/cache', $config['cache_prefix']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | depends :)
| New feature? | depends :)
| BC breaks? | yes
| Deprecations? | no
| Tests pass? | 
| Fixed tickets | 
| License | MIT
| Doc PR | included

default should now be `public` but wondering if it in fact should be `"%kernel.project_dir%/public"`