### PR TITLE
Update imagine.xml

### DIFF
--- a/Compat/ProcessBuilder.php
+++ b/Compat/ProcessBuilder.php
@@ -1,0 +1,244 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Liip\ImagineBundle\Compat;
+use Symfony\Component\Process\ProcessUtils;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\InvalidArgumentException;
+use Symfony\Component\Process\Exception\LogicException;
+//Compat layer for deprecated, removed later, ProcessBuilder
+/**
+ * Process builder compat for symfony >= 3.4
+ *
+ * @author Kris Wallsmith <kris@symfony.com>
+ *
+ * @deprecated since version 3.4, to be removed in 4.0. Use the Process class instead.
+ */
+class ProcessBuilder
+{
+    private $arguments;
+    private $cwd;
+    private $env = array();
+    private $input;
+    private $timeout = 60;
+    private $options;
+    private $inheritEnv = true;
+    private $prefix = array();
+    private $outputDisabled = false;
+    /**
+     * Constructor.
+     *
+     * @param string[] $arguments An array of arguments
+     */
+    public function __construct(array $arguments = array())
+    {
+        $this->arguments = $arguments;
+    }
+    /**
+     * Creates a process builder instance.
+     *
+     * @param string[] $arguments An array of arguments
+     *
+     * @return static
+     */
+    public static function create(array $arguments = array())
+    {
+        return new static($arguments);
+    }
+    /**
+     * Adds an unescaped argument to the command string.
+     *
+     * @param string $argument A command argument
+     *
+     * @return $this
+     */
+    public function add($argument)
+    {
+        $this->arguments[] = $argument;
+        return $this;
+    }
+    /**
+     * Adds a prefix to the command string.
+     *
+     * The prefix is preserved when resetting arguments.
+     *
+     * @param string|array $prefix A command prefix or an array of command prefixes
+     *
+     * @return $this
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = is_array($prefix) ? $prefix : array($prefix);
+        return $this;
+    }
+    /**
+     * Sets the arguments of the process.
+     *
+     * Arguments must not be escaped.
+     * Previous arguments are removed.
+     *
+     * @param string[] $arguments
+     *
+     * @return $this
+     */
+    public function setArguments(array $arguments)
+    {
+        $this->arguments = $arguments;
+        return $this;
+    }
+    /**
+     * Sets the working directory.
+     *
+     * @param null|string $cwd The working directory
+     *
+     * @return $this
+     */
+    public function setWorkingDirectory($cwd)
+    {
+        $this->cwd = $cwd;
+        return $this;
+    }
+    /**
+     * Sets whether environment variables will be inherited or not.
+     *
+     * @param bool $inheritEnv
+     *
+     * @return $this
+     */
+    public function inheritEnvironmentVariables($inheritEnv = true)
+    {
+        $this->inheritEnv = $inheritEnv;
+        return $this;
+    }
+    /**
+     * Sets an environment variable.
+     *
+     * Setting a variable overrides its previous value. Use `null` to unset a
+     * defined environment variable.
+     *
+     * @param string      $name  The variable name
+     * @param null|string $value The variable value
+     *
+     * @return $this
+     */
+    public function setEnv($name, $value)
+    {
+        $this->env[$name] = $value;
+        return $this;
+    }
+    /**
+     * Adds a set of environment variables.
+     *
+     * Already existing environment variables with the same name will be
+     * overridden by the new values passed to this method. Pass `null` to unset
+     * a variable.
+     *
+     * @param array $variables The variables
+     *
+     * @return $this
+     */
+    public function addEnvironmentVariables(array $variables)
+    {
+        $this->env = array_replace($this->env, $variables);
+        return $this;
+    }
+    /**
+     * Sets the input of the process.
+     *
+     * @param resource|scalar|\Traversable|null $input The input content
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException In case the argument is invalid
+     */
+    public function setInput($input)
+    {
+        $this->input = ProcessUtils::validateInput(__METHOD__, $input);
+        return $this;
+    }
+    /**
+     * Sets the process timeout.
+     *
+     * To disable the timeout, set this value to null.
+     *
+     * @param float|null $timeout
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setTimeout($timeout)
+    {
+        if (null === $timeout) {
+            $this->timeout = null;
+            return $this;
+        }
+        $timeout = (float) $timeout;
+        if ($timeout < 0) {
+            throw new InvalidArgumentException('The timeout value must be a valid positive integer or float number.');
+        }
+        $this->timeout = $timeout;
+        return $this;
+    }
+    /**
+     * Adds a proc_open option.
+     *
+     * @param string $name  The option name
+     * @param string $value The option value
+     *
+     * @return $this
+     */
+    public function setOption($name, $value)
+    {
+        $this->options[$name] = $value;
+        return $this;
+    }
+    /**
+     * Disables fetching output and error output from the underlying process.
+     *
+     * @return $this
+     */
+    public function disableOutput()
+    {
+        $this->outputDisabled = true;
+        return $this;
+    }
+    /**
+     * Enables fetching output and error output from the underlying process.
+     *
+     * @return $this
+     */
+    public function enableOutput()
+    {
+        $this->outputDisabled = false;
+        return $this;
+    }
+    /**
+     * Creates a Process instance and returns it.
+     *
+     * @return Process
+     *
+     * @throws LogicException In case no arguments have been provided
+     */
+    public function getProcess()
+    {
+        if (0 === count($this->prefix) && 0 === count($this->arguments)) {
+            throw new LogicException('You must add() command arguments before calling getProcess().');
+        }
+        $arguments = array_merge($this->prefix, $this->arguments);
+        $process = new Process($arguments, $this->cwd, $this->env, $this->input, $this->timeout, $this->options);
+        if ($this->inheritEnv) {
+            $process->inheritEnvironmentVariables();
+        }
+        if ($this->outputDisabled) {
+            $process->disableOutput();
+        }
+        return $process;
+    }
+}

