### PR TITLE
[CI] [Dependencies] Cleanup Travis configuration and upgrade coveralls

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,3 @@
-service_name: travis-ci
-src_dir: .
-coverage_clover : var/build/clover.xml
-json_path       : var/build/coveralls-upload.json
+service_name   : travis-ci
+coverage_clover: var/build/clover.xml
+json_path      : var/build/upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   global:
     - SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
     - ENABLE_CODE_COVERAGE="false"
+    - SIMPLE_PHPUNIT_FLAGS="-v"
 
 matrix:
   fast_finish: true
@@ -28,10 +29,11 @@ matrix:
     - php: 7.2
       env:
         - DEPENDENCIES="symfony/phpunit-bridge:^4"
-        - COMPOSER_UPDATE_OPTIONS="--no-dev"
+        - COMPOSER_UPDATE_FLAGS="--no-dev"
     - php: 7.2
       env:
         - ENABLE_CODE_COVERAGE="true"
+        - SIMPLE_PHPUNIT_FLAGS="-v --coverage-text --coverage-clover var/build/clover.xml"
     - php: 7.2
       env:
         - SYMFONY_VERSION=dev-master
@@ -43,25 +45,41 @@ matrix:
   allow_failures:
     - env:
         - ENABLE_CODE_COVERAGE="true"
+        - SIMPLE_PHPUNIT_FLAGS="-v --coverage-text --coverage-clover var/build/clover.xml"
     - env:
         - SYMFONY_VERSION=dev-master
         - STABILITY=dev
     - php: nightly
 
 before_install:
-  - if [[ "$SYMFONY_VERSION" != "" ]]; then travis_retry composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update $COMPOSER_FLAGS; fi;
-  - if [[ "$DEPENDENCIES" != "" ]]; then travis_retry composer require ${DEPENDENCIES} --no-update $COMPOSER_FLAGS; fi;
-  - if [[ "$STABILITY" != "" ]]; then composer config minimum-stability $STABILITY; fi
-  - if [[ "$ENABLE_CODE_COVERAGE" != "true" && "$TRAVIS_EVENT_TYPE" != "cron" ]]; then phpenv config-rm xdebug.ini || true; fi;
-  - if [[ "$ENABLE_CODE_COVERAGE" != "true" && "$TRAVIS_EVENT_TYPE" != "cron" ]]; then travis_retry composer require satooshi/php-coveralls:^1.0 --no-update $COMPOSER_FLAGS; fi;
+
+  - if [[ "$SYMFONY_VERSION" != "" ]]; then
+      travis_retry composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update $COMPOSER_FLAGS;
+    fi
+  - if [[ "$DEPENDENCIES" != "" ]]; then
+      travis_retry composer require $DEPENDENCIES --no-update $COMPOSER_FLAGS;
+    fi
+  - if [[ "$STABILITY" != "" ]]; then
+      travis_retry composer config minimum-stability $STABILITY;
+    fi
+  - if [[ "$ENABLE_CODE_COVERAGE" != "true" ]]; then
+      phpenv config-rm xdebug.ini || true;
+    fi
+  - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then
+      travis_retry composer require --dev satooshi/php-coveralls:^2.0@dev --no-update $COMPOSER_FLAGS;
+    fi
 
 install:
-  - travis_retry composer update  --prefer-dist --no-interaction --no-suggest --no-progress --ansi $COMPOSER_FLAGS $COMPOSER_UPDATE_OPTIONS
-  - if [[ "$ENABLE_CODE_COVERAGE" == "true" && "$TRAVIS_EVENT_TYPE" == "cron" ]]; then travis_retry composer require --dev satooshi/php-coveralls; fi
+
+  - travis_retry composer update --prefer-dist --no-interaction --no-suggest --no-progress --ansi $COMPOSER_FLAGS $COMPOSER_UPDATE_FLAGS
   - ./vendor/bin/simple-phpunit install
 
 script:
-  - if [[ "$ENABLE_CODE_COVERAGE" == "true" && "$TRAVIS_EVENT_TYPE" == "cron" ]]; then vendor/bin/simple-phpunit --coverage-text --coverage-clover build/logs/clover.xml; else vendor/bin/simple-phpunit -v; fi;
+
+  - ./vendor/bin/simple-phpunit $SIMPLE_PHPUNIT_FLAGS
 
 after_success:
-  - if [[ "$ENABLE_CODE_COVERAGE" == "true" && "$TRAVIS_EVENT_TYPE" == "cron" ]]; then php vendor/bin/coveralls -v --config .coveralls.yml; fi;
+
+  - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then
+      ./vendor/bin/php-coveralls -vvv --config .coveralls.yml;
+    fi;


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | `2.0`
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT

This PR cleans up the Travis configuration and upgrades and simplifies coveralls handling:
- Resolves @sebastianblum's comment about an incorrect conditional stopping code coverage from running properly in builds: https://github.com/liip/LiipImagineBundle/pull/1048#issuecomment-364778167
- Cleans up the Travis build configuration to be more readable
- Upgrades coveralls from `1.x` to `2.x`
- Removed double call to `composer install/upgrade`
- Removes all cron conditional checks

As for the last bullet point, was there a reason to include those @sebastianblum? They make the build script more confusing and AFAIK we don't use cron automated builds with this repository on Travis. Is there another reason to have them?