### PR TITLE
[Deps] Revert php-cs-fixer development dependency removal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ matrix:
         - SYMFONY_VERSION=dev-master
         - STABILITY=dev
     - php: nightly
+      env:
+        - SYMFONY_VERSION=4.0.*
+        - COMPOSER_FLAGS="--ignore-platform-reqs"
   allow_failures:
     - env:
         - ENABLE_CODE_COVERAGE="true"

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "doctrine/cache": "^1.1",
         "doctrine/orm": "^2.3",
         "enqueue/enqueue-bundle": "^0.7|^0.8",
+        "friendsofphp/php-cs-fixer": "^2.10",
         "league/flysystem": "^1.0",
         "psr/log": "^1.0",
         "symfony/browser-kit": "^3.0|^4.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | => travis
| Fixed tickets | #1031
| License | MIT
| Doc PR | -

adding back the php-cs-fixer as dev dependency because some of the maintainer use it on the cli.