### PR TITLE
[CI] [CS] Add a required php-cs-fixer build run to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,14 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-
 env:
 
   global:
     - SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
-    - COVERALLS_ENABLED="false"
     - PHPUNIT_FLAGS="-v"
     - PHPUNIT_ENABLED="true"
     - PHPCSFIXER_ENABLED="false"
+    - COVERALLS_ENABLED="false"
 
 matrix:
 
@@ -84,12 +83,10 @@ before_install:
       travis_retry composer require --dev satooshi/php-coveralls:^2.0@dev --no-update $COMPOSER_FLAGS;
     fi
 
-
 install:
 
   - travis_retry composer update --prefer-dist --no-interaction --no-suggest --no-progress --ansi $COMPOSER_FLAGS $COMPOSER_UPDATE_FLAGS
   - ./vendor/bin/simple-phpunit install
-
 
 script:
 
@@ -99,7 +96,6 @@ script:
   - if [[ "$PHPCSFIXER_ENABLED" == "true" ]]; then
       vendor/bin/php-cs-fixer --dry-run --diff -vvv fix;
     fi
-
 
 after_success:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ env:
 
   global:
     - SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
-    - ENABLE_CODE_COVERAGE="false"
-    - SIMPLE_PHPUNIT_FLAGS="-v"
-
+    - COVERALLS_ENABLED="false"
+    - PHPUNIT_FLAGS="-v"
+    - PHPUNIT_ENABLED="true"
+    - PHPCSFIXER_ENABLED="false"
 
 matrix:
 
@@ -23,6 +24,10 @@ matrix:
   include:
 
     - php: 7.1
+    - php: 7.1
+      env:
+        - PHPUNIT_ENABLED="false"
+        - PHPCSFIXER_ENABLED="true"
     - php: 7.1
       env:
         - SYMFONY_VERSION=4.0.*
@@ -39,8 +44,8 @@ matrix:
         - COMPOSER_UPDATE_FLAGS="--no-dev"
     - php: 7.2
       env:
-        - ENABLE_CODE_COVERAGE="true"
-        - SIMPLE_PHPUNIT_FLAGS="-v --coverage-text --coverage-clover var/build/clover.xml"
+        - COVERALLS_ENABLED="true"
+        - PHPUNIT_FLAGS="-v --coverage-text --coverage-clover var/build/clover.xml"
     - php: 7.2
       env:
         - SYMFONY_VERSION=dev-master
@@ -53,8 +58,8 @@ matrix:
   allow_failures:
 
     - env:
-        - ENABLE_CODE_COVERAGE="true"
-        - SIMPLE_PHPUNIT_FLAGS="-v --coverage-text --coverage-clover var/build/clover.xml"
+        - COVERALLS_ENABLED="true"
+        - PHPUNIT_FLAGS="-v --coverage-text --coverage-clover var/build/clover.xml"
     - env:
         - SYMFONY_VERSION=dev-master
         - STABILITY=dev
@@ -72,10 +77,10 @@ before_install:
   - if [[ "$STABILITY" != "" ]]; then
       travis_retry composer config minimum-stability $STABILITY;
     fi
-  - if [[ "$ENABLE_CODE_COVERAGE" != "true" ]]; then
+  - if [[ "$COVERALLS_ENABLED" != "true" ]]; then
       phpenv config-rm xdebug.ini || true;
     fi
-  - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then
+  - if [[ "$COVERALLS_ENABLED" == "true" ]]; then
       travis_retry composer require --dev satooshi/php-coveralls:^2.0@dev --no-update $COMPOSER_FLAGS;
     fi
 
@@ -88,11 +93,16 @@ install:
 
 script:
 
-  - ./vendor/bin/simple-phpunit $SIMPLE_PHPUNIT_FLAGS
+  - if [[ "$PHPUNIT_ENABLED" == "true" ]]; then
+      ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS;
+    fi
+  - if [[ "$PHPCSFIXER_ENABLED" == "true" ]]; then
+      vendor/bin/php-cs-fixer --dry-run --diff -vvv fix;
+    fi
 
 
 after_success:
 
-  - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then
+  - if [[ "$PHPUNIT_ENABLED" == "true" && "$COVERALLS_ENABLED" == "true" ]]; then
       ./vendor/bin/php-coveralls -vvv --config .coveralls.yml;
     fi;


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | `2.0`
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | no
| Fixed tickets | #1040 
| License | MIT
| Doc PR | 

This PR provides an implementation of #1049 that adds a *requires build* of `php-cs-fixer` to our Travis matrix, enforcing the new code style rules implemented in #1040.

__Blocked until #1058 is merged.__