--- a/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
@@ -13,9 +13,9 @@ namespace Liip\ImagineBundle\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Binary\FileBinaryInterface;
+use Liip\ImagineBundle\Compat\ProcessBuilder;
 use Liip\ImagineBundle\Model\Binary;
 use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\ProcessBuilder;
 
 class JpegOptimPostProcessor implements PostProcessorInterface, ConfigurablePostProcessorInterface
 {

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -263,7 +263,7 @@
 
         <!-- Data loader locators -->
 
-        <service id="liip_imagine.binary.locator.filesystem" class="%liip_imagine.binary.locator.filesystem.class%" public="false" public="true">
+        <service id="liip_imagine.binary.locator.filesystem" class="%liip_imagine.binary.locator.filesystem.class%" public="false">
             <argument><!-- will be injected by FileSystemLoaderFactory --></argument>
             <tag name="liip_imagine.binary.locator" shared="false" />
         </service>

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -101,13 +101,13 @@
     <services>
         <!-- Utility services -->
 
-        <service id="liip_imagine.filter.manager" class="%liip_imagine.filter.manager.class%">
+        <service id="liip_imagine.filter.manager" class="%liip_imagine.filter.manager.class%" public="true">
             <argument type="service" id="liip_imagine.filter.configuration" />
             <argument type="service" id="liip_imagine" />
             <argument type="service" id="liip_imagine.binary.mime_type_guesser" />
         </service>
 
-        <service id="liip_imagine.data.manager" class="%liip_imagine.data.manager.class%">
+        <service id="liip_imagine.data.manager" class="%liip_imagine.data.manager.class%" public="true">
             <argument type="service" id="liip_imagine.binary.mime_type_guesser" />
             <argument type="service" id="liip_imagine.extension_guesser" />
             <argument type="service" id="liip_imagine.filter.configuration" />
@@ -115,7 +115,7 @@
             <argument>%liip_imagine.default_image%</argument>
         </service>
 
-        <service id="liip_imagine.cache.manager" class="%liip_imagine.cache.manager.class%">
+        <service id="liip_imagine.cache.manager" class="%liip_imagine.cache.manager.class%" public="true">
             <argument type="service" id="liip_imagine.filter.configuration" />
             <argument type="service" id="router" />
             <argument type="service" id="liip_imagine.cache.signer" />
@@ -123,13 +123,13 @@
             <argument>%liip_imagine.cache.resolver.default%</argument>
         </service>
 
-        <service id="liip_imagine.filter.configuration" class="%liip_imagine.filter.configuration.class%">
+        <service id="liip_imagine.filter.configuration" class="%liip_imagine.filter.configuration.class%" public="true">
             <argument>%liip_imagine.filter_sets%</argument>
         </service>
 
         <!-- Controller -->
 
-        <service id="liip_imagine.controller" class="%liip_imagine.controller.class%">
+        <service id="liip_imagine.controller" class="%liip_imagine.controller.class%"  public="true">
             <argument type="service" id="liip_imagine.data.manager" />
             <argument type="service" id="liip_imagine.filter.manager" />
             <argument type="service" id="liip_imagine.cache.manager" />
@@ -142,7 +142,7 @@
 
         <!-- ImagineInterface instances -->
 
-        <service id="liip_imagine" alias="liip_imagine.gd" />
+        <service id="liip_imagine" alias="liip_imagine.gd" public="true" />
 
         <service id="liip_imagine.gd" class="%liip_imagine.gd.class%" public="false" />
 
@@ -157,113 +157,113 @@
             <argument type="service" id="liip_imagine.cache.manager" />
         </service>
 
-        <service id="liip_imagine.templating.helper" class="%liip_imagine.templating.helper.class%">
+        <service id="liip_imagine.templating.helper" class="%liip_imagine.templating.helper.class%" public="true">
             <tag name="templating.helper" alias="imagine" />
             <argument type="service" id="liip_imagine.cache.manager" />
         </service>
 
         <!-- Filter loaders -->
 
-        <service id="liip_imagine.filter.loader.relative_resize" class="%liip_imagine.filter.loader.relative_resize.class%">
+        <service id="liip_imagine.filter.loader.relative_resize" class="%liip_imagine.filter.loader.relative_resize.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="relative_resize" />
         </service>
 
-        <service id="liip_imagine.filter.loader.resize" class="%liip_imagine.filter.loader.resize.class%">
+        <service id="liip_imagine.filter.loader.resize" class="%liip_imagine.filter.loader.resize.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="resize" />
         </service>
 
-        <service id="liip_imagine.filter.loader.thumbnail" class="%liip_imagine.filter.loader.thumbnail.class%">
+        <service id="liip_imagine.filter.loader.thumbnail" class="%liip_imagine.filter.loader.thumbnail.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="thumbnail" />
         </service>
 
-        <service id="liip_imagine.filter.loader.crop" class="%liip_imagine.filter.loader.crop.class%">
+        <service id="liip_imagine.filter.loader.crop" class="%liip_imagine.filter.loader.crop.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="crop" />
         </service>
 
-        <service id="liip_imagine.filter.loader.grayscale" class="%liip_imagine.filter.loader.grayscale.class%">
+        <service id="liip_imagine.filter.loader.grayscale" class="%liip_imagine.filter.loader.grayscale.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="grayscale" />
         </service>
 
-        <service id="liip_imagine.filter.loader.paste" class="%liip_imagine.filter.loader.paste.class%">
+        <service id="liip_imagine.filter.loader.paste" class="%liip_imagine.filter.loader.paste.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="paste" />
             <argument type="service" id="liip_imagine" />
             <argument>%kernel.root_dir%</argument>
         </service>
 
-        <service id="liip_imagine.filter.loader.watermark" class="%liip_imagine.filter.loader.watermark.class%">
+        <service id="liip_imagine.filter.loader.watermark" class="%liip_imagine.filter.loader.watermark.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="watermark" />
             <argument type="service" id="liip_imagine" />
             <argument>%kernel.root_dir%</argument>
         </service>
 
-        <service id="liip_imagine.filter.loader.background" class="%liip_imagine.filter.loader.background.class%">
+        <service id="liip_imagine.filter.loader.background" class="%liip_imagine.filter.loader.background.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="background" />
             <argument type="service" id="liip_imagine" />
         </service>
 
-        <service id="liip_imagine.filter.loader.strip" class="%liip_imagine.filter.loader.strip.class%">
+        <service id="liip_imagine.filter.loader.strip" class="%liip_imagine.filter.loader.strip.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="strip" />
         </service>
 
-        <service id="liip_imagine.filter.loader.scale" class="%liip_imagine.filter.loader.scale.class%">
+        <service id="liip_imagine.filter.loader.scale" class="%liip_imagine.filter.loader.scale.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="scale" />
         </service>
 
-        <service id="liip_imagine.filter.loader.upscale" class="%liip_imagine.filter.loader.upscale.class%">
+        <service id="liip_imagine.filter.loader.upscale" class="%liip_imagine.filter.loader.upscale.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="upscale" />
         </service>
 
-        <service id="liip_imagine.filter.loader.downscale" class="%liip_imagine.filter.loader.downscale.class%">
+        <service id="liip_imagine.filter.loader.downscale" class="%liip_imagine.filter.loader.downscale.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="downscale" />
         </service>
 
-        <service id="liip_imagine.filter.loader.auto_rotate" class="%liip_imagine.filter.loader.auto_rotate.class%">
+        <service id="liip_imagine.filter.loader.auto_rotate" class="%liip_imagine.filter.loader.auto_rotate.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="auto_rotate" />
         </service>
 
-        <service id="liip_imagine.filter.loader.rotate" class="%liip_imagine.filter.loader.rotate.class%">
+        <service id="liip_imagine.filter.loader.rotate" class="%liip_imagine.filter.loader.rotate.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="rotate" />
         </service>
 
-        <service id="liip_imagine.filter.loader.flip" class="%liip_imagine.filter.loader.flip.class%">
+        <service id="liip_imagine.filter.loader.flip" class="%liip_imagine.filter.loader.flip.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="flip" />
         </service>
 
-        <service id="liip_imagine.filter.loader.interlace" class="%liip_imagine.filter.loader.interlace.class%">
+        <service id="liip_imagine.filter.loader.interlace" class="%liip_imagine.filter.loader.interlace.class%" public="true">
             <tag name="liip_imagine.filter.loader" loader="interlace" />
         </service>
 
-        <service id="liip_imagine.filter.loader.resample" class="%liip_imagine.filter.loader.resample.class%">
+        <service id="liip_imagine.filter.loader.resample" class="%liip_imagine.filter.loader.resample.class%" public="true">
             <argument type="service" id="liip_imagine" />
             <tag name="liip_imagine.filter.loader" loader="resample" />
         </service>
 
         <!-- Data loaders -->
 
-        <service id="liip_imagine.binary.loader.prototype.filesystem" class="%liip_imagine.binary.loader.filesystem.class%">
+        <service id="liip_imagine.binary.loader.prototype.filesystem" class="%liip_imagine.binary.loader.filesystem.class%" public="true">
             <argument type="service" id="liip_imagine.mime_type_guesser" />
             <argument type="service" id="liip_imagine.extension_guesser" />
             <argument><!-- will be injected by FileSystemLoaderFactory --></argument>
             <argument><!-- will be injected by FileSystemLoaderFactory --></argument>
         </service>
 
-        <service id="liip_imagine.binary.loader.prototype.stream" class="%liip_imagine.binary.loader.stream.class%">
+        <service id="liip_imagine.binary.loader.prototype.stream" class="%liip_imagine.binary.loader.stream.class%" public="true">
             <argument><!-- will be injected by StreamLoaderFactory --></argument>
             <argument><!-- will be injected by StreamLoaderFactory --></argument>
         </service>
 
-        <service id="liip_imagine.binary.loader.prototype.flysystem" class="%liip_imagine.binary.loader.flysystem.class%" abstract="true">
+        <service id="liip_imagine.binary.loader.prototype.flysystem" class="%liip_imagine.binary.loader.flysystem.class%" abstract="true" public="true">
             <argument type="service" id="liip_imagine.extension_guesser" />
             <argument><!-- will be injected by FlysystemLoaderFactory --></argument>
         </service>
 
-        <service id="liip_imagine.binary.loader.prototype.chain" class="%liip_imagine.binary.loader.chain.class%" abstract="true">
+        <service id="liip_imagine.binary.loader.prototype.chain" class="%liip_imagine.binary.loader.chain.class%" abstract="true" public="true">
             <argument><!-- will be injected by ChainLoaderFactory --></argument>
         </service>
 
         <!-- Data loader locators -->
 
-        <service id="liip_imagine.binary.locator.filesystem" class="%liip_imagine.binary.locator.filesystem.class%" public="false">
+        <service id="liip_imagine.binary.locator.filesystem" class="%liip_imagine.binary.locator.filesystem.class%" public="false" public="true">
             <argument><!-- will be injected by FileSystemLoaderFactory --></argument>
             <tag name="liip_imagine.binary.locator" shared="false" />
         </service>
@@ -315,7 +315,7 @@
 
         <!-- Form types -->
 
-        <service id="liip_imagine.form.type.image" class="%liip_imagine.form.type.image.class%">
+        <service id="liip_imagine.form.type.image" class="%liip_imagine.form.type.image.class%" public="true">
             <tag name="form.type" alias="liip_imagine_image" />
         </service>
 
@@ -324,23 +324,25 @@
         <service
             id="liip_imagine.mime_type_guesser"
             class="Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface"
+            public="true"
         />
 
         <service
             id="liip_imagine.extension_guesser"
             class="Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface"
+            public="true"
         />
 
-        <service id="liip_imagine.binary.mime_type_guesser" class="%liip_imagine.binary.mime_type_guesser.class%">
+        <service id="liip_imagine.binary.mime_type_guesser" class="%liip_imagine.binary.mime_type_guesser.class%" public="true">
             <argument type="service" id="liip_imagine.mime_type_guesser" />
         </service>
 
-        <service id="liip_imagine.cache.signer" class="%liip_imagine.cache.signer.class%">
+        <service id="liip_imagine.cache.signer" class="%liip_imagine.cache.signer.class%" public="true">
             <argument>%kernel.secret%</argument>
         </service>
 
         <!-- Post processors -->
-        <service id="liip_imagine.filter.post_processor.jpegoptim" class="%liip_imagine.filter.post_processor.jpegoptim.class%">
+        <service id="liip_imagine.filter.post_processor.jpegoptim" class="%liip_imagine.filter.post_processor.jpegoptim.class%" public="true">
             <argument>%liip_imagine.jpegoptim.binary%</argument>
             <argument>%liip_imagine.jpegoptim.stripAll%</argument>
             <argument>%liip_imagine.jpegoptim.max%</argument>
@@ -348,18 +350,18 @@
             <argument>%liip_imagine.jpegoptim.tempDir%</argument>
             <tag name="liip_imagine.filter.post_processor" post_processor="jpegoptim" />
         </service>
-        <service id="liip_imagine.filter.post_processor.optipng" class="%liip_imagine.filter.post_processor.optipng.class%">
+        <service id="liip_imagine.filter.post_processor.optipng" class="%liip_imagine.filter.post_processor.optipng.class%" public="true">
             <argument>%liip_imagine.optipng.binary%</argument>
             <argument>%liip_imagine.optipng.level%</argument>
             <argument>%liip_imagine.optipng.stripAll%</argument>
             <argument>%liip_imagine.optipng.tempDir%</argument>
             <tag name="liip_imagine.filter.post_processor" post_processor="optipng" />
         </service>
-        <service id="liip_imagine.filter.post_processor.pngquant" class="%liip_imagine.filter.post_processor.pngquant.class%">
+        <service id="liip_imagine.filter.post_processor.pngquant" class="%liip_imagine.filter.post_processor.pngquant.class%" public="true">
             <argument>%liip_imagine.pngquant.binary%</argument>
             <tag name="liip_imagine.filter.post_processor" post_processor="pngquant" />
         </service>
-        <service id="liip_imagine.filter.post_processor.mozjpeg" class="%liip_imagine.filter.post_processor.mozjpeg.class%">
+        <service id="liip_imagine.filter.post_processor.mozjpeg" class="%liip_imagine.filter.post_processor.mozjpeg.class%" public="true">
             <argument>%liip_imagine.mozjpeg.binary%</argument>
             <tag name="liip_imagine.filter.post_processor" post_processor="mozjpeg" />
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | hope so
| License | MIT

we are in the process to upgrade to symfony to 3.4 (and later on to 4.0).
we stumbled upon a few deprecations with this bundle. services are by default now `non-public`
this PR makes all "not already explicitly defined" services public. 


edit: it also fixes ProcessBuilder deprecation, for the sake of it, as it is not a really big deal, i just added the processbuilder locally, instead of a heavy refactor