### PR TITLE
[Async] [DI] Make resolve_cache_processor a public service

### DIFF
--- a/Resources/config/enqueue.xml
+++ b/Resources/config/enqueue.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="liip_imagine.async.resolve_cache_processor" class="Liip\ImagineBundle\Async\ResolveCacheProcessor">
+        <service id="liip_imagine.async.resolve_cache_processor" class="Liip\ImagineBundle\Async\ResolveCacheProcessor" public="true">
             <argument type="service" id="liip_imagine.filter.manager" />
             <argument type="service" id="liip_imagine.service.filter" />
             <argument type="service" id="enqueue.producer" />


### PR DESCRIPTION
liip_imagine.async.resolve_cache_processor should be public or an exception is thrown when sending enqueue command.

| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Tests pass? | 
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

I had an exception about this service needing to be public using SF4. All services are private by default now. Not sure where it was used and if dependency injection through the __construct method would be preferred but wanted to submit this PR as a quick easy fix which shouldn't result in any breaking changes with older symfony versions either.