### PR TITLE
[CS] Changes to support new php-cs-fixer rule set

### DIFF
--- a/Async/ResolveCache.php
+++ b/Async/ResolveCache.php
@@ -84,11 +84,11 @@ class ResolveCache implements \JsonSerializable
     {
         $data = array_replace(['path' => null, 'filters' => null, 'force' => false], JSON::decode($json));
 
-        if (false == $data['path']) {
+        if (!$data['path']) {
             throw new LogicException('The message does not contain "path" but it is required.');
         }
 
-        if (false == (is_null($data['filters']) || is_array($data['filters']))) {
+        if (!(is_null($data['filters']) || is_array($data['filters']))) {
             throw new LogicException('The message filters could be either null or array.');
         }
 

--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -106,7 +106,7 @@ class CacheManager
     protected function getResolver($filter, $resolver)
     {
         // BC
-        if (false == $resolver) {
+        if (!$resolver) {
             $config = $this->filterConfig->get($filter);
 
             $resolverName = empty($config['cache']) ? $this->defaultResolver : $config['cache'];


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | `2.0`
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1040
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Required changes to allow the new `php-cs-fixer` rule set defined in #1040. Without these changes, the non-strict comparisons are changed to strict comparisons, which results in incorrect behavior (the automatic fix provided by the new rule set isn't the problem, but the original implementation, which is changed here accordingly).