### PR TITLE
[CS] Globally update code style using new php-cs-fixer rules

### DIFF
--- a/Async/ResolveCache.php
+++ b/Async/ResolveCache.php
@@ -88,7 +88,7 @@ class ResolveCache implements \JsonSerializable
             throw new LogicException('The message does not contain "path" but it is required.');
         }
 
-        if (!(is_null($data['filters']) || is_array($data['filters']))) {
+        if (!(null === $data['filters'] || is_array($data['filters']))) {
             throw new LogicException('The message filters could be either null or array.');
         }
 

--- a/Async/ResolveCacheProcessor.php
+++ b/Async/ResolveCacheProcessor.php
@@ -15,10 +15,10 @@ use Enqueue\Client\CommandSubscriberInterface;
 use Enqueue\Client\ProducerInterface;
 use Enqueue\Consumption\QueueSubscriberInterface;
 use Enqueue\Consumption\Result;
+use Enqueue\Util\JSON;
 use Interop\Queue\PsrContext;
 use Interop\Queue\PsrMessage;
 use Interop\Queue\PsrProcessor;
-use Enqueue\Util\JSON;
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
 use Liip\ImagineBundle\Service\FilterService;
 

--- a/Binary/Loader/AbstractDoctrineLoader.php
+++ b/Binary/Loader/AbstractDoctrineLoader.php
@@ -37,24 +37,6 @@ abstract class AbstractDoctrineLoader implements LoaderInterface
     }
 
     /**
-     * Map the requested path (ie. subpath in the URL) to an id that can be used to lookup the image in the Doctrine store.
-     *
-     * @param string $path
-     *
-     * @return string
-     */
-    abstract protected function mapPathToId($path);
-
-    /**
-     * Return a stream resource from the Doctrine entity/document with the image content.
-     *
-     * @param object $image
-     *
-     * @return resource
-     */
-    abstract protected function getStreamFromImage($image);
-
-    /**
      * {@inheritdoc}
      */
     public function find($path)
@@ -75,4 +57,22 @@ abstract class AbstractDoctrineLoader implements LoaderInterface
 
         return stream_get_contents($this->getStreamFromImage($image));
     }
+
+    /**
+     * Map the requested path (ie. subpath in the URL) to an id that can be used to lookup the image in the Doctrine store.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    abstract protected function mapPathToId($path);
+
+    /**
+     * Return a stream resource from the Doctrine entity/document with the image content.
+     *
+     * @param object $image
+     *
+     * @return resource
+     */
+    abstract protected function getStreamFromImage($image);
 }

--- a/Binary/Loader/FlysystemLoader.php
+++ b/Binary/Loader/FlysystemLoader.php
@@ -41,7 +41,7 @@ class FlysystemLoader implements LoaderInterface
      */
     public function find($path)
     {
-        if ($this->filesystem->has($path) === false) {
+        if (false === $this->filesystem->has($path)) {
             throw new NotLoadableException(sprintf('Source image "%s" not found.', $path));
         }
 

--- a/Binary/Locator/FileSystemInsecureLocator.php
+++ b/Binary/Locator/FileSystemInsecureLocator.php
@@ -21,8 +21,8 @@ class FileSystemInsecureLocator extends FileSystemLocator
      */
     protected function generateAbsolutePath($root, $path)
     {
-        if (false !== strpos($path, '..'.DIRECTORY_SEPARATOR) ||
-            false !== strpos($path, DIRECTORY_SEPARATOR.'..') ||
+        if (false !== mb_strpos($path, '..'.DIRECTORY_SEPARATOR) ||
+            false !== mb_strpos($path, DIRECTORY_SEPARATOR.'..') ||
             false === file_exists($absolute = $root.DIRECTORY_SEPARATOR.$path)) {
             return false;
         }

--- a/Binary/Locator/FileSystemLocator.php
+++ b/Binary/Locator/FileSystemLocator.php
@@ -62,6 +62,17 @@ class FileSystemLocator implements LocatorInterface
     }
 
     /**
+     * @param string $root
+     * @param string $path
+     *
+     * @return string|false
+     */
+    protected function generateAbsolutePath($root, $path)
+    {
+        return realpath($root.DIRECTORY_SEPARATOR.$path);
+    }
+
+    /**
      * @param string $path
      *
      * @return bool|string
@@ -84,7 +95,7 @@ class FileSystemLocator implements LocatorInterface
      */
     private function locateUsingRootPlaceholder($path)
     {
-        if (0 !== strpos($path, '@') || 1 !== preg_match('{@(?<name>[^:]+):(?<path>.+)}', $path, $matches)) {
+        if (0 !== mb_strpos($path, '@') || 1 !== preg_match('{@(?<name>[^:]+):(?<path>.+)}', $path, $matches)) {
             return false;
         }
 
@@ -94,17 +105,6 @@ class FileSystemLocator implements LocatorInterface
 
         throw new NotLoadableException(sprintf('Invalid root placeholder "%s" for path "%s"',
             $matches['name'], $matches['path']));
-    }
-
-    /**
-     * @param string $root
-     * @param string $path
-     *
-     * @return string|false
-     */
-    protected function generateAbsolutePath($root, $path)
-    {
-        return realpath($root.DIRECTORY_SEPARATOR.$path);
     }
 
     /**
@@ -133,7 +133,7 @@ class FileSystemLocator implements LocatorInterface
     private function sanitizeAbsolutePath($path)
     {
         foreach ($this->roots as $root) {
-            if (0 === strpos($path, $root)) {
+            if (0 === mb_strpos($path, $root)) {
                 return $path;
             }
         }

--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -75,7 +75,7 @@ class ImagineController
         try {
             return new RedirectResponse($this->filterService->getUrlOfFilteredImage($path, $filter, $resolver), 301);
         } catch (NotLoadableException $e) {
-            if ($this->dataManager->getDefaultImageUrl($filter) !== null) {
+            if (null !== $this->dataManager->getDefaultImageUrl($filter)) {
                 return new RedirectResponse($this->dataManager->getDefaultImageUrl($filter));
             }
 
@@ -126,7 +126,7 @@ class ImagineController
         try {
             return new RedirectResponse($this->filterService->getUrlOfFilteredImageWithRuntimeFilters($path, $filter, $runtimeConfig, $resolver), 301);
         } catch (NotLoadableException $e) {
-            if ($this->dataManager->getDefaultImageUrl($filter) !== null) {
+            if (null !== $this->dataManager->getDefaultImageUrl($filter)) {
                 return new RedirectResponse($this->dataManager->getDefaultImageUrl($filter));
             }
 

--- a/DependencyInjection/Compiler/MetadataReaderCompilerPass.php
+++ b/DependencyInjection/Compiler/MetadataReaderCompilerPass.php
@@ -49,6 +49,14 @@ class MetadataReaderCompilerPass extends AbstractCompilerPass
     }
 
     /**
+     * @return bool
+     */
+    protected function isExifExtensionLoaded(): bool
+    {
+        return extension_loaded('exif');
+    }
+
+    /**
      * @param ContainerBuilder $container
      *
      * @return bool
@@ -56,13 +64,5 @@ class MetadataReaderCompilerPass extends AbstractCompilerPass
     private function isExifMetadataReaderSet(ContainerBuilder $container): bool
     {
         return $container->getDefinition(self::$metadataReaderServiceId)->getClass() === self::$metadataReaderExifClass;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function isExifExtensionLoaded(): bool
-    {
-        return extension_loaded('exif');
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -52,16 +52,14 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('resolvers')
                     ->useAttributeAsKey('name')
                     ->prototype('array')
-                        ->performNoDeepMerging()
-        ;
+                        ->performNoDeepMerging();
         $this->addResolversSections($resolversPrototypeNode);
 
         $loadersPrototypeNode = $rootNode
             ->children()
                 ->arrayNode('loaders')
                     ->useAttributeAsKey('name')
-                    ->prototype('array')
-        ;
+                    ->prototype('array');
         $this->addLoadersSections($loadersPrototypeNode);
 
         $rootNode
@@ -71,19 +69,18 @@ class Configuration implements ConfigurationInterface
                         empty($v['loaders']) ||
                         empty($v['loaders']['default']) ||
                         empty($v['resolvers']) ||
-                        empty($v['resolvers']['default'])
-                    ;
+                        empty($v['resolvers']['default']);
                 })
                 ->then(function ($v) {
                     if (empty($v['loaders'])) {
                         $v['loaders'] = [];
                     }
 
-                    if (false == is_array($v['loaders'])) {
+                    if (false === is_array($v['loaders'])) {
                         throw new \LogicException('Loaders has to be array');
                     }
 
-                    if (false == array_key_exists('default', $v['loaders'])) {
+                    if (false === array_key_exists('default', $v['loaders'])) {
                         $v['loaders']['default'] = ['filesystem' => null];
                     }
 
@@ -91,18 +88,17 @@ class Configuration implements ConfigurationInterface
                         $v['resolvers'] = [];
                     }
 
-                    if (false == is_array($v['resolvers'])) {
+                    if (false === is_array($v['resolvers'])) {
                         throw new \LogicException('Resolvers has to be array');
                     }
 
-                    if (false == array_key_exists('default', $v['resolvers'])) {
+                    if (false === array_key_exists('default', $v['resolvers'])) {
                         $v['resolvers']['default'] = ['web_path' => null];
                     }
 
                     return $v;
                 })
-            ->end()
-        ;
+            ->end();
 
         $rootNode
             ->fixXmlConfig('filter_set', 'filter_sets')
@@ -110,7 +106,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('driver')->defaultValue('gd')
                     ->validate()
                         ->ifTrue(function ($v) {
-                            return !in_array($v, ['gd', 'imagick', 'gmagick']);
+                            return !in_array($v, ['gd', 'imagick', 'gmagick'], true);
                         })
                         ->thenInvalid('Invalid imagine driver specified: %s')
                     ->end()

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -55,7 +55,7 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
                     ->beforeNormalization()
                     ->ifString()
                         ->then(function ($value) {
-                            return array($value);
+                            return [$value];
                         })
                     ->end()
                     ->treatNullLike([])
@@ -103,7 +103,7 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
         $resourcePaths = [];
 
         foreach ($this->getBundleResourcePaths($container) as $name => $path) {
-            if (('whitelist' === $config['access_control_type']) === in_array($name, $config['access_control_list']) && is_dir($path)) {
+            if (('whitelist' === $config['access_control_type']) === in_array($name, $config['access_control_list'], true) && is_dir($path)) {
                 $resourcePaths[$name] = $path;
             }
         }

--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -92,40 +92,6 @@ class CacheManager
     }
 
     /**
-     * Gets a resolver for the given filter.
-     *
-     * In case there is no specific resolver, but a default resolver has been configured, the default will be returned.
-     *
-     * @param string $filter
-     * @param string $resolver
-     *
-     * @throws \OutOfBoundsException If neither a specific nor a default resolver is available
-     *
-     * @return ResolverInterface
-     */
-    protected function getResolver($filter, $resolver)
-    {
-        // BC
-        if (!$resolver) {
-            $config = $this->filterConfig->get($filter);
-
-            $resolverName = empty($config['cache']) ? $this->defaultResolver : $config['cache'];
-        } else {
-            $resolverName = $resolver;
-        }
-
-        if (!isset($this->resolvers[$resolverName])) {
-            throw new \OutOfBoundsException(sprintf(
-                'Could not find resolver "%s" for "%s" filter type',
-                $resolverName,
-                $filter
-            ));
-        }
-
-        return $this->resolvers[$resolverName];
-    }
-
-    /**
      * Gets filtered path for rendering in the browser.
      * It could be the cached one or an url of filter action.
      *
@@ -143,14 +109,12 @@ class CacheManager
 
             return $this->isStored($rcPath, $filter, $resolver) ?
                 $this->resolve($rcPath, $filter, $resolver) :
-                $this->generateUrl($path, $filter, $runtimeConfig, $resolver)
-            ;
+                $this->generateUrl($path, $filter, $runtimeConfig, $resolver);
         }
 
         return $this->isStored($path, $filter, $resolver) ?
             $this->resolve($path, $filter, $resolver) :
-            $this->generateUrl($path, $filter, [], $resolver)
-        ;
+            $this->generateUrl($path, $filter, [], $resolver);
     }
 
     /**
@@ -226,7 +190,7 @@ class CacheManager
      */
     public function resolve($path, $filter, $resolver = null)
     {
-        if (false !== strpos($path, '/../') || 0 === strpos($path, '../')) {
+        if (false !== mb_strpos($path, '/../') || 0 === mb_strpos($path, '../')) {
             throw new NotFoundHttpException(sprintf("Source image was searched with '%s' outside of the defined root path", $path));
         }
 
@@ -286,5 +250,39 @@ class CacheManager
         foreach ($mapping as $resolver) {
             $resolver->remove($paths, $mapping[$resolver]);
         }
+    }
+
+    /**
+     * Gets a resolver for the given filter.
+     *
+     * In case there is no specific resolver, but a default resolver has been configured, the default will be returned.
+     *
+     * @param string $filter
+     * @param string $resolver
+     *
+     * @throws \OutOfBoundsException If neither a specific nor a default resolver is available
+     *
+     * @return ResolverInterface
+     */
+    protected function getResolver($filter, $resolver)
+    {
+        // BC
+        if (!$resolver) {
+            $config = $this->filterConfig->get($filter);
+
+            $resolverName = empty($config['cache']) ? $this->defaultResolver : $config['cache'];
+        } else {
+            $resolverName = $resolver;
+        }
+
+        if (!isset($this->resolvers[$resolverName])) {
+            throw new \OutOfBoundsException(sprintf(
+                'Could not find resolver "%s" for "%s" filter type',
+                $resolverName,
+                $filter
+            ));
+        }
+
+        return $this->resolvers[$resolverName];
     }
 }

--- a/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
+++ b/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
@@ -21,11 +21,6 @@ use Symfony\Component\HttpFoundation\Request;
 abstract class AbstractFilesystemResolver implements ResolverInterface, CacheManagerAwareInterface
 {
     /**
-     * @var Request
-     */
-    private $request;
-
-    /**
      * @var Filesystem
      */
     protected $filesystem;
@@ -44,6 +39,10 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
      * @var int
      */
     protected $folderPermissions = 0777;
+    /**
+     * @var Request
+     */
+    private $request;
 
     /**
      * Constructs a filesystem based cache resolver.
@@ -121,7 +120,7 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
         }
 
         // TODO: this logic has to be refactored.
-        list($rootCachePath) = explode(current($filters), $this->getFilePath('whateverpath', current($filters)));
+        [$rootCachePath] = explode(current($filters), $this->getFilePath('whateverpath', current($filters)));
 
         if (empty($paths)) {
             $filtersCachePaths = [];
@@ -151,7 +150,7 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
      */
     protected function getRequest()
     {
-        if (false == $this->request) {
+        if (false === $this->request) {
             throw new \LogicException('The request was not injected, inject it before using resolver.');
         }
 

--- a/Imagine/Cache/Resolver/AmazonS3Resolver.php
+++ b/Imagine/Cache/Resolver/AmazonS3Resolver.php
@@ -92,7 +92,7 @@ class AmazonS3Resolver implements ResolverInterface
         $storageResponse = $this->storage->create_object($this->bucket, $objectPath, [
             'body' => $binary->getContent(),
             'contentType' => $binary->getMimeType(),
-            'length' => strlen($binary->getContent()),
+            'length' => mb_strlen($binary->getContent()),
             'acl' => $this->acl,
         ]);
 

--- a/Imagine/Cache/Resolver/CacheResolver.php
+++ b/Imagine/Cache/Resolver/CacheResolver.php
@@ -70,8 +70,7 @@ class CacheResolver implements ResolverInterface
 
         return
             $this->cache->contains($cacheKey) ||
-            $this->resolver->isStored($path, $filter)
-        ;
+            $this->resolver->isStored($path, $filter);
     }
 
     /**
@@ -117,36 +116,6 @@ class CacheResolver implements ResolverInterface
         }
     }
 
-    protected function removePathAndFilter($path, $filter)
-    {
-        $indexKey = $this->generateIndexKey($this->generateCacheKey($path, $filter));
-        if (!$this->cache->contains($indexKey)) {
-            return;
-        }
-
-        $index = $this->cache->fetch($indexKey);
-
-        if (null === $path) {
-            foreach ($index as $eachCacheKey) {
-                $this->cache->delete($eachCacheKey);
-            }
-
-            $index = [];
-        } else {
-            $cacheKey = $this->generateCacheKey($path, $filter);
-            if (false !== $indexIndex = array_search($cacheKey, $index)) {
-                unset($index[$indexIndex]);
-                $this->cache->delete($cacheKey);
-            }
-        }
-
-        if (empty($index)) {
-            $this->cache->delete($indexKey);
-        } else {
-            $this->cache->save($indexKey, $index);
-        }
-    }
-
     /**
      * Generate a unique cache key based on the given parameters.
      *
@@ -165,6 +134,36 @@ class CacheResolver implements ResolverInterface
             $this->sanitizeCacheKeyPart($filter),
             $this->sanitizeCacheKeyPart($path),
         ]);
+    }
+
+    protected function removePathAndFilter($path, $filter)
+    {
+        $indexKey = $this->generateIndexKey($this->generateCacheKey($path, $filter));
+        if (!$this->cache->contains($indexKey)) {
+            return;
+        }
+
+        $index = $this->cache->fetch($indexKey);
+
+        if (null === $path) {
+            foreach ($index as $eachCacheKey) {
+                $this->cache->delete($eachCacheKey);
+            }
+
+            $index = [];
+        } else {
+            $cacheKey = $this->generateCacheKey($path, $filter);
+            if (false !== $indexIndex = array_search($cacheKey, $index, true)) {
+                unset($index[$indexIndex]);
+                $this->cache->delete($cacheKey);
+            }
+        }
+
+        if (empty($index)) {
+            $this->cache->delete($indexKey);
+        } else {
+            $this->cache->save($indexKey, $index);
+        }
     }
 
     /**
@@ -213,7 +212,7 @@ class CacheResolver implements ResolverInterface
         if ($this->cache->contains($indexKey)) {
             $index = (array) $this->cache->fetch($indexKey);
 
-            if (!in_array($cacheKey, $index)) {
+            if (!in_array($cacheKey, $index, true)) {
                 $index[] = $cacheKey;
             }
         } else {

--- a/Imagine/Cache/Resolver/FlysystemResolver.php
+++ b/Imagine/Cache/Resolver/FlysystemResolver.php
@@ -92,25 +92,6 @@ class FlysystemResolver implements ResolverInterface
     }
 
     /**
-     * {@inheritdoc}
-     */
-    protected function getFilePath($path, $filter)
-    {
-        return $this->getFileUrl($path, $filter);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFileUrl($path, $filter)
-    {
-        // crude way of sanitizing URL scheme ("protocol") part
-        $path = str_replace('://', '---', $path);
-
-        return $this->cachePrefix.'/'.$filter.'/'.ltrim($path, '/');
-    }
-
-    /**
      * Resolves filtered path for rendering in the browser.
      *
      * @param string $path   The path where the original file is expected to be
@@ -171,5 +152,24 @@ class FlysystemResolver implements ResolverInterface
                 }
             }
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFilePath($path, $filter)
+    {
+        return $this->getFileUrl($path, $filter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFileUrl($path, $filter)
+    {
+        // crude way of sanitizing URL scheme ("protocol") part
+        $path = str_replace('://', '---', $path);
+
+        return $this->cachePrefix.'/'.$filter.'/'.ltrim($path, '/');
     }
 }

--- a/Imagine/Cache/Resolver/ProxyResolver.php
+++ b/Imagine/Cache/Resolver/ProxyResolver.php
@@ -95,8 +95,8 @@ class ProxyResolver implements ResolverInterface
             return str_replace($host, $proxyHost, $url);
         }
 
-        if (0 === strpos($randKey, 'regexp/')) {
-            $regExp = substr($randKey, 6);
+        if (0 === mb_strpos($randKey, 'regexp/')) {
+            $regExp = mb_substr($randKey, 6);
 
             return preg_replace($regExp, $this->hosts[$randKey], $url);
         }

--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -144,16 +144,16 @@ class WebPathResolver implements ResolverInterface
     protected function getBaseUrl()
     {
         $port = '';
-        if ('https' == $this->requestContext->getScheme() && $this->requestContext->getHttpsPort() != 443) {
+        if ('https' === $this->requestContext->getScheme() && 443 !== $this->requestContext->getHttpsPort()) {
             $port = ":{$this->requestContext->getHttpsPort()}";
         }
 
-        if ('http' == $this->requestContext->getScheme() && $this->requestContext->getHttpPort() != 80) {
+        if ('http' === $this->requestContext->getScheme() && 80 !== $this->requestContext->getHttpPort()) {
             $port = ":{$this->requestContext->getHttpPort()}";
         }
 
         $baseUrl = $this->requestContext->getBaseUrl();
-        if ('.php' == substr($this->requestContext->getBaseUrl(), -4)) {
+        if ('.php' === mb_substr($this->requestContext->getBaseUrl(), -4)) {
             $baseUrl = pathinfo($this->requestContext->getBaseurl(), PATHINFO_DIRNAME);
         }
         $baseUrl = rtrim($baseUrl, '/\\');

--- a/Imagine/Cache/Signer.php
+++ b/Imagine/Cache/Signer.php
@@ -37,7 +37,7 @@ class Signer implements SignerInterface
             });
         }
 
-        return substr(preg_replace('/[^a-zA-Z0-9-_]/', '', base64_encode(hash_hmac('sha256', ltrim($path, '/').(null === $runtimeConfig ?: serialize($runtimeConfig)), $this->secret, true))), 0, 8);
+        return mb_substr(preg_replace('/[^a-zA-Z0-9-_]/', '', base64_encode(hash_hmac('sha256', ltrim($path, '/').(null === $runtimeConfig ?: serialize($runtimeConfig)), $this->secret, true))), 0, 8);
     }
 
     /**

--- a/Imagine/Data/DataManager.php
+++ b/Imagine/Data/DataManager.php
@@ -137,7 +137,7 @@ class DataManager
             throw new \LogicException(sprintf('The mime type of image %s was not guessed.', $path));
         }
 
-        if (0 !== strpos($binary->getMimeType(), 'image/')) {
+        if (0 !== mb_strpos($binary->getMimeType(), 'image/')) {
             throw new \LogicException(sprintf('The mime type of image %s must be image/xxx got %s.', $path, $binary->getMimeType()));
         }
 
@@ -156,7 +156,7 @@ class DataManager
         $config = $this->filterConfig->get($filter);
 
         $defaultImage = null;
-        if (false == empty($config['default_image'])) {
+        if (false === empty($config['default_image'])) {
             $defaultImage = $config['default_image'];
         } elseif (!empty($this->globalDefaultImage)) {
             $defaultImage = $this->globalDefaultImage;

--- a/Imagine/Filter/FilterManager.php
+++ b/Imagine/Filter/FilterManager.php
@@ -145,7 +145,7 @@ class FilterManager
             $options['png_compression_filter'] = $config['png_compression_filter'];
         }
 
-        if ($binary->getFormat() === 'gif' && $config['animated']) {
+        if ('gif' === $binary->getFormat() && $config['animated']) {
             $options['animated'] = $config['animated'];
         }
 

--- a/Imagine/Filter/Loader/AutoRotateFilterLoader.php
+++ b/Imagine/Filter/Loader/AutoRotateFilterLoader.php
@@ -37,7 +37,7 @@ class AutoRotateFilterLoader implements LoaderInterface
 
             // Rotates if necessary.
             $degree = $this->calculateRotation($orientation);
-            if ($degree !== 0) {
+            if (0 !== $degree) {
                 $image->rotate($degree);
             }
 
@@ -88,7 +88,7 @@ class AutoRotateFilterLoader implements LoaderInterface
             if ($orientation) {
                 $image->metadata()->offsetSet($orientationKey, '1');
 
-                return intval($orientation);
+                return (int) $orientation;
             }
         }
 
@@ -104,6 +104,6 @@ class AutoRotateFilterLoader implements LoaderInterface
      */
     private function isFlipped($orientation)
     {
-        return in_array((int) $orientation, [2, 4, 5, 7]);
+        return in_array((int) $orientation, [2, 4, 5, 7], true);
     }
 }

--- a/Imagine/Filter/Loader/FlipFilterLoader.php
+++ b/Imagine/Filter/Loader/FlipFilterLoader.php
@@ -13,8 +13,8 @@ namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Image\ImageInterface;
 use Liip\ImagineBundle\Exception\InvalidArgumentException;
-use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FlipFilterLoader implements LoaderInterface
@@ -29,7 +29,7 @@ class FlipFilterLoader implements LoaderInterface
     {
         $options = $this->sanitizeOptions($options);
 
-        return $options['axis'] === 'x' ? $image->flipHorizontally() : $image->flipVertically();
+        return 'x' === $options['axis'] ? $image->flipHorizontally() : $image->flipVertically();
     }
 
     /**
@@ -43,7 +43,7 @@ class FlipFilterLoader implements LoaderInterface
         $resolver->setDefault('axis', 'x');
         $resolver->setAllowedValues('axis', ['x', 'horizontal', 'y', 'vertical']);
         $resolver->setNormalizer('axis', function (Options $options, $value) {
-            return $value === 'horizontal' ? 'x' : ($value === 'vertical' ? 'y' : $value);
+            return 'horizontal' === $value ? 'x' : ('vertical' === $value ? 'y' : $value);
         });
 
         try {

--- a/Imagine/Filter/Loader/ScaleFilterLoader.php
+++ b/Imagine/Filter/Loader/ScaleFilterLoader.php
@@ -68,7 +68,7 @@ class ScaleFilterLoader implements LoaderInterface
             $widthRatio = $width / $origWidth;
             $heightRatio = $height / $origHeight;
 
-            if (null == $width || null == $height) {
+            if (null === $width || null === $height) {
                 $ratio = max($widthRatio, $heightRatio);
             } else {
                 $ratio = ('min' === $this->dimensionKey) ? max($widthRatio, $heightRatio) : min($widthRatio, $heightRatio);

--- a/Imagine/Filter/Loader/ThumbnailFilterLoader.php
+++ b/Imagine/Filter/Loader/ThumbnailFilterLoader.php
@@ -28,7 +28,7 @@ class ThumbnailFilterLoader implements LoaderInterface
         }
 
         if (!empty($options['filter'])) {
-            $filter = constant('Imagine\Image\ImageInterface::FILTER_'.strtoupper($options['filter']));
+            $filter = constant('Imagine\Image\ImageInterface::FILTER_'.mb_strtoupper($options['filter']));
         }
         if (empty($filter)) {
             $filter = ImageInterface::FILTER_UNDEFINED;

--- a/Imagine/Filter/Loader/WatermarkFilterLoader.php
+++ b/Imagine/Filter/Loader/WatermarkFilterLoader.php
@@ -49,8 +49,8 @@ class WatermarkFilterLoader implements LoaderInterface
             'position' => 'center',
         ];
 
-        if (substr($options['size'], -1) == '%') {
-            $options['size'] = substr($options['size'], 0, -1) / 100;
+        if ('%' === mb_substr($options['size'], -1)) {
+            $options['size'] = mb_substr($options['size'], 0, -1) / 100;
         }
 
         $watermark = $this->imagine->open($this->rootPath.'/'.$options['image']);

--- a/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
@@ -131,8 +131,8 @@ class JpegOptimPostProcessor implements PostProcessorInterface, ConfigurablePost
      */
     public function processWithConfiguration(BinaryInterface $binary, array $options)
     {
-        $type = strtolower($binary->getMimeType());
-        if (!in_array($type, ['image/jpeg', 'image/jpg'])) {
+        $type = mb_strtolower($binary->getMimeType());
+        if (!in_array($type, ['image/jpeg', 'image/jpg'], true)) {
             return $binary;
         }
 
@@ -145,19 +145,19 @@ class JpegOptimPostProcessor implements PostProcessorInterface, ConfigurablePost
 
         $stripAll = array_key_exists('strip_all', $options) ? $options['strip_all'] : $this->stripAll;
         if ($stripAll) {
-            $processArguments[] =  '--strip-all';
+            $processArguments[] = '--strip-all';
         }
 
         $max = array_key_exists('max', $options) ? $options['max'] : $this->max;
         if ($max) {
-            $processArguments[] =  '--max='.$max;
+            $processArguments[] = '--max='.$max;
         }
 
         $progressive = array_key_exists('progressive', $options) ? $options['progressive'] : $this->progressive;
         if ($progressive) {
-            $processArguments[] =  '--all-progressive';
+            $processArguments[] = '--all-progressive';
         } else {
-            $processArguments[] =  '--all-normal';
+            $processArguments[] = '--all-normal';
         }
 
         $processArguments[] = $input;
@@ -170,7 +170,7 @@ class JpegOptimPostProcessor implements PostProcessorInterface, ConfigurablePost
         $proc = new Process($processArguments);
         $proc->run();
 
-        if (false !== strpos($proc->getOutput(), 'ERROR') || 0 !== $proc->getExitCode()) {
+        if (false !== mb_strpos($proc->getOutput(), 'ERROR') || 0 !== $proc->getExitCode()) {
             unlink($input);
             throw new ProcessFailedException($proc);
         }

--- a/Imagine/Filter/PostProcessor/MozJpegPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/MozJpegPostProcessor.php
@@ -80,31 +80,31 @@ class MozJpegPostProcessor implements PostProcessorInterface, ConfigurablePostPr
      */
     public function processWithConfiguration(BinaryInterface $binary, array $options)
     {
-        $type = strtolower($binary->getMimeType());
-        if (!in_array($type, ['image/jpeg', 'image/jpg'])) {
+        $type = mb_strtolower($binary->getMimeType());
+        if (!in_array($type, ['image/jpeg', 'image/jpg'], true)) {
             return $binary;
         }
 
         $processArguments = [$this->mozjpegBin];
 
         // Places emphasis on DC
-        $processArguments[] =  '-quant-table';
-        $processArguments[] =  2;
+        $processArguments[] = '-quant-table';
+        $processArguments[] = 2;
 
         $transformQuality = array_key_exists('quality', $options) ? $options['quality'] : $this->quality;
-        if ($transformQuality !== null) {
-            $processArguments[] =  '-quality';
-            $processArguments[] =  $transformQuality;
+        if (null !== $transformQuality) {
+            $processArguments[] = '-quality';
+            $processArguments[] = $transformQuality;
         }
 
-        $processArguments[] =  '-optimise';
+        $processArguments[] = '-optimise';
 
         // Favor stdin/stdout so we don't waste time creating a new file.
         $proc = new Process($processArguments);
         $proc->setInput($binary->getContent());
         $proc->run();
 
-        if (false !== strpos($proc->getOutput(), 'ERROR') || 0 !== $proc->getExitCode()) {
+        if (false !== mb_strpos($proc->getOutput(), 'ERROR') || 0 !== $proc->getExitCode()) {
             throw new ProcessFailedException($proc);
         }
 

--- a/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
@@ -83,8 +83,8 @@ class OptiPngPostProcessor implements PostProcessorInterface, ConfigurablePostPr
      */
     public function processWithConfiguration(BinaryInterface $binary, array $options)
     {
-        $type = strtolower($binary->getMimeType());
-        if (!in_array($type, ['image/png'])) {
+        $type = mb_strtolower($binary->getMimeType());
+        if (!in_array($type, ['image/png'], true)) {
             return $binary;
         }
 
@@ -96,16 +96,16 @@ class OptiPngPostProcessor implements PostProcessorInterface, ConfigurablePostPr
         $processArguments = [$this->optipngBin];
 
         $level = array_key_exists('level', $options) ? $options['level'] : $this->level;
-        if ($level !== null) {
-            $processArguments[] =  sprintf('--o%d', $level);
+        if (null !== $level) {
+            $processArguments[] = sprintf('--o%d', $level);
         }
 
         $stripAll = array_key_exists('strip_all', $options) ? $options['strip_all'] : $this->stripAll;
         if ($stripAll) {
-            $processArguments[] =  '--strip=all';
+            $processArguments[] = '--strip=all';
         }
 
-        $processArguments[] =  $input;
+        $processArguments[] = $input;
 
         if ($binary instanceof FileBinaryInterface) {
             copy($binary->getPath(), $input);
@@ -116,7 +116,7 @@ class OptiPngPostProcessor implements PostProcessorInterface, ConfigurablePostPr
         $proc = new Process($processArguments);
         $proc->run();
 
-        if (false !== strpos($proc->getOutput(), 'ERROR') || 0 !== $proc->getExitCode()) {
+        if (false !== mb_strpos($proc->getOutput(), 'ERROR') || 0 !== $proc->getExitCode()) {
             unlink($input);
             throw new ProcessFailedException($proc);
         }

--- a/Imagine/Filter/PostProcessor/PngquantPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/PngquantPostProcessor.php
@@ -79,8 +79,8 @@ class PngquantPostProcessor implements PostProcessorInterface, ConfigurablePostP
      */
     public function processWithConfiguration(BinaryInterface $binary, array $options)
     {
-        $type = strtolower($binary->getMimeType());
-        if (!in_array($type, ['image/png'])) {
+        $type = mb_strtolower($binary->getMimeType());
+        if (!in_array($type, ['image/png'], true)) {
             return $binary;
         }
 
@@ -88,17 +88,17 @@ class PngquantPostProcessor implements PostProcessorInterface, ConfigurablePostP
 
         // Specify quality.
         $tranformQuality = array_key_exists('quality', $options) ? $options['quality'] : $this->quality;
-        $processArguments[] =  '--quality';
-        $processArguments[] =  $tranformQuality;
+        $processArguments[] = '--quality';
+        $processArguments[] = $tranformQuality;
 
         // Read to/from stdout to save resources.
-        $processArguments[] =  '-';
+        $processArguments[] = '-';
         $proc = new Process($processArguments);
         $proc->setInput($binary->getContent());
         $proc->run();
 
         // 98 and 99 are "quality too low" to compress current current image which, while isn't ideal, is not a failure
-        if (!in_array($proc->getExitCode(), [0, 98, 99])) {
+        if (!in_array($proc->getExitCode(), [0, 98, 99], true)) {
             throw new ProcessFailedException($proc);
         }
 

--- a/Imagine/Filter/RelativeResize.php
+++ b/Imagine/Filter/RelativeResize.php
@@ -35,7 +35,7 @@ class RelativeResize implements FilterInterface
      */
     public function __construct($method, $parameter)
     {
-        if (!in_array($method, ['heighten', 'increase', 'scale', 'widen'])) {
+        if (!in_array($method, ['heighten', 'increase', 'scale', 'widen'], true)) {
             throw new InvalidArgumentException(sprintf('Unsupported method: ', $method));
         }
 

--- a/Service/FilterService.php
+++ b/Service/FilterService.php
@@ -137,7 +137,7 @@ class FilterService
      * @param array  $runtimeFilters
      *
      * @throws NonExistingFilterException
-
+     *
      * @return BinaryInterface
      */
     private function createFilteredBinary($path, $filter, array $runtimeFilters = [])

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -61,16 +61,27 @@ abstract class AbstractTest extends TestCase
         $this->filesystem->mkdir($this->temporaryPath);
     }
 
+    protected function tearDown()
+    {
+        if (!$this->filesystem) {
+            return;
+        }
+
+        if ($this->filesystem->exists($this->temporaryPath)) {
+            $this->filesystem->remove($this->temporaryPath);
+        }
+    }
+
     /**
      * @return string[]
      */
     public function invalidPathProvider()
     {
-        return array(
-            array($this->fixturesPath.'/assets/../../foobar.png'),
-            array($this->fixturesPath.'/assets/some_folder/../foobar.png'),
-            array('../../outside/foobar.jpg'),
-        );
+        return [
+            [$this->fixturesPath.'/assets/../../foobar.png'],
+            [$this->fixturesPath.'/assets/some_folder/../foobar.png'],
+            ['../../outside/foobar.jpg'],
+        ];
     }
 
     /**
@@ -79,10 +90,10 @@ abstract class AbstractTest extends TestCase
     protected function createFilterConfiguration()
     {
         $config = new FilterConfiguration();
-        $config->set('thumbnail', array(
-            'size' => array(180, 180),
+        $config->set('thumbnail', [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        ));
+        ]);
 
         return $config;
     }
@@ -94,12 +105,12 @@ abstract class AbstractTest extends TestCase
     {
         return $this
             ->getMockBuilder(CacheManager::class)
-            ->setConstructorArgs(array(
+            ->setConstructorArgs([
                 $this->createFilterConfiguration(),
                 $this->createRouterInterfaceMock(),
                 $this->createSignerInterfaceMock(),
                 $this->createEventDispatcherInterfaceMock(),
-            ))
+            ])
             ->getMock();
     }
 
@@ -212,7 +223,7 @@ abstract class AbstractTest extends TestCase
      */
     protected function createFilterManagerMock()
     {
-        return $this->createObjectMock(FilterManager::class, array(), false);
+        return $this->createObjectMock(FilterManager::class, [], false);
     }
 
     /**
@@ -228,7 +239,7 @@ abstract class AbstractTest extends TestCase
      */
     protected function createDataManagerMock()
     {
-        return $this->createObjectMock(DataManager::class, array(), false);
+        return $this->createObjectMock(DataManager::class, [], false);
     }
 
     /**
@@ -239,7 +250,7 @@ abstract class AbstractTest extends TestCase
      *
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    protected function createObjectMock($object, array $methods = array(), $constructorInvoke = false, array $constructorParams = array())
+    protected function createObjectMock($object, array $methods = [], $constructorInvoke = false, array $constructorParams = [])
     {
         $builder = $this->getMockBuilder($object);
 
@@ -274,16 +285,5 @@ abstract class AbstractTest extends TestCase
         $m->setAccessible(true);
 
         return $m;
-    }
-
-    protected function tearDown()
-    {
-        if (!$this->filesystem) {
-            return;
-        }
-
-        if ($this->filesystem->exists($this->temporaryPath)) {
-            $this->filesystem->remove($this->temporaryPath);
-        }
     }
 }

--- a/Tests/Async/CacheResolvedTest.php
+++ b/Tests/Async/CacheResolvedTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Async;
 
 use Enqueue\Bundle\EnqueueBundle;
@@ -20,12 +29,12 @@ class CacheResolvedTest extends TestCase
 
     public function testCouldBeJsonSerialized()
     {
-        $message = new CacheResolved('thePath', array(
+        $message = new CacheResolved('thePath', [
             'fooFilter' => 'http://example.com/fooFilter/thePath',
             'barFilter' => 'http://example.com/barFilter/thePath',
-        ));
+        ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             '{"path":"thePath","uris":{"fooFilter":"http:\/\/example.com\/fooFilter\/thePath","barFilter":"http:\/\/example.com\/barFilter\/thePath"}}',
             json_encode($message)
         );
@@ -36,10 +45,10 @@ class CacheResolvedTest extends TestCase
         $message = CacheResolved::jsonDeserialize('{"path":"thePath","uris":{"fooFilter":"http:\/\/example.com\/fooFilter\/thePath","barFilter":"http:\/\/example.com\/barFilter\/thePath"}}');
 
         $this->assertInstanceOf('Liip\ImagineBundle\Async\CacheResolved', $message);
-        $this->assertEquals('thePath', $message->getPath());
-        $this->assertEquals(array(
+        $this->assertSame('thePath', $message->getPath());
+        $this->assertSame([
             'fooFilter' => 'http://example.com/fooFilter/thePath',
             'barFilter' => 'http://example.com/barFilter/thePath',
-        ), $message->getUris());
+        ], $message->getUris());
     }
 }

--- a/Tests/Async/ResolveCacheProcessorTest.php
+++ b/Tests/Async/ResolveCacheProcessorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Async;
 
 use Enqueue\Bundle\EnqueueBundle;
@@ -54,12 +63,12 @@ class ResolveCacheProcessorTest extends AbstractTest
         $command = ResolveCacheProcessor::getSubscribedCommand();
 
         $this->assertInternalType('array', $command);
-        $this->assertEquals(array(
+        $this->assertSame([
             'processorName' => Commands::RESOLVE_CACHE,
             'queueName' => Commands::RESOLVE_CACHE,
             'queueNameHardcoded' => true,
             'exclusive' => true,
-        ), $command);
+        ], $command);
     }
 
     public function testShouldSubscribeToExpectedQueue()
@@ -67,7 +76,7 @@ class ResolveCacheProcessorTest extends AbstractTest
         $queues = ResolveCacheProcessor::getSubscribedQueues();
 
         $this->assertInternalType('array', $queues);
-        $this->assertEquals(array('liip_imagine_resolve_cache'), $queues);
+        $this->assertSame(['liip_imagine_resolve_cache'], $queues);
     }
 
     public function testCouldBeConstructedWithExpectedArguments()
@@ -95,7 +104,7 @@ class ResolveCacheProcessorTest extends AbstractTest
         $result = $processor->process($message, new NullContext());
 
         $this->assertInstanceOf('Enqueue\Consumption\Result', $result);
-        $this->assertEquals(Result::REJECT, $result->getStatus());
+        $this->assertSame(Result::REJECT, $result->getStatus());
         $this->assertStringStartsWith('The malformed json given.', $result->getReason());
     }
 
@@ -114,11 +123,11 @@ class ResolveCacheProcessorTest extends AbstractTest
 
         $this->assertInstanceOf('Enqueue\Consumption\Result', $result);
         $this->assertInstanceOf('Interop\Queue\PsrMessage', $result->getReply());
-        $this->assertEquals(
-            array(
-                "status" => false,
-                "exception" => "The malformed json given. Error 2 and message State mismatch (invalid or malformed JSON)"
-            ),
+        $this->assertSame(
+            [
+                'status' => false,
+                'exception' => 'The malformed json given. Error 2 and message State mismatch (invalid or malformed JSON)',
+            ],
             json_decode($result->getReply()->getBody(), true)
         );
     }
@@ -137,8 +146,8 @@ class ResolveCacheProcessorTest extends AbstractTest
         $result = $processor->process($message, new NullContext());
 
         $this->assertInstanceOf('Enqueue\Consumption\Result', $result);
-        $this->assertEquals(Result::REJECT, (string) $result);
-        $this->assertEquals('The message does not contain "path" but it is required.', $result->getReason());
+        $this->assertSame(Result::REJECT, (string) $result);
+        $this->assertSame('The message does not contain "path" but it is required.', $result->getReason());
     }
 
     public function testShouldCreateFilteredImage()
@@ -150,10 +159,9 @@ class ResolveCacheProcessorTest extends AbstractTest
         $filterManagerMock
             ->expects($this->once())
             ->method('getFilterConfiguration')
-            ->willReturn(new FilterConfiguration(array(
-                $filterName => array('fooFilterConfig'),
-            )))
-        ;
+            ->willReturn(new FilterConfiguration([
+                $filterName => ['fooFilterConfig'],
+            ]));
 
         $filterServiceMock = $this->createFilterServiceMock();
         $filterServiceMock
@@ -172,7 +180,7 @@ class ResolveCacheProcessorTest extends AbstractTest
 
         $result = $processor->process($message, new NullContext());
 
-        $this->assertEquals(Result::ACK, (string) $result);
+        $this->assertSame(Result::ACK, (string) $result);
     }
 
     public function testShouldCreateOneImagePerFilter()
@@ -185,11 +193,10 @@ class ResolveCacheProcessorTest extends AbstractTest
         $filterManagerMock
             ->expects($this->once())
             ->method('getFilterConfiguration')
-            ->willReturn(new FilterConfiguration(array(
-                $filterName1 => array('fooFilterConfig'),
-                $filterName2 => array('fooFilterConfig'),
-            )))
-        ;
+            ->willReturn(new FilterConfiguration([
+                $filterName1 => ['fooFilterConfig'],
+                $filterName2 => ['fooFilterConfig'],
+            ]));
 
         $filterServiceMock = $this->createFilterServiceMock();
         $filterServiceMock
@@ -211,7 +218,7 @@ class ResolveCacheProcessorTest extends AbstractTest
 
         $result = $processor->process($message, new NullContext());
 
-        $this->assertEquals(Result::ACK, (string) $result);
+        $this->assertSame(Result::ACK, (string) $result);
     }
 
     public function testShouldOnlyCreateImageForRequestedFilter()
@@ -241,7 +248,7 @@ class ResolveCacheProcessorTest extends AbstractTest
 
         $result = $processor->process($message, new NullContext());
 
-        $this->assertEquals(Result::ACK, (string) $result);
+        $this->assertSame(Result::ACK, (string) $result);
     }
 
     public function testShouldCreateOneImagePerRequestedFilter()
@@ -275,7 +282,7 @@ class ResolveCacheProcessorTest extends AbstractTest
 
         $result = $processor->process($message, new NullContext());
 
-        $this->assertEquals(Result::ACK, (string) $result);
+        $this->assertSame(Result::ACK, (string) $result);
     }
 
     public function testShouldBurstCacheWhenResolvingForced()
@@ -287,10 +294,9 @@ class ResolveCacheProcessorTest extends AbstractTest
         $filterManagerMock
             ->expects($this->once())
             ->method('getFilterConfiguration')
-            ->willReturn(new FilterConfiguration(array(
-                $filterName => array('fooFilterConfig'),
-            )))
-        ;
+            ->willReturn(new FilterConfiguration([
+                $filterName => ['fooFilterConfig'],
+            ]));
 
         $filterServiceMock = $this->createFilterServiceMock();
         $filterServiceMock
@@ -310,7 +316,7 @@ class ResolveCacheProcessorTest extends AbstractTest
         $result = $processor->process($message, new NullContext());
 
         $this->assertInstanceOf('Enqueue\Consumption\Result', $result);
-        $this->assertEquals(Result::ACK, (string) $result);
+        $this->assertSame(Result::ACK, (string) $result);
     }
 
     public function testShouldNotBurstCacheWhenResolvingNotForced()
@@ -319,10 +325,9 @@ class ResolveCacheProcessorTest extends AbstractTest
         $filterManagerMock
             ->expects($this->once())
             ->method('getFilterConfiguration')
-            ->willReturn(new FilterConfiguration(array(
-                'fooFilter' => array('fooFilterConfig'),
-            )))
-        ;
+            ->willReturn(new FilterConfiguration([
+                'fooFilter' => ['fooFilterConfig'],
+            ]));
 
         $filterServiceMock = $this->createFilterServiceMock();
         $filterServiceMock
@@ -341,7 +346,7 @@ class ResolveCacheProcessorTest extends AbstractTest
         $result = $processor->process($message, new NullContext());
 
         $this->assertInstanceOf('Enqueue\Consumption\Result', $result);
-        $this->assertEquals(Result::ACK, (string) $result);
+        $this->assertSame(Result::ACK, (string) $result);
     }
 
     public function testShouldSendMessageOnSuccessResolve()
@@ -350,18 +355,17 @@ class ResolveCacheProcessorTest extends AbstractTest
         $filterManagerMock
             ->expects($this->once())
             ->method('getFilterConfiguration')
-            ->willReturn(new FilterConfiguration(array(
-                'fooFilter' => array('fooFilterConfig'),
-                'barFilter' => array('barFilterConfig'),
-                'bazFilter' => array('bazFilterConfig'),
-            )))
-        ;
+            ->willReturn(new FilterConfiguration([
+                'fooFilter' => ['fooFilterConfig'],
+                'barFilter' => ['barFilterConfig'],
+                'bazFilter' => ['bazFilterConfig'],
+            ]));
 
         $filterServiceMock = $this->createFilterServiceMock();
         $filterServiceMock
             ->expects($this->exactly(3))
             ->method('getUrlOfFilteredImage')
-            ->willReturnCallback(function($path, $filter) {
+            ->willReturnCallback(function ($path, $filter) {
                 return $path.$filter.'Uri';
             });
 
@@ -371,12 +375,12 @@ class ResolveCacheProcessorTest extends AbstractTest
             ->method('sendEvent')
             ->with(Topics::CACHE_RESOLVED, $this->isInstanceOf('Liip\ImagineBundle\Async\CacheResolved'))
         ->willReturnCallback(function ($topic, CacheResolved $message) {
-            $this->assertEquals('theImagePath', $message->getPath());
-            $this->assertEquals(array(
+            $this->assertSame('theImagePath', $message->getPath());
+            $this->assertSame([
                 'fooFilter' => 'theImagePathfooFilterUri',
                 'barFilter' => 'theImagePathbarFilterUri',
                 'bazFilter' => 'theImagePathbazFilterUri',
-            ), $message->getUris());
+            ], $message->getUris());
         });
 
         $processor = new ResolveCacheProcessor(
@@ -391,7 +395,7 @@ class ResolveCacheProcessorTest extends AbstractTest
         $result = $processor->process($message, new NullContext());
 
         $this->assertInstanceOf('Enqueue\Consumption\Result', $result);
-        $this->assertEquals(Result::ACK, (string) $result);
+        $this->assertSame(Result::ACK, (string) $result);
     }
 
     public function testShouldReturnReplyOnSuccessResolve()
@@ -400,42 +404,36 @@ class ResolveCacheProcessorTest extends AbstractTest
         $filterManagerMock
             ->expects($this->once())
             ->method('getFilterConfiguration')
-            ->willReturn(new FilterConfiguration(array(
-                'fooFilter' => array('fooFilterConfig'),
-                'barFilter' => array('barFilterConfig'),
-                'bazFilter' => array('bazFilterConfig'),
-            )))
-        ;
+            ->willReturn(new FilterConfiguration([
+                'fooFilter' => ['fooFilterConfig'],
+                'barFilter' => ['barFilterConfig'],
+                'bazFilter' => ['bazFilterConfig'],
+            ]));
         $filterManagerMock
             ->expects($this->atLeastOnce())
             ->method('applyFilter')
-            ->willReturn($this->createDummyBinary())
-        ;
+            ->willReturn($this->createDummyBinary());
 
         $cacheManagerMock = $this->createCacheManagerMock();
         $cacheManagerMock
             ->expects($this->atLeastOnce())
             ->method('isStored')
-            ->willReturn(false)
-        ;
+            ->willReturn(false);
         $cacheManagerMock
             ->expects($this->atLeastOnce())
-            ->method('store')
-        ;
+            ->method('store');
         $cacheManagerMock
             ->expects($this->atLeastOnce())
             ->method('resolve')
             ->willReturnCallback(function ($path, $filter) {
                 return $path.$filter.'Uri';
-            })
-        ;
+            });
 
         $dataManagerMock = $this->createDataManagerMock();
         $dataManagerMock
             ->expects($this->atLeastOnce())
             ->method('find')
-            ->willReturn($this->createDummyBinary())
-        ;
+            ->willReturn($this->createDummyBinary());
 
         $filterService = new FilterService(
             $dataManagerMock,
@@ -456,15 +454,15 @@ class ResolveCacheProcessorTest extends AbstractTest
 
         $this->assertInstanceOf('Enqueue\Consumption\Result', $result);
         $this->assertInstanceOf('Interop\Queue\PsrMessage', $result->getReply());
-        $this->assertEquals(
-            array(
-                "status" => true,
-                "results" => array(
+        $this->assertSame(
+            [
+                'status' => true,
+                'results' => [
                     'fooFilter' => 'theImagePathfooFilterUri',
                     'barFilter' => 'theImagePathbarFilterUri',
                     'bazFilter' => 'theImagePathbazFilterUri',
-                )
-            ),
+                ],
+            ],
             json_decode($result->getReply()->getBody(), true)
         );
     }

--- a/Tests/Async/ResolveCacheTest.php
+++ b/Tests/Async/ResolveCacheTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Async;
 
 use Enqueue\Bundle\EnqueueBundle;
@@ -22,21 +31,21 @@ class ResolveCacheTest extends TestCase
     {
         $message = new ResolveCache('thePath');
 
-        $this->assertEquals('{"path":"thePath","filters":null,"force":false}', json_encode($message));
+        $this->assertSame('{"path":"thePath","filters":null,"force":false}', json_encode($message));
     }
 
     public function testCouldBeJsonSerializedWithFilters()
     {
-        $message = new ResolveCache('thePath', array('fooFilter', 'barFilter'));
+        $message = new ResolveCache('thePath', ['fooFilter', 'barFilter']);
 
-        $this->assertEquals('{"path":"thePath","filters":["fooFilter","barFilter"],"force":false}', json_encode($message));
+        $this->assertSame('{"path":"thePath","filters":["fooFilter","barFilter"],"force":false}', json_encode($message));
     }
 
     public function testCouldBeJsonSerializedWithFiltersAndForce()
     {
-        $message = new ResolveCache('thePath', array('fooFilter', 'barFilter'), true);
+        $message = new ResolveCache('thePath', ['fooFilter', 'barFilter'], true);
 
-        $this->assertEquals('{"path":"thePath","filters":["fooFilter","barFilter"],"force":true}', json_encode($message));
+        $this->assertSame('{"path":"thePath","filters":["fooFilter","barFilter"],"force":true}', json_encode($message));
     }
 
     public function testCouldBeJsonDeSerializedWithoutFiltersAndForce()
@@ -44,7 +53,7 @@ class ResolveCacheTest extends TestCase
         $message = ResolveCache::jsonDeserialize('{"path":"thePath","filters":null,"force":false}');
 
         $this->assertInstanceOf('Liip\ImagineBundle\Async\ResolveCache', $message);
-        $this->assertEquals('thePath', $message->getPath());
+        $this->assertSame('thePath', $message->getPath());
         $this->assertNull($message->getFilters());
         $this->assertFalse($message->isForce());
     }
@@ -54,8 +63,8 @@ class ResolveCacheTest extends TestCase
         $message = ResolveCache::jsonDeserialize('{"path":"thePath","filters":["fooFilter","barFilter"],"force":false}');
 
         $this->assertInstanceOf('Liip\ImagineBundle\Async\ResolveCache', $message);
-        $this->assertEquals('thePath', $message->getPath());
-        $this->assertEquals(array('fooFilter', 'barFilter'), $message->getFilters());
+        $this->assertSame('thePath', $message->getPath());
+        $this->assertSame(['fooFilter', 'barFilter'], $message->getFilters());
         $this->assertFalse($message->isForce());
     }
 
@@ -64,8 +73,8 @@ class ResolveCacheTest extends TestCase
         $message = ResolveCache::jsonDeserialize('{"path":"thePath","filters":["fooFilter","barFilter"],"force":true}');
 
         $this->assertInstanceOf('Liip\ImagineBundle\Async\ResolveCache', $message);
-        $this->assertEquals('thePath', $message->getPath());
-        $this->assertEquals(array('fooFilter', 'barFilter'), $message->getFilters());
+        $this->assertSame('thePath', $message->getPath());
+        $this->assertSame(['fooFilter', 'barFilter'], $message->getFilters());
         $this->assertTrue($message->isForce());
     }
 
@@ -74,26 +83,24 @@ class ResolveCacheTest extends TestCase
         $message = ResolveCache::jsonDeserialize('{"path":"thePath"}');
 
         $this->assertInstanceOf('Liip\ImagineBundle\Async\ResolveCache', $message);
-        $this->assertEquals('thePath', $message->getPath());
+        $this->assertSame('thePath', $message->getPath());
         $this->assertNull($message->getFilters());
         $this->assertFalse($message->isForce());
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\LogicException
-     * @expectedExceptionMessage The message does not contain "path" but it is required.
-     */
     public function testThrowIfMessageMissingPathOnJsonDeserialize()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\LogicException::class);
+        $this->expectExceptionMessage('The message does not contain "path" but it is required.');
+
         ResolveCache::jsonDeserialize('{}');
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\LogicException
-     * @expectedExceptionMessage The message filters could be either null or array.
-     */
     public function testThrowIfMessageContainsNotSupportedFilters()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\LogicException::class);
+        $this->expectExceptionMessage('The message filters could be either null or array.');
+
         ResolveCache::jsonDeserialize('{"path": "aPath", "filters": "stringFilterIsNotAllowed"}');
     }
 }

--- a/Tests/Binary/Loader/AbstractDoctrineLoaderTest.php
+++ b/Tests/Binary/Loader/AbstractDoctrineLoaderTest.php
@@ -43,7 +43,7 @@ class AbstractDoctrineLoaderTest extends TestCase
 
         $this->loader = $this
             ->getMockBuilder(AbstractDoctrineLoader::class)
-            ->setConstructorArgs(array($this->om))
+            ->setConstructorArgs([$this->om])
             ->getMockForAbstractClass();
     }
 
@@ -69,7 +69,7 @@ class AbstractDoctrineLoaderTest extends TestCase
             ->with(null, 1337)
             ->will($this->returnValue($image));
 
-        $this->assertEquals('foo', $this->loader->find('/foo/bar'));
+        $this->assertSame('foo', $this->loader->find('/foo/bar'));
     }
 
     public function testFindWithValidObjectSecondHit()
@@ -79,10 +79,10 @@ class AbstractDoctrineLoaderTest extends TestCase
         $this->loader
             ->expects($this->atLeastOnce())
             ->method('mapPathToId')
-            ->will($this->returnValueMap(array(
-                array('/foo/bar.png', 1337),
-                array('/foo/bar', 4711),
-            )));
+            ->will($this->returnValueMap([
+                ['/foo/bar.png', 1337],
+                ['/foo/bar', 4711],
+            ]));
 
         $this->loader
             ->expects($this->atLeastOnce())
@@ -93,19 +93,18 @@ class AbstractDoctrineLoaderTest extends TestCase
         $this->om
             ->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValueMap(array(
-                array(null, 1337, null),
-                array(null, 4711, $image),
-            )));
+            ->will($this->returnValueMap([
+                [null, 1337, null],
+                [null, 4711, $image],
+            ]));
 
-        $this->assertEquals('foo', $this->loader->find('/foo/bar.png'));
+        $this->assertSame('foo', $this->loader->find('/foo/bar.png'));
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
-     */
     public function testFindWithInvalidObject()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
+
         $this->loader
             ->expects($this->atLeastOnce())
             ->method('mapPathToId')

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -44,32 +44,32 @@ class FileSystemLoaderTest extends TestCase
     {
         $file = pathinfo(__FILE__, PATHINFO_BASENAME);
 
-        return array(
-            array(
+        return [
+            [
                 __DIR__,
                 $file,
-            ),
-            array(
+            ],
+            [
                 __DIR__.'/',
                 $file,
-            ),
-            array(
+            ],
+            [
                 __DIR__, '/'.
                 $file,
-            ),
-            array(
+            ],
+            [
                 __DIR__.'/../../Binary/Loader',
                 '/'.$file,
-            ),
-            array(
+            ],
+            [
                 realpath(__DIR__.'/..'),
                 'Loader/'.$file,
-            ),
-            array(
+            ],
+            [
                 __DIR__.'/../',
                 '/Loader/../../Binary/Loader/'.$file,
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -80,7 +80,7 @@ class FileSystemLoaderTest extends TestCase
      */
     public function testLoad($root, $path)
     {
-        $this->assertValidLoaderFindReturn($this->getFileSystemLoader(array($root))->find($path));
+        $this->assertValidLoaderFindReturn($this->getFileSystemLoader([$root])->find($path));
     }
 
     /**
@@ -88,14 +88,14 @@ class FileSystemLoaderTest extends TestCase
      */
     public static function provideMultipleRootLoadCases()
     {
-        $pathsPrepended = array(
+        $pathsPrepended = [
             realpath(__DIR__.'/../'),
             realpath(__DIR__.'/../../'),
             realpath(__DIR__.'/../../../'),
-        );
+        ];
 
         return array_map(function ($parameters) use ($pathsPrepended) {
-            return array(array($pathsPrepended[mt_rand(0, count($pathsPrepended) - 1)], $parameters[0]), $parameters[1]);
+            return [[$pathsPrepended[mt_rand(0, count($pathsPrepended) - 1)], $parameters[0]], $parameters[1]];
         }, static::provideLoadCases());
     }
 
@@ -112,18 +112,17 @@ class FileSystemLoaderTest extends TestCase
 
     public function testAllowsEmptyRootPath()
     {
-        $loader = $this->getFileSystemLoader(array());
+        $loader = $this->getFileSystemLoader([]);
 
         $this->assertInstanceOf(FileSystemLoader::class, $loader);
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Root image path not resolvable
-     */
     public function testThrowsIfRootPathDoesNotExist()
     {
-        $loader = $this->getFileSystemLoader(array('/a/bad/root/path'));
+        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Root image path not resolvable');
+
+        $loader = $this->getFileSystemLoader(['/a/bad/root/path']);
 
         $this->assertInstanceOf(FileSystemLoader::class, $loader);
     }
@@ -133,22 +132,22 @@ class FileSystemLoaderTest extends TestCase
      */
     public function provideOutsideRootPathsData()
     {
-        return array(
-            array('../Loader/../../Binary/Loader/../../../Resources/config/routing.yaml'),
-            array('../../Binary/'),
-        );
+        return [
+            ['../Loader/../../Binary/Loader/../../../Resources/config/routing.yaml'],
+            ['../../Binary/'],
+        ];
     }
 
     /**
      * @dataProvider provideOutsideRootPathsData
      *
-     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
-     * @expectedExceptionMessage Source image invalid
-     *
      * @param string $path
      */
     public function testThrowsIfRealPathOutsideRootPath($path)
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
+        $this->expectExceptionMessage('Source image invalid');
+
         $loader = $this->getFileSystemLoader()->find($path);
 
         $this->assertInstanceOf(FileSystemLoader::class, $loader);
@@ -159,12 +158,11 @@ class FileSystemLoaderTest extends TestCase
         $this->assertValidLoaderFindReturn($this->getFileSystemLoader()->find('/../../Binary/Loader/'.pathinfo(__FILE__, PATHINFO_BASENAME)));
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
-     * @expectedExceptionMessage Source image not resolvable
-     */
     public function testThrowsIfFileDoesNotExist()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
+        $this->expectExceptionMessage('Source image not resolvable');
+
         $loader = $this->getFileSystemLoader()->find('fileNotExist');
 
         $this->assertInstanceOf(FileSystemLoader::class, $loader);
@@ -183,7 +181,7 @@ class FileSystemLoaderTest extends TestCase
      */
     private function getDefaultDataRoots()
     {
-        return array(__DIR__);
+        return [__DIR__];
     }
 
     /**

--- a/Tests/Binary/Loader/FlysystemLoaderTest.php
+++ b/Tests/Binary/Loader/FlysystemLoaderTest.php
@@ -61,12 +61,11 @@ class FlysystemLoaderTest extends AbstractTest
         );
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
-     * @expectedExceptionMessageRegExp {Source image .+ not found}
-     */
     public function testThrowsIfInvalidPathGivenOnFind()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
+        $this->expectExceptionMessageRegExp('{Source image .+ not found}');
+
         $loader = $this->getFlysystemLoader();
 
         $loader->find('invalid.jpeg');

--- a/Tests/Binary/Loader/StreamLoaderTest.php
+++ b/Tests/Binary/Loader/StreamLoaderTest.php
@@ -19,12 +19,11 @@ use Liip\ImagineBundle\Tests\AbstractTest;
  */
 class StreamLoaderTest extends AbstractTest
 {
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
-     * @expectedExceptionMessageRegExp {Source image file://.+ not found.}
-     */
     public function testThrowsIfInvalidPathGivenOnFind()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
+        $this->expectExceptionMessageRegExp('{Source image file://.+ not found.}');
+
         $loader = new StreamLoader('file://');
         $loader->find($this->temporaryPath.'/invalid.jpeg');
     }
@@ -49,12 +48,11 @@ class StreamLoaderTest extends AbstractTest
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The given context is no valid resource
-     */
     public function testThrowsIfInvalidResourceGivenInConstructor()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given context is no valid resource');
+
         new StreamLoader('an-invalid-resource-name', true);
     }
 }

--- a/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/AbstractFileSystemLocatorTest.php
@@ -17,60 +17,48 @@ use PHPUnit\Framework\TestCase;
 
 abstract class AbstractFileSystemLocatorTest extends TestCase
 {
-    /**
-     * @param string[]|string $paths
-     *
-     * @return LocatorInterface
-     */
-    abstract protected function getFileSystemLocator($paths);
-
     public function testImplementsLocatorInterface()
     {
         $this->assertInstanceOf(LocatorInterface::class, new FileSystemLocator());
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Root image path not resolvable
-     */
     public function testThrowsIfEmptyRootPath()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Root image path not resolvable');
+
         $this->getFileSystemLocator('');
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Root image path not resolvable
-     */
     public function testThrowsIfRootPathDoesNotExist()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Root image path not resolvable');
+
         $this->getFileSystemLocator('/a/bad/root/path');
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
-     * @expectedExceptionMessage Source image not resolvable
-     */
     public function testThrowsIfFileDoesNotExist()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
+        $this->expectExceptionMessage('Source image not resolvable');
+
         $this->getFileSystemLocator(__DIR__)->locate('fileNotExist');
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid options provided to
-     */
     public function testThrowsIfInvalidOptionProvided()
     {
-        $this->getFileSystemLocator(__DIR__)->setOptions(array('foo' => 'bar'));
+        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid options provided to');
+
+        $this->getFileSystemLocator(__DIR__)->setOptions(['foo' => 'bar']);
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
-     * @expectedExceptionMessage Invalid root placeholder "invalid-placeholder" for path
-     */
     public function testThrowsIfRootPlaceholderInvalid()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
+        $this->expectExceptionMessage('Invalid root placeholder "invalid-placeholder" for path');
+
         $this->getFileSystemLocator(__DIR__)->locate('@invalid-placeholder:file.ext');
     }
 
@@ -79,7 +67,7 @@ abstract class AbstractFileSystemLocatorTest extends TestCase
      */
     public static function provideLoadCases()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -98,7 +86,7 @@ abstract class AbstractFileSystemLocatorTest extends TestCase
      */
     public static function provideMultipleRootLoadCases()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -117,22 +105,29 @@ abstract class AbstractFileSystemLocatorTest extends TestCase
      */
     public function provideOutsideRootPathsData()
     {
-        return array(
-            array('../Loader/../../Binary/Loader/../../../Resources/config/routing.yaml'),
-            array('../../Binary/'),
-        );
+        return [
+            ['../Loader/../../Binary/Loader/../../../Resources/config/routing.yaml'],
+            ['../../Binary/'],
+        ];
     }
 
     /**
      * @dataProvider provideOutsideRootPathsData
      *
-     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Root image path not resolvable
-     *
      * @param string $path
      */
     public function testThrowsIfRealPathOutsideRootPath($path)
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Root image path not resolvable');
+
         $this->getFileSystemLocator($path)->locate($path);
     }
+
+    /**
+     * @param string[]|string $paths
+     *
+     * @return LocatorInterface
+     */
+    abstract protected function getFileSystemLocator($paths);
 }

--- a/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemInsecureLocatorTest.php
@@ -19,31 +19,17 @@ use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
  */
 class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
 {
-    /**
-     * @param string|string[] $paths
-     *
-     * @return LocatorInterface
-     */
-    protected function getFileSystemLocator($paths)
-    {
-        $locator = new FileSystemInsecureLocator();
-        $locator->setOptions(array('roots' => (array) $paths));
-
-        return $locator;
-    }
-
     public function testLoadsOnSymbolicLinks()
     {
         $loader = $this->getFileSystemLocator($root = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02'));
         $this->assertStringStartsWith(realpath($root), $loader->locate('root-01/file.ext'));
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
-     * @expectedExceptionMessage Source image not resolvable
-     */
     public function testThrowsIfPathHasDoublePeriodBackStep()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
+        $this->expectExceptionMessage('Source image not resolvable');
+
         $this->getFileSystemLocator(realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02'))->locate('/../root-01/file.ext');
     }
 
@@ -52,10 +38,10 @@ class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
         $root01 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-01');
         $root02 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02');
 
-        $loader = $this->getFileSystemLocator(array(
+        $loader = $this->getFileSystemLocator([
             'root-01' => $root01,
             'root-02' => $root02,
-        ));
+        ]);
 
         $this->assertStringStartsWith($root01, $loader->locate('@root-01:file.ext'));
         $this->assertStringStartsWith($root02, $loader->locate('@root-02:root-01/file.ext'));
@@ -68,13 +54,13 @@ class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
     {
         $fileName = pathinfo(__FILE__, PATHINFO_BASENAME);
 
-        return array(
-            array(__DIR__, $fileName),
-            array(__DIR__.'/', $fileName),
-            array(__DIR__, '/'.$fileName),
-            array(__DIR__.'/../../Binary/Locator', '/'.$fileName),
-            array(realpath(__DIR__.'/..'), 'Locator/'.$fileName),
-        );
+        return [
+            [__DIR__, $fileName],
+            [__DIR__.'/', $fileName],
+            [__DIR__, '/'.$fileName],
+            [__DIR__.'/../../Binary/Locator', '/'.$fileName],
+            [realpath(__DIR__.'/..'), 'Locator/'.$fileName],
+        ];
     }
 
     /**
@@ -82,14 +68,27 @@ class FileSystemInsecureLocatorTest extends AbstractFileSystemLocatorTest
      */
     public static function provideMultipleRootLoadCases()
     {
-        $prepend = array(
+        $prepend = [
             realpath(__DIR__.'/../'),
             realpath(__DIR__.'/../../'),
             realpath(__DIR__.'/../../../'),
-        );
+        ];
 
         return array_map(function ($params) use ($prepend) {
-            return array(array($prepend[mt_rand(0, count($prepend) - 1)], $params[0]), $params[1]);
+            return [[$prepend[mt_rand(0, count($prepend) - 1)], $params[0]], $params[1]];
         }, static::provideLoadCases());
+    }
+
+    /**
+     * @param string|string[] $paths
+     *
+     * @return LocatorInterface
+     */
+    protected function getFileSystemLocator($paths)
+    {
+        $locator = new FileSystemInsecureLocator();
+        $locator->setOptions(['roots' => (array) $paths]);
+
+        return $locator;
     }
 }

--- a/Tests/Binary/Locator/FileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemLocatorTest.php
@@ -19,25 +19,11 @@ use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
  */
 class FileSystemLocatorTest extends AbstractFileSystemLocatorTest
 {
-    /**
-     * @param string|string[] $paths
-     *
-     * @return LocatorInterface
-     */
-    protected function getFileSystemLocator($paths)
-    {
-        $locator = new FileSystemLocator();
-        $locator->setOptions(array('roots' => (array) $paths));
-
-        return $locator;
-    }
-
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException
-     * @expectedExceptionMessage Source image invalid
-     */
     public function testThrowsIfPathHasSymbolicLinksPointOutsideRoot()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
+        $this->expectExceptionMessage('Source image invalid');
+
         $this->getFileSystemLocator(realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02'))->locate('root-01/file.ext');
     }
 
@@ -46,10 +32,10 @@ class FileSystemLocatorTest extends AbstractFileSystemLocatorTest
         $root01 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-01');
         $root02 = realpath(__DIR__.'/../../Fixtures/FileSystemLocator/root-02');
 
-        $loader = $this->getFileSystemLocator(array(
+        $loader = $this->getFileSystemLocator([
             'root-01' => $root01,
             'root-02' => $root02,
-        ));
+        ]);
 
         $this->assertStringStartsWith($root01, $loader->locate('@root-01:file.ext'));
         $this->assertStringStartsWith($root01, $loader->locate('@root-02:root-01/file.ext'));
@@ -62,14 +48,14 @@ class FileSystemLocatorTest extends AbstractFileSystemLocatorTest
     {
         $fileName = pathinfo(__FILE__, PATHINFO_BASENAME);
 
-        return array(
-            array(__DIR__, $fileName),
-            array(__DIR__.'/', $fileName),
-            array(__DIR__, '/'.$fileName),
-            array(__DIR__.'/../../Binary/Locator', '/'.$fileName),
-            array(realpath(__DIR__.'/..'), 'Locator/'.$fileName),
-            array(__DIR__.'/../', '/Locator/../../Binary/Locator/'.$fileName),
-        );
+        return [
+            [__DIR__, $fileName],
+            [__DIR__.'/', $fileName],
+            [__DIR__, '/'.$fileName],
+            [__DIR__.'/../../Binary/Locator', '/'.$fileName],
+            [realpath(__DIR__.'/..'), 'Locator/'.$fileName],
+            [__DIR__.'/../', '/Locator/../../Binary/Locator/'.$fileName],
+        ];
     }
 
     /**
@@ -77,14 +63,27 @@ class FileSystemLocatorTest extends AbstractFileSystemLocatorTest
      */
     public static function provideMultipleRootLoadCases()
     {
-        $prepend = array(
+        $prepend = [
             realpath(__DIR__.'/../'),
             realpath(__DIR__.'/../../'),
             realpath(__DIR__.'/../../../'),
-        );
+        ];
 
         return array_map(function ($params) use ($prepend) {
-            return array(array($prepend[mt_rand(0, count($prepend) - 1)], $params[0]), $params[1]);
+            return [[$prepend[mt_rand(0, count($prepend) - 1)], $params[0]], $params[1]];
         }, static::provideLoadCases());
+    }
+
+    /**
+     * @param string|string[] $paths
+     *
+     * @return LocatorInterface
+     */
+    protected function getFileSystemLocator($paths)
+    {
+        $locator = new FileSystemLocator();
+        $locator->setOptions(['roots' => (array) $paths]);
+
+        return $locator;
     }
 }

--- a/Tests/Binary/SimpleMimeTypeGuesserTest.php
+++ b/Tests/Binary/SimpleMimeTypeGuesserTest.php
@@ -21,14 +21,6 @@ use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
  */
 class SimpleMimeTypeGuesserTest extends TestCase
 {
-    /**
-     * @return SimpleMimeTypeGuesser
-     */
-    private function getSimpleMimeTypeGuesser()
-    {
-        return new SimpleMimeTypeGuesser(MimeTypeGuesser::getInstance());
-    }
-
     public function testCouldBeConstructedWithSymfonyMimeTypeGuesserAsFirstArgument()
     {
         $guesser = $this->getSimpleMimeTypeGuesser();
@@ -46,13 +38,13 @@ class SimpleMimeTypeGuesserTest extends TestCase
      */
     public static function provideImageData()
     {
-        return array(
-            'gif' => array(__DIR__.'/../Fixtures/assets/cats.gif', 'image/gif'),
-            'png' => array(__DIR__.'/../Fixtures/assets/cats.png', 'image/png'),
-            'jpg' => array(__DIR__.'/../Fixtures/assets/cats.jpeg', 'image/jpeg'),
-            'pdf' => array(__DIR__.'/../Fixtures/assets/cats.pdf', 'application/pdf'),
-            'txt' => array(__DIR__.'/../Fixtures/assets/cats.txt', 'text/plain'),
-        );
+        return [
+            'gif' => [__DIR__.'/../Fixtures/assets/cats.gif', 'image/gif'],
+            'png' => [__DIR__.'/../Fixtures/assets/cats.png', 'image/png'],
+            'jpg' => [__DIR__.'/../Fixtures/assets/cats.jpeg', 'image/jpeg'],
+            'pdf' => [__DIR__.'/../Fixtures/assets/cats.pdf', 'application/pdf'],
+            'txt' => [__DIR__.'/../Fixtures/assets/cats.txt', 'text/plain'],
+        ];
     }
 
     /**
@@ -65,6 +57,14 @@ class SimpleMimeTypeGuesserTest extends TestCase
      */
     public function testGuessMimeType($fileName, $mimeType)
     {
-        $this->assertEquals($mimeType, $this->getSimpleMimeTypeGuesser()->guess(file_get_contents($fileName)));
+        $this->assertSame($mimeType, $this->getSimpleMimeTypeGuesser()->guess(file_get_contents($fileName)));
+    }
+
+    /**
+     * @return SimpleMimeTypeGuesser
+     */
+    private function getSimpleMimeTypeGuesser()
+    {
+        return new SimpleMimeTypeGuesser(MimeTypeGuesser::getInstance());
     }
 }

--- a/Tests/DependencyInjection/Compiler/AbstractCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AbstractCompilerPassTest.php
@@ -13,25 +13,11 @@ namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass;
 
-
 /**
  * @covers \Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass
  */
 class AbstractCompilerPassTest extends AbstractCompilerPassTestCase
 {
-    /**
-     * @param string[] $methods
-     *
-     * @return \PHPUnit_Framework_MockObject_MockObject|AbstractCompilerPass
-     */
-    private function createAbstractCompilerPassMock(array $methods = array())
-    {
-        return $this
-            ->getMockBuilder(AbstractCompilerPass::class)
-            ->setMethods($methods)
-            ->getMock();
-    }
-
     public function testCompilerLogging()
     {
         $pass = $this->createAbstractCompilerPassMock();
@@ -45,5 +31,18 @@ class AbstractCompilerPassTest extends AbstractCompilerPassTestCase
 
         $log = $this->getVisibilityRestrictedMethod($pass, 'log');
         $log->invoke($pass, $container, $message, ...$replace);
+    }
+
+    /**
+     * @param string[] $methods
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|AbstractCompilerPass
+     */
+    private function createAbstractCompilerPassMock(array $methods = [])
+    {
+        return $this
+            ->getMockBuilder(AbstractCompilerPass::class)
+            ->setMethods($methods)
+            ->getMock();
     }
 }

--- a/Tests/DependencyInjection/Compiler/AbstractCompilerPassTestCase.php
+++ b/Tests/DependencyInjection/Compiler/AbstractCompilerPassTestCase.php
@@ -16,6 +16,9 @@ use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
+/**
+ * @coversNothing
+ */
 class AbstractCompilerPassTestCase extends AbstractTest
 {
     /**
@@ -23,7 +26,7 @@ class AbstractCompilerPassTestCase extends AbstractTest
      *
      * @return Definition
      */
-    protected function createDefinition(array $tags = array())
+    protected function createDefinition(array $tags = [])
     {
         $definition = new Definition();
 
@@ -39,7 +42,7 @@ class AbstractCompilerPassTestCase extends AbstractTest
      *
      * @return ContainerBuilder
      */
-    protected function createContainerBuilder(array $definitions = array())
+    protected function createContainerBuilder(array $definitions = [])
     {
         $container = new ContainerBuilder();
 
@@ -56,7 +59,7 @@ class AbstractCompilerPassTestCase extends AbstractTest
      *
      * @return ContainerBuilder|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected function createContainerBuilderMock(array $methods = array(), array $definitions = array())
+    protected function createContainerBuilderMock(array $methods = [], array $definitions = [])
     {
         $container = $this
             ->getMockBuilder(ContainerBuilder::class)

--- a/Tests/DependencyInjection/Compiler/FiltersCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FiltersCompilerPassTest.php
@@ -21,7 +21,7 @@ class FiltersCompilerPassTest extends AbstractCompilerPassTestCase
 {
     public function testProcess()
     {
-        list($d, $m) = $this->getFiltersCompilerPassContainerDefinitions();
+        [$d, $m] = $this->getFiltersCompilerPassContainerDefinitions();
 
         $container = $this->createContainerBuilder($d);
 

--- a/Tests/DependencyInjection/Compiler/LoadersCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoadersCompilerPassTest.php
@@ -11,7 +11,6 @@
 
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
-
 use Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -22,7 +21,7 @@ class LoadersCompilerPassTest extends AbstractCompilerPassTestCase
 {
     public function testProcess()
     {
-        list($d, $m) = $this->getLoadersCompilerPassContainerDefinitions();
+        [$d, $m] = $this->getLoadersCompilerPassContainerDefinitions();
 
         $container = $this->createContainerBuilder($d);
 

--- a/Tests/DependencyInjection/Compiler/MetadataReaderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MetadataReaderCompilerPassTest.php
@@ -12,7 +12,6 @@
 namespace Liip\ImagineBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass;
-
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -22,6 +21,57 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 class MetadataReaderCompilerPassTest extends TestCase
 {
+    public function testProcessBasedOnExtensionsInEnvironment()
+    {
+        [$metadataServiceId, $metadataExifClass, $metadataDefaultClass] = static::getReaderParamAndDefaultAndExifValues();
+
+        $container = new ContainerBuilder();
+        $container->setDefinition($metadataServiceId, new Definition($metadataExifClass));
+
+        $pass = new MetadataReaderCompilerPass();
+        $pass->process($container);
+        $this->assertInstanceOf(extension_loaded('exif') ? $metadataExifClass : $metadataDefaultClass, $container->get($metadataServiceId));
+    }
+
+    public function testProcessWithoutExtExifAddsDefaultReader()
+    {
+        [$metadataServiceId, $metadataExifClass, $metadataDefaultClass] = static::getReaderParamAndDefaultAndExifValues();
+
+        $container = new ContainerBuilder();
+        $container->setDefinition($metadataServiceId, new Definition($metadataExifClass));
+
+        $pass = $this->getMetadataReaderCompilerPass(false);
+
+        $pass->process($container);
+        $this->assertInstanceOf($metadataDefaultClass, $container->get($metadataServiceId));
+    }
+
+    public function testProcessWithExtExifKeepsExifReader()
+    {
+        [$metadataServiceId, $metadataExifClass] = static::getReaderParamAndDefaultAndExifValues();
+
+        $container = new ContainerBuilder();
+        $container->setDefinition($metadataServiceId, new Definition($metadataExifClass));
+
+        $pass = static::getMetadataReaderCompilerPass(true);
+
+        $pass->process($container);
+        $this->assertInstanceOf($metadataExifClass, $container->get($metadataServiceId));
+    }
+
+    public function testDoesNotOverrideCustomReaderWhenExifNotAvailable()
+    {
+        [$metadataServiceId] = static::getReaderParamAndDefaultAndExifValues();
+
+        $container = new ContainerBuilder();
+        $container->setDefinition($metadataServiceId, new Definition('stdClass'));
+
+        $pass = static::getMetadataReaderCompilerPass(false);
+
+        $pass->process($container);
+        $this->assertInstanceOf('stdClass', $container->get($metadataServiceId));
+    }
+
     /**
      * @param \ReflectionClass $r
      * @param string           $p
@@ -37,19 +87,19 @@ class MetadataReaderCompilerPassTest extends TestCase
     }
 
     /**
-     * @return mixed[]
-     *
      * @throws \ReflectionException
+     *
+     * @return mixed[]
      */
     private static function getReaderParamAndDefaultAndExifValues()
     {
         $r = new \ReflectionClass(MetadataReaderCompilerPass::class);
 
-        return array(
+        return [
             static::getVisibilityRestrictedStaticProperty($r, 'metadataReaderServiceId'),
             static::getVisibilityRestrictedStaticProperty($r, 'metadataReaderExifClass'),
             static::getVisibilityRestrictedStaticProperty($r, 'metadataReaderDefaultClass'),
-        );
+        ];
     }
 
     /**
@@ -60,7 +110,7 @@ class MetadataReaderCompilerPassTest extends TestCase
     private function getMetadataReaderCompilerPass($isExifExtensionLoaded)
     {
         $mock = $this->getMockBuilder(MetadataReaderCompilerPass::class)
-            ->setMethods(array('isExifExtensionLoaded'))
+            ->setMethods(['isExifExtensionLoaded'])
             ->getMock();
 
         $mock
@@ -69,56 +119,5 @@ class MetadataReaderCompilerPassTest extends TestCase
             ->willReturn($isExifExtensionLoaded);
 
         return $mock;
-    }
-
-    public function testProcessBasedOnExtensionsInEnvironment()
-    {
-        list($metadataServiceId, $metadataExifClass, $metadataDefaultClass) = static::getReaderParamAndDefaultAndExifValues();
-
-        $container = new ContainerBuilder();
-        $container->setDefinition($metadataServiceId, new Definition($metadataExifClass));
-
-        $pass = new MetadataReaderCompilerPass();
-        $pass->process($container);
-        $this->assertInstanceOf(extension_loaded('exif') ? $metadataExifClass : $metadataDefaultClass, $container->get($metadataServiceId));
-    }
-
-    public function testProcessWithoutExtExifAddsDefaultReader()
-    {
-        list($metadataServiceId, $metadataExifClass, $metadataDefaultClass) = static::getReaderParamAndDefaultAndExifValues();
-
-        $container = new ContainerBuilder();
-        $container->setDefinition($metadataServiceId, new Definition($metadataExifClass));
-
-        $pass = $this->getMetadataReaderCompilerPass(false);
-
-        $pass->process($container);
-        $this->assertInstanceOf($metadataDefaultClass, $container->get($metadataServiceId));
-    }
-
-    public function testProcessWithExtExifKeepsExifReader()
-    {
-        list($metadataServiceId, $metadataExifClass) = static::getReaderParamAndDefaultAndExifValues();
-
-        $container = new ContainerBuilder();
-        $container->setDefinition($metadataServiceId, new Definition($metadataExifClass));
-
-        $pass = static::getMetadataReaderCompilerPass(true);
-
-        $pass->process($container);
-        $this->assertInstanceOf($metadataExifClass, $container->get($metadataServiceId));
-    }
-
-    public function testDoesNotOverrideCustomReaderWhenExifNotAvailable()
-    {
-        list($metadataServiceId) = static::getReaderParamAndDefaultAndExifValues();
-
-        $container = new ContainerBuilder();
-        $container->setDefinition($metadataServiceId, new Definition('stdClass'));
-
-        $pass = static::getMetadataReaderCompilerPass(false);
-
-        $pass->process($container);
-        $this->assertInstanceOf('stdClass', $container->get($metadataServiceId));
     }
 }

--- a/Tests/DependencyInjection/Compiler/PostProcessorsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/PostProcessorsCompilerPassTest.php
@@ -21,7 +21,7 @@ class PostProcessorsCompilerPassTest extends AbstractCompilerPassTestCase
 {
     public function testProcess()
     {
-        list($d, $m) = $this->getPostProcessorsCompilerPassContainerDefinitions();
+        [$d, $m] = $this->getPostProcessorsCompilerPassContainerDefinitions();
 
         $container = $this->createContainerBuilder($d);
 

--- a/Tests/DependencyInjection/Compiler/ResolversCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResolversCompilerPassTest.php
@@ -21,7 +21,7 @@ class ResolversCompilerPassTest extends AbstractCompilerPassTestCase
 {
     public function testProcess()
     {
-        list($d, $m) = $this->getResolversCompilerPassContainerDefinitions();
+        [$d, $m] = $this->getResolversCompilerPassContainerDefinitions();
 
         $container = $this->createContainerBuilder($d);
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -36,7 +36,7 @@ class ConfigurationTest extends TestCase
 
     public function testCouldBeConstructedWithResolversAndLoadersFactoriesAsArguments()
     {
-        $config = new Configuration(array(), array());
+        $config = new Configuration([], []);
 
         $this->assertInstanceOf(Configuration::class, $config);
     }
@@ -45,60 +45,58 @@ class ConfigurationTest extends TestCase
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new WebPathResolverFactory(),
-                ),
-                array(
+                ],
+                [
                     new FooLoaderFactory(),
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
-                'loaders' => array(
-                    'aLoader' => array(
-                        'foo' => array(
+            [[
+                'loaders' => [
+                    'aLoader' => [
+                        'foo' => [
                             'foo_option' => 'theValue',
-                        ),
-                    ),
-                ),
-
-            ))
+                        ],
+                    ],
+                ],
+            ]]
         );
 
         $this->assertArrayHasKey('loaders', $config);
         $this->assertArrayHasKey('aLoader', $config['loaders']);
         $this->assertArrayHasKey('foo', $config['loaders']['aLoader']);
         $this->assertArrayHasKey('foo_option', $config['loaders']['aLoader']['foo']);
-        $this->assertEquals('theValue', $config['loaders']['aLoader']['foo']['foo_option']);
+        $this->assertSame('theValue', $config['loaders']['aLoader']['foo']['foo_option']);
     }
 
     public function testAllowToUseLoaderFactorySeveralTimes()
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new WebPathResolverFactory(),
-                ),
-                array(
+                ],
+                [
                     new FooLoaderFactory(),
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
-                'loaders' => array(
-                    'aLoader' => array(
-                        'foo' => array(
+            [[
+                'loaders' => [
+                    'aLoader' => [
+                        'foo' => [
                             'foo_option' => 'theValue',
-                        ),
-                    ),
-                    'anotherLoader' => array(
-                        'foo' => array(
+                        ],
+                    ],
+                    'anotherLoader' => [
+                        'foo' => [
                             'foo_option' => 'theValue',
-                        ),
-                    ),
-                ),
-
-            ))
+                        ],
+                    ],
+                ],
+            ]]
         );
 
         $this->assertArrayHasKey('loaders', $config);
@@ -110,17 +108,17 @@ class ConfigurationTest extends TestCase
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new WebPathResolverFactory(),
-                ),
-                array(
+                ],
+                [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
-                'loaders' => array(
-                ),
-            ))
+            [[
+                'loaders' => [
+                ],
+            ]]
         );
 
         $this->assertArrayHasKey('loaders', $config);
@@ -132,16 +130,16 @@ class ConfigurationTest extends TestCase
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new WebPathResolverFactory(),
-                ),
-                array(
+                ],
+                [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
+            [[
                 'loaders' => null,
-            ))
+            ]]
         );
 
         $this->assertArrayHasKey('loaders', $config);
@@ -149,24 +147,23 @@ class ConfigurationTest extends TestCase
         $this->assertArrayHasKey('filesystem', $config['loaders']['default']);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Loaders has to be array
-     */
     public function testThrowIfLoadersNotArray()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Loaders has to be array');
+
         $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new WebPathResolverFactory(),
-                ),
-                array(
+                ],
+                [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
+            [[
                 'loaders' => 'not_array',
-            ))
+            ]]
         );
     }
 
@@ -174,14 +171,14 @@ class ConfigurationTest extends TestCase
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new WebPathResolverFactory(),
-                ),
-                array(
+                ],
+                [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array())
+            [[]]
         );
 
         $this->assertArrayHasKey('loaders', $config);
@@ -193,14 +190,14 @@ class ConfigurationTest extends TestCase
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new WebPathResolverFactory(),
-                ),
-                array(
+                ],
+                [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array())
+            [[]]
         );
 
         $this->assertArrayHasKey('resolvers', $config);
@@ -212,24 +209,23 @@ class ConfigurationTest extends TestCase
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new WebPathResolverFactory(),
-                ),
-                array(
+                ],
+                [
                     new FooLoaderFactory(),
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
-                'loaders' => array(
-                    'default' => array(
-                        'foo' => array(
+            [[
+                'loaders' => [
+                    'default' => [
+                        'foo' => [
                             'foo_option' => 'theValue',
-                        ),
-                    ),
-                ),
-
-            ))
+                        ],
+                    ],
+                ],
+            ]]
         );
 
         $this->assertArrayHasKey('loaders', $config);
@@ -241,59 +237,57 @@ class ConfigurationTest extends TestCase
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new BarResolverFactory(),
                     new WebPathResolverFactory(),
-                ), array(
+                ], [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
-                'resolvers' => array(
-                    'aResolver' => array(
-                        'bar' => array(
+            [[
+                'resolvers' => [
+                    'aResolver' => [
+                        'bar' => [
                             'bar_option' => 'theValue',
-                        ),
-                    ),
-                ),
-
-            ))
+                        ],
+                    ],
+                ],
+            ]]
         );
 
         $this->assertArrayHasKey('resolvers', $config);
         $this->assertArrayHasKey('aResolver', $config['resolvers']);
         $this->assertArrayHasKey('bar', $config['resolvers']['aResolver']);
         $this->assertArrayHasKey('bar_option', $config['resolvers']['aResolver']['bar']);
-        $this->assertEquals('theValue', $config['resolvers']['aResolver']['bar']['bar_option']);
+        $this->assertSame('theValue', $config['resolvers']['aResolver']['bar']['bar_option']);
     }
 
     public function testAllowToUseResolverFactorySeveralTimes()
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new BarResolverFactory(),
                     new WebPathResolverFactory(),
-                ),
-                array(
+                ],
+                [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
-                'resolvers' => array(
-                    'aResolver' => array(
-                        'bar' => array(
+            [[
+                'resolvers' => [
+                    'aResolver' => [
+                        'bar' => [
                             'bar_option' => 'theValue',
-                        ),
-                    ),
-                    'anotherResolver' => array(
-                        'bar' => array(
+                        ],
+                    ],
+                    'anotherResolver' => [
+                        'bar' => [
                             'bar_option' => 'theValue',
-                        ),
-                    ),
-                ),
-
-            ))
+                        ],
+                    ],
+                ],
+            ]]
         );
 
         $this->assertArrayHasKey('resolvers', $config);
@@ -305,16 +299,16 @@ class ConfigurationTest extends TestCase
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new WebPathResolverFactory(),
-                ), array(
+                ], [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
-                'resolvers' => array(
-                ),
-            ))
+            [[
+                'resolvers' => [
+                ],
+            ]]
         );
 
         $this->assertArrayHasKey('resolvers', $config);
@@ -326,15 +320,15 @@ class ConfigurationTest extends TestCase
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new WebPathResolverFactory(),
-                ), array(
+                ], [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
+            [[
                 'resolvers' => null,
-            ))
+            ]]
         );
 
         $this->assertArrayHasKey('resolvers', $config);
@@ -342,23 +336,22 @@ class ConfigurationTest extends TestCase
         $this->assertArrayHasKey('web_path', $config['resolvers']['default']);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Resolvers has to be array
-     */
     public function testThrowsIfResolversNotArray()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Resolvers has to be array');
+
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new WebPathResolverFactory(),
-                ), array(
+                ], [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
+            [[
                 'resolvers' => 'not_array',
-            ))
+            ]]
         );
 
         $this->assertArrayHasKey('resolvers', $config);
@@ -370,24 +363,23 @@ class ConfigurationTest extends TestCase
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new BarResolverFactory(),
                     new WebPathResolverFactory(),
-                ),
-                array(
+                ],
+                [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
-                'resolvers' => array(
-                    'default' => array(
-                        'bar' => array(
+            [[
+                'resolvers' => [
+                    'default' => [
+                        'bar' => [
                             'bar_option' => 'theValue',
-                        ),
-                    ),
-                ),
-
-            ))
+                        ],
+                    ],
+                ],
+            ]]
         );
 
         $this->assertArrayHasKey('resolvers', $config);
@@ -399,33 +391,33 @@ class ConfigurationTest extends TestCase
     {
         $config = $this->processConfiguration(
             new Configuration(
-                array(
+                [
                     new BarResolverFactory(),
                     new WebPathResolverFactory(),
-                ),
-                array(
+                ],
+                [
                     new FileSystemLoaderFactory(),
-                )
+                ]
             ),
-            array(array(
-                'filter_sets' => array(
-                    'test' => array(
+            [[
+                'filter_sets' => [
+                    'test' => [
                         'jpeg_quality' => 70,
                         'png_compression_level' => 9,
                         'png_compression_filter' => PNG_ALL_FILTERS,
-                    ),
-                ),
-            ))
+                    ],
+                ],
+            ]]
         );
 
         $this->assertArrayHasKey('filter_sets', $config);
         $this->assertArrayHasKey('test', $config['filter_sets']);
         $this->assertArrayHasKey('jpeg_quality', $config['filter_sets']['test']);
-        $this->assertEquals(70, $config['filter_sets']['test']['jpeg_quality']);
+        $this->assertSame(70, $config['filter_sets']['test']['jpeg_quality']);
         $this->assertArrayHasKey('png_compression_level', $config['filter_sets']['test']);
-        $this->assertEquals(9, $config['filter_sets']['test']['png_compression_level']);
+        $this->assertSame(9, $config['filter_sets']['test']['png_compression_level']);
         $this->assertArrayHasKey('png_compression_filter', $config['filter_sets']['test']);
-        $this->assertEquals(PNG_ALL_FILTERS, $config['filter_sets']['test']['png_compression_filter']);
+        $this->assertSame(PNG_ALL_FILTERS, $config['filter_sets']['test']['png_compression_filter']);
     }
 
     /**
@@ -458,8 +450,7 @@ class FooLoaderFactory implements LoaderFactoryInterface
         $builder
             ->children()
                 ->scalarNode('foo_option')->isRequired()->cannotBeEmpty()->end()
-            ->end()
-        ;
+            ->end();
     }
 }
 
@@ -479,7 +470,6 @@ class BarResolverFactory implements ResolverFactoryInterface
         $builder
             ->children()
                 ->scalarNode('bar_option')->isRequired()->cannotBeEmpty()->end()
-            ->end()
-        ;
+            ->end();
     }
 }

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -44,7 +44,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
     {
         $loader = new FileSystemLoaderFactory();
 
-        $this->assertEquals('filesystem', $loader->getName());
+        $this->assertSame('filesystem', $loader->getName());
     }
 
     public function testCreateLoaderDefinitionOnCreate()
@@ -52,24 +52,24 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $container = new ContainerBuilder();
 
         $loader = new FileSystemLoaderFactory();
-        $loader->create($container, 'the_loader_name', array(
-            'data_root' => array('theDataRoot'),
+        $loader->create($container, 'the_loader_name', [
+            'data_root' => ['theDataRoot'],
             'locator' => 'filesystem',
-            'bundle_resources' => array(
+            'bundle_resources' => [
                 'enabled' => false,
                 'access_control_type' => 'blacklist',
-                'access_control_list' => array(),
-            ),
-        ));
+                'access_control_list' => [],
+            ],
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.binary.loader.the_loader_name'));
 
         $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.the_loader_name');
 
         $this->assertInstanceOfChildDefinition($loaderDefinition);
-        $this->assertEquals('liip_imagine.binary.loader.prototype.filesystem', $loaderDefinition->getParent());
+        $this->assertSame('liip_imagine.binary.loader.prototype.filesystem', $loaderDefinition->getParent());
 
-        $this->assertEquals(array('theDataRoot'), $loaderDefinition->getArgument(3));
+        $this->assertSame(['theDataRoot'], $loaderDefinition->getArgument(3));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadata()
@@ -78,33 +78,33 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $barBundleRootPath = realpath(__DIR__.'/../../../Functional/Fixtures/BarBundle');
 
         $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles_metadata', array(
-            'LiipFooBundle' => array(
+        $container->setParameter('kernel.bundles_metadata', [
+            'LiipFooBundle' => [
                 'path' => $fooBundleRootPath,
-            ),
-            'LiipBarBundle' => array(
+            ],
+            'LiipBarBundle' => [
                 'path' => $barBundleRootPath,
-            ),
-        ));
+            ],
+        ]);
 
         $loader = new FileSystemLoaderFactory();
-        $loader->create($container, 'the_loader_name', array(
-            'data_root' => array('theDataRoot'),
+        $loader->create($container, 'the_loader_name', [
+            'data_root' => ['theDataRoot'],
             'locator' => 'filesystem',
-            'bundle_resources' => array(
+            'bundle_resources' => [
                 'enabled' => true,
                 'access_control_type' => 'blacklist',
-                'access_control_list' => array(),
-            ),
-        ));
+                'access_control_list' => [],
+            ],
+        ]);
 
-        $expected = array(
+        $expected = [
             'theDataRoot',
             'LiipFooBundle' => $fooBundleRootPath.'/Resources/public',
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
-        );
+        ];
 
-        $this->assertEquals($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadataAndBlacklisting()
@@ -113,34 +113,34 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $barBundleRootPath = realpath(__DIR__.'/../../../Functional/Fixtures/BarBundle');
 
         $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles_metadata', array(
-            'LiipFooBundle' => array(
+        $container->setParameter('kernel.bundles_metadata', [
+            'LiipFooBundle' => [
                 'path' => $fooBundleRootPath,
-            ),
-            'LiipBarBundle' => array(
+            ],
+            'LiipBarBundle' => [
                 'path' => $barBundleRootPath,
-            ),
-        ));
+            ],
+        ]);
 
         $loader = new FileSystemLoaderFactory();
-        $loader->create($container, 'the_loader_name', array(
-            'data_root' => array('theDataRoot'),
+        $loader->create($container, 'the_loader_name', [
+            'data_root' => ['theDataRoot'],
             'locator' => 'filesystem',
-            'bundle_resources' => array(
+            'bundle_resources' => [
                 'enabled' => true,
                 'access_control_type' => 'blacklist',
-                'access_control_list' => array(
+                'access_control_list' => [
                     'LiipFooBundle',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
-        $expected = array(
+        $expected = [
             'theDataRoot',
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
-        );
+        ];
 
-        $this->assertEquals($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadataAndWhitelisting()
@@ -149,34 +149,34 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $barBundleRootPath = realpath(__DIR__.'/../../../Functional/Fixtures/BarBundle');
 
         $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles_metadata', array(
-            'LiipFooBundle' => array(
+        $container->setParameter('kernel.bundles_metadata', [
+            'LiipFooBundle' => [
                 'path' => $fooBundleRootPath,
-            ),
-            'LiipBarBundle' => array(
+            ],
+            'LiipBarBundle' => [
                 'path' => $barBundleRootPath,
-            ),
-        ));
+            ],
+        ]);
 
         $loader = new FileSystemLoaderFactory();
-        $loader->create($container, 'the_loader_name', array(
-            'data_root' => array('theDataRoot'),
+        $loader->create($container, 'the_loader_name', [
+            'data_root' => ['theDataRoot'],
             'locator' => 'filesystem',
-            'bundle_resources' => array(
+            'bundle_resources' => [
                 'enabled' => true,
                 'access_control_type' => 'whitelist',
-                'access_control_list' => array(
+                'access_control_list' => [
                     'LiipFooBundle',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
-        $expected = array(
+        $expected = [
             'theDataRoot',
             'LiipFooBundle' => $fooBundleRootPath.'/Resources/public',
-        );
+        ];
 
-        $this->assertEquals($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingNamedObj()
@@ -185,55 +185,54 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $barBundleRootPath = realpath(__DIR__.'/../../../Functional/Fixtures/BarBundle');
 
         $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles', array(
+        $container->setParameter('kernel.bundles', [
             LiipFooBundle::class,
             LiipBarBundle::class,
-        ));
+        ]);
 
         $loader = new FileSystemLoaderFactory();
-        $loader->create($container, 'the_loader_name', array(
-            'data_root' => array('theDataRoot'),
+        $loader->create($container, 'the_loader_name', [
+            'data_root' => ['theDataRoot'],
             'locator' => 'filesystem',
-            'bundle_resources' => array(
+            'bundle_resources' => [
                 'enabled' => true,
                 'access_control_type' => 'blacklist',
-                'access_control_list' => array(),
-            ),
-        ));
+                'access_control_list' => [],
+            ],
+        ]);
 
-        $expected = array(
+        $expected = [
             'theDataRoot',
             'LiipFooBundle' => $fooBundleRootPath.'/Resources/public',
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
-        );
+        ];
 
-        $this->assertEquals($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(3));
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Unable to resolve bundle "ThisBundleDoesNotExistPleaseNoOneNameTheirObjectThisInThisScopeOrTheGlobalScopeIMeanAreYouInsane" while auto-registering bundle resource paths
-     */
     public function testThrowsExceptionOnCreateWithBundlesEnabledUsingInvalidNamedObj()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to resolve bundle "ThisBundleDoesNotExistPleaseNoOneNameTheirObjectThisInThisScopeOrTheGlobalScopeIMeanAreYouInsane" while auto-registering bundle resource paths');
+
         $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles', array(
+        $container->setParameter('kernel.bundles', [
             'ThisBundleDoesNotExistPleaseNoOneNameTheirObjectThisInThisScopeOrTheGlobalScopeIMeanAreYouInsane',
-        ));
+        ]);
 
         $loader = new FileSystemLoaderFactory();
-        $loader->create($container, 'the_loader_name', array(
-            'data_root' => array('theDataRoot'),
+        $loader->create($container, 'the_loader_name', [
+            'data_root' => ['theDataRoot'],
             'locator' => 'filesystem',
-            'bundle_resources' => array(
+            'bundle_resources' => [
                 'enabled' => true,
-            ),
-        ));
+            ],
+        ]);
     }
 
     public function testProcessCorrectlyOptionsOnAddConfiguration()
     {
-        $expectedDataRoot = array('theDataRoot');
+        $expectedDataRoot = ['theDataRoot'];
 
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('filesystem', 'array');
@@ -241,19 +240,19 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'filesystem' => array(
+        $config = $this->processConfigTree($treeBuilder, [
+            'filesystem' => [
                 'data_root' => $expectedDataRoot,
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertArrayHasKey('data_root', $config);
-        $this->assertEquals($expectedDataRoot, $config['data_root']);
+        $this->assertSame($expectedDataRoot, $config['data_root']);
     }
 
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
     {
-        $expectedDataRoot = array(SymfonyFramework::getContainerResolvableRootWebPath());
+        $expectedDataRoot = [SymfonyFramework::getContainerResolvableRootWebPath()];
 
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('filesystem', 'array');
@@ -261,17 +260,17 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'filesystem' => array(),
-        ));
+        $config = $this->processConfigTree($treeBuilder, [
+            'filesystem' => [],
+        ]);
 
         $this->assertArrayHasKey('data_root', $config);
-        $this->assertEquals($expectedDataRoot, $config['data_root']);
+        $this->assertSame($expectedDataRoot, $config['data_root']);
     }
 
     public function testAddAsScalarExpectingArrayNormalizationOfConfiguration()
     {
-        $expectedDataRoot = array(SymfonyFramework::getContainerResolvableRootWebPath());
+        $expectedDataRoot = [SymfonyFramework::getContainerResolvableRootWebPath()];
 
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('filesystem', 'array');
@@ -279,14 +278,14 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'filesystem' => array(
+        $config = $this->processConfigTree($treeBuilder, [
+            'filesystem' => [
                 'data_root' => $expectedDataRoot[0],
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertArrayHasKey('data_root', $config);
-        $this->assertEquals($expectedDataRoot, $config['data_root']);
+        $this->assertSame($expectedDataRoot, $config['data_root']);
     }
 
     /**

--- a/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
@@ -17,8 +17,8 @@ use Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @requires PHP 5.4
@@ -54,7 +54,7 @@ class FlysystemLoaderFactoryTest extends TestCase
     {
         $loader = new FlysystemLoaderFactory();
 
-        $this->assertEquals('flysystem', $loader->getName());
+        $this->assertSame('flysystem', $loader->getName());
     }
 
     public function testCreateLoaderDefinitionOnCreate()
@@ -63,33 +63,32 @@ class FlysystemLoaderFactoryTest extends TestCase
 
         $loader = new FlysystemLoaderFactory();
 
-        $loader->create($container, 'the_loader_name', array(
+        $loader->create($container, 'the_loader_name', [
             'filesystem_service' => 'flyfilesystemservice',
-        ));
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.binary.loader.the_loader_name'));
 
         $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.the_loader_name');
         $this->assertInstanceOf(ChildDefinition::class, $loaderDefinition);
-        $this->assertEquals('liip_imagine.binary.loader.prototype.flysystem', $loaderDefinition->getParent());
+        $this->assertSame('liip_imagine.binary.loader.prototype.flysystem', $loaderDefinition->getParent());
 
         $reference = $loaderDefinition->getArgument(1);
-        $this->assertEquals('flyfilesystemservice', "$reference");
+        $this->assertSame('flyfilesystemservice', "$reference");
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The child node "filesystem_service" at path "flysystem" must be configured.
-     */
     public function testThrowIfFileSystemServiceNotSetOnAddConfiguration()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The child node "filesystem_service" at path "flysystem" must be configured.');
+
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('flysystem', 'array');
 
         $resolver = new FlysystemLoaderFactory();
         $resolver->addConfiguration($rootNode);
 
-        $this->processConfigTree($treeBuilder, array());
+        $this->processConfigTree($treeBuilder, []);
     }
 
     public function testProcessCorrectlyOptionsOnAddConfiguration()
@@ -102,14 +101,14 @@ class FlysystemLoaderFactoryTest extends TestCase
         $loader = new FlysystemLoaderFactory();
         $loader->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'flysystem' => array(
+        $config = $this->processConfigTree($treeBuilder, [
+            'flysystem' => [
                 'filesystem_service' => $expectedService,
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertArrayHasKey('filesystem_service', $config);
-        $this->assertEquals($expectedService, $config['filesystem_service']);
+        $this->assertSame($expectedService, $config['filesystem_service']);
     }
 
     /**

--- a/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
@@ -16,8 +16,8 @@ use Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory<extended>
@@ -42,7 +42,7 @@ class StreamLoaderFactoryTest extends TestCase
     {
         $loader = new StreamLoaderFactory();
 
-        $this->assertEquals('stream', $loader->getName());
+        $this->assertSame('stream', $loader->getName());
     }
 
     public function testCreateLoaderDefinitionOnCreate()
@@ -51,34 +51,33 @@ class StreamLoaderFactoryTest extends TestCase
 
         $loader = new StreamLoaderFactory();
 
-        $loader->create($container, 'the_loader_name', array(
+        $loader->create($container, 'the_loader_name', [
             'wrapper' => 'theWrapper',
             'context' => 'theContext',
-        ));
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.binary.loader.the_loader_name'));
 
         $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.the_loader_name');
         $this->assertInstanceOf(ChildDefinition::class, $loaderDefinition);
-        $this->assertEquals('liip_imagine.binary.loader.prototype.stream', $loaderDefinition->getParent());
+        $this->assertSame('liip_imagine.binary.loader.prototype.stream', $loaderDefinition->getParent());
 
-        $this->assertEquals('theWrapper', $loaderDefinition->getArgument(0));
-        $this->assertEquals('theContext', $loaderDefinition->getArgument(1));
+        $this->assertSame('theWrapper', $loaderDefinition->getArgument(0));
+        $this->assertSame('theContext', $loaderDefinition->getArgument(1));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The child node "wrapper" at path "stream" must be configured.
-     */
     public function testThrowIfWrapperNotSetOnAddConfiguration()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The child node "wrapper" at path "stream" must be configured.');
+
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('stream', 'array');
 
         $resolver = new StreamLoaderFactory();
         $resolver->addConfiguration($rootNode);
 
-        $this->processConfigTree($treeBuilder, array());
+        $this->processConfigTree($treeBuilder, []);
     }
 
     public function testProcessCorrectlyOptionsOnAddConfiguration()
@@ -92,18 +91,18 @@ class StreamLoaderFactoryTest extends TestCase
         $loader = new StreamLoaderFactory();
         $loader->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'stream' => array(
+        $config = $this->processConfigTree($treeBuilder, [
+            'stream' => [
                 'wrapper' => $expectedWrapper,
                 'context' => $expectedContext,
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertArrayHasKey('wrapper', $config);
-        $this->assertEquals($expectedWrapper, $config['wrapper']);
+        $this->assertSame($expectedWrapper, $config['wrapper']);
 
         $this->assertArrayHasKey('context', $config);
-        $this->assertEquals($expectedContext, $config['context']);
+        $this->assertSame($expectedContext, $config['context']);
     }
 
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
@@ -114,11 +113,11 @@ class StreamLoaderFactoryTest extends TestCase
         $loader = new StreamLoaderFactory();
         $loader->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'stream' => array(
+        $config = $this->processConfigTree($treeBuilder, [
+            'stream' => [
                 'wrapper' => 'aWrapper',
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertArrayHasKey('context', $config);
         $this->assertNull($config['context']);

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -16,8 +16,8 @@ use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInter
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -43,7 +43,7 @@ class AwsS3ResolverFactoryTest extends TestCase
     {
         $resolver = new AwsS3ResolverFactory();
 
-        $this->assertEquals('aws_s3', $resolver->getName());
+        $this->assertSame('aws_s3', $resolver->getName());
     }
 
     public function testCreateResolverDefinitionOnCreate()
@@ -52,29 +52,29 @@ class AwsS3ResolverFactoryTest extends TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'the_resolver_name', array(
-            'client_config' => array(),
+        $resolver->create($container, 'the_resolver_name', [
+            'client_config' => [],
             'bucket' => 'theBucket',
             'acl' => 'theAcl',
-            'get_options' => array('fooKey' => 'fooVal'),
-            'put_options' => array('barKey' => 'barVal'),
+            'get_options' => ['fooKey' => 'fooVal'],
+            'put_options' => ['barKey' => 'barVal'],
             'cache' => false,
-            'proxies' => array(),
-        ));
+            'proxies' => [],
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
 
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf(ChildDefinition::class, $resolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $resolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.aws_s3', $resolverDefinition->getParent());
 
         $this->assertInstanceOf(Reference::class, $resolverDefinition->getArgument(0));
-        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.client', (string) $resolverDefinition->getArgument(0));
+        $this->assertSame('liip_imagine.cache.resolver.the_resolver_name.client', (string) $resolverDefinition->getArgument(0));
 
-        $this->assertEquals('theBucket', $resolverDefinition->getArgument(1));
-        $this->assertEquals('theAcl', $resolverDefinition->getArgument(2));
-        $this->assertEquals(array('fooKey' => 'fooVal'), $resolverDefinition->getArgument(3));
-        $this->assertEquals(array('barKey' => 'barVal'), $resolverDefinition->getArgument(4));
+        $this->assertSame('theBucket', $resolverDefinition->getArgument(1));
+        $this->assertSame('theAcl', $resolverDefinition->getArgument(2));
+        $this->assertSame(['fooKey' => 'fooVal'], $resolverDefinition->getArgument(3));
+        $this->assertSame(['barKey' => 'barVal'], $resolverDefinition->getArgument(4));
     }
 
     public function testCreateS3ClientDefinitionOnCreate()
@@ -83,21 +83,21 @@ class AwsS3ResolverFactoryTest extends TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'the_resolver_name', array(
-            'client_config' => array('theClientConfigKey' => 'theClientConfigVal'),
+        $resolver->create($container, 'the_resolver_name', [
+            'client_config' => ['theClientConfigKey' => 'theClientConfigVal'],
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
-            'get_options' => array(),
-            'put_options' => array(),
+            'get_options' => [],
+            'put_options' => [],
             'cache' => false,
-            'proxies' => array(),
-        ));
+            'proxies' => [],
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.client'));
 
         $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.client');
-        $this->assertEquals('Aws\S3\S3Client', $clientDefinition->getClass());
-        $this->assertEquals(array('theClientConfigKey' => 'theClientConfigVal'), $clientDefinition->getArgument(0));
+        $this->assertSame('Aws\S3\S3Client', $clientDefinition->getClass());
+        $this->assertSame(['theClientConfigKey' => 'theClientConfigVal'], $clientDefinition->getArgument(0));
     }
 
     public function testCreateS3ClientDefinitionWithFactoryOnCreate()
@@ -106,18 +106,18 @@ class AwsS3ResolverFactoryTest extends TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'the_resolver_name', array(
-            'client_config' => array('theClientConfigKey' => 'theClientConfigVal'),
+        $resolver->create($container, 'the_resolver_name', [
+            'client_config' => ['theClientConfigKey' => 'theClientConfigVal'],
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
-            'get_options' => array(),
-            'put_options' => array(),
+            'get_options' => [],
+            'put_options' => [],
             'cache' => false,
-            'proxies' => array(),
-        ));
+            'proxies' => [],
+        ]);
 
         $clientDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.client');
-        $this->assertEquals(array('Aws\S3\S3Client', 'factory'), $clientDefinition->getFactory());
+        $this->assertSame(['Aws\S3\S3Client', 'factory'], $clientDefinition->getFactory());
     }
 
     public function testWrapResolverWithProxyOnCreateWithoutCache()
@@ -126,32 +126,32 @@ class AwsS3ResolverFactoryTest extends TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'the_resolver_name', array(
-            'client_config' => array(),
+        $resolver->create($container, 'the_resolver_name', [
+            'client_config' => [],
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
-            'get_options' => array(),
-            'put_options' => array(),
+            'get_options' => [],
+            'put_options' => [],
             'cache' => false,
-            'proxies' => array('foo'),
-        ));
+            'proxies' => ['foo'],
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
         $proxiedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied');
         $this->assertInstanceOf(ChildDefinition::class, $proxiedResolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $proxiedResolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.aws_s3', $proxiedResolverDefinition->getParent());
 
         $this->assertFalse($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf(ChildDefinition::class, $resolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.proxy', $resolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.proxy', $resolverDefinition->getParent());
 
         $this->assertInstanceOf(Reference::class, $resolverDefinition->getArgument(0));
-        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.proxied', (string) $resolverDefinition->getArgument(0));
+        $this->assertSame('liip_imagine.cache.resolver.the_resolver_name.proxied', (string) $resolverDefinition->getArgument(0));
 
-        $this->assertEquals(array('foo'), $resolverDefinition->getArgument(1));
+        $this->assertSame(['foo'], $resolverDefinition->getArgument(1));
     }
 
     public function testWrapResolverWithCacheOnCreateWithoutProxy()
@@ -160,33 +160,33 @@ class AwsS3ResolverFactoryTest extends TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'the_resolver_name', array(
-            'client_config' => array(),
+        $resolver->create($container, 'the_resolver_name', [
+            'client_config' => [],
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
-            'get_options' => array(),
-            'put_options' => array(),
+            'get_options' => [],
+            'put_options' => [],
             'cache' => 'the_cache_service_id',
-            'proxies' => array(),
-        ));
+            'proxies' => [],
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
         $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.cached');
         $this->assertInstanceOf(ChildDefinition::class, $cachedResolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $cachedResolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.aws_s3', $cachedResolverDefinition->getParent());
 
         $this->assertFalse($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf(ChildDefinition::class, $resolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.cache', $resolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.cache', $resolverDefinition->getParent());
 
         $this->assertInstanceOf(Reference::class, $resolverDefinition->getArgument(0));
-        $this->assertEquals('the_cache_service_id', (string) $resolverDefinition->getArgument(0));
+        $this->assertSame('the_cache_service_id', (string) $resolverDefinition->getArgument(0));
 
         $this->assertInstanceOf(Reference::class, $resolverDefinition->getArgument(1));
-        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.cached', (string) $resolverDefinition->getArgument(1));
+        $this->assertSame('liip_imagine.cache.resolver.the_resolver_name.cached', (string) $resolverDefinition->getArgument(1));
     }
 
     public function testWrapResolverWithProxyAndCacheOnCreate()
@@ -195,41 +195,41 @@ class AwsS3ResolverFactoryTest extends TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'the_resolver_name', array(
-            'client_config' => array(),
+        $resolver->create($container, 'the_resolver_name', [
+            'client_config' => [],
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
-            'get_options' => array(),
-            'put_options' => array(),
+            'get_options' => [],
+            'put_options' => [],
             'cache' => 'the_cache_service_id',
-            'proxies' => array('foo'),
-        ));
+            'proxies' => ['foo'],
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
         $proxiedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied');
         $this->assertInstanceOf(ChildDefinition::class, $proxiedResolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $proxiedResolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.aws_s3', $proxiedResolverDefinition->getParent());
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
         $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.cached');
         $this->assertInstanceOf(ChildDefinition::class, $cachedResolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.proxy', $cachedResolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.proxy', $cachedResolverDefinition->getParent());
 
         $this->assertInstanceOf(Reference::class, $cachedResolverDefinition->getArgument(0));
-        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.proxied', (string) $cachedResolverDefinition->getArgument(0));
+        $this->assertSame('liip_imagine.cache.resolver.the_resolver_name.proxied', (string) $cachedResolverDefinition->getArgument(0));
 
-        $this->assertEquals(array('foo'), $cachedResolverDefinition->getArgument(1));
+        $this->assertSame(['foo'], $cachedResolverDefinition->getArgument(1));
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf(ChildDefinition::class, $resolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.cache', $resolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.cache', $resolverDefinition->getParent());
 
         $this->assertInstanceOf(Reference::class, $resolverDefinition->getArgument(0));
-        $this->assertEquals('the_cache_service_id', (string) $resolverDefinition->getArgument(0));
+        $this->assertSame('the_cache_service_id', (string) $resolverDefinition->getArgument(0));
 
         $this->assertInstanceOf(Reference::class, $resolverDefinition->getArgument(1));
-        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.cached', (string) $resolverDefinition->getArgument(1));
+        $this->assertSame('liip_imagine.cache.resolver.the_resolver_name.cached', (string) $resolverDefinition->getArgument(1));
     }
 
     public function testWrapResolverWithProxyMatchReplaceStrategyOnCreate()
@@ -238,30 +238,30 @@ class AwsS3ResolverFactoryTest extends TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'the_resolver_name', array(
-            'client_config' => array(),
+        $resolver->create($container, 'the_resolver_name', [
+            'client_config' => [],
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
-            'get_options' => array(),
-            'put_options' => array(),
+            'get_options' => [],
+            'put_options' => [],
             'cache' => 'the_cache_service_id',
-            'proxies' => array('foo' => 'bar'),
-        ));
+            'proxies' => ['foo' => 'bar'],
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
         $proxiedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied');
         $this->assertInstanceOf(ChildDefinition::class, $proxiedResolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.aws_s3', $proxiedResolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.aws_s3', $proxiedResolverDefinition->getParent());
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
         $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.cached');
         $this->assertInstanceOf(ChildDefinition::class, $cachedResolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.proxy', $cachedResolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.proxy', $cachedResolverDefinition->getParent());
 
         $this->assertInstanceOf(Reference::class, $cachedResolverDefinition->getArgument(0));
-        $this->assertEquals('liip_imagine.cache.resolver.the_resolver_name.proxied', (string) $cachedResolverDefinition->getArgument(0));
+        $this->assertSame('liip_imagine.cache.resolver.the_resolver_name.proxied', (string) $cachedResolverDefinition->getArgument(0));
 
-        $this->assertEquals(array('foo' => 'bar'), $cachedResolverDefinition->getArgument(1));
+        $this->assertSame(['foo' => 'bar'], $cachedResolverDefinition->getArgument(1));
     }
 
     public function testSetCachePrefixIfDefined()
@@ -270,16 +270,16 @@ class AwsS3ResolverFactoryTest extends TestCase
 
         $resolver = new AwsS3ResolverFactory();
 
-        $resolver->create($container, 'the_resolver_name', array(
-            'client_config' => array(),
+        $resolver->create($container, 'the_resolver_name', [
+            'client_config' => [],
             'bucket' => 'aBucket',
             'acl' => 'aAcl',
-            'get_options' => array(),
-            'put_options' => array(),
+            'get_options' => [],
+            'put_options' => [],
             'cache_prefix' => 'theCachePrefix',
             'cache' => null,
-            'proxies' => array(),
-        ));
+            'proxies' => [],
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
@@ -287,78 +287,75 @@ class AwsS3ResolverFactoryTest extends TestCase
         $methodCalls = $resolverDefinition->getMethodCalls();
 
         $this->assertCount(1, $methodCalls);
-        $this->assertEquals('setCachePrefix', $methodCalls[0][0]);
-        $this->assertEquals(array('theCachePrefix'), $methodCalls[0][1]);
+        $this->assertSame('setCachePrefix', $methodCalls[0][0]);
+        $this->assertSame(['theCachePrefix'], $methodCalls[0][1]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The child node "bucket" at path "aws_s3" must be configured.
-     */
     public function testThrowBucketNotSetOnAddConfiguration()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The child node "bucket" at path "aws_s3" must be configured.');
+
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('aws_s3', 'array');
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
 
-        $this->processConfigTree($treeBuilder, array());
+        $this->processConfigTree($treeBuilder, []);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The child node "client_config" at path "aws_s3" must be configured.
-     */
     public function testThrowClientConfigNotSetOnAddConfiguration()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The child node "client_config" at path "aws_s3" must be configured.');
+
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('aws_s3', 'array');
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
 
-        $this->processConfigTree($treeBuilder, array(
-            'aws_s3' => array(
+        $this->processConfigTree($treeBuilder, [
+            'aws_s3' => [
                 'bucket' => 'aBucket',
-            ),
-        ));
+            ],
+        ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid type for path "aws_s3.client_config". Expected array, but got string
-     */
     public function testThrowClientConfigNotArrayOnAddConfiguration()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid type for path "aws_s3.client_config". Expected array, but got string');
+
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('aws_s3', 'array');
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
 
-        $this->processConfigTree($treeBuilder, array(
-            'aws_s3' => array(
+        $this->processConfigTree($treeBuilder, [
+            'aws_s3' => [
                 'bucket' => 'aBucket',
                 'client_config' => 'not_array',
-            ),
-        ));
+            ],
+        ]);
     }
 
     public function testProcessCorrectlyOptionsOnAddConfiguration()
     {
-        $expectedClientConfig = array(
+        $expectedClientConfig = [
             'theKey' => 'theClientConfigVal',
             'theOtherKey' => 'theOtherClientConfigValue',
-        );
-        $expectedGetOptions = array(
+        ];
+        $expectedGetOptions = [
             'theKey' => 'theGetOptionsVal',
             'theOtherKey' => 'theOtherGetOptionsValue',
-        );
-        $expectedObjectOptions = array(
+        ];
+        $expectedObjectOptions = [
             'theKey' => 'theObjectOptionsVal',
             'theOtherKey' => 'theOtherObjectOptionsValue',
-        );
+        ];
         $expectedBucket = 'theBucket';
         $expectedAcl = 'theAcl';
         $expectedCachePrefix = 'theCachePrefix';
@@ -369,34 +366,34 @@ class AwsS3ResolverFactoryTest extends TestCase
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'aws_s3' => array(
+        $config = $this->processConfigTree($treeBuilder, [
+            'aws_s3' => [
                 'bucket' => $expectedBucket,
                 'acl' => $expectedAcl,
                 'client_config' => $expectedClientConfig,
                 'get_options' => $expectedGetOptions,
                 'put_options' => $expectedObjectOptions,
                 'cache_prefix' => $expectedCachePrefix,
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertArrayHasKey('bucket', $config);
-        $this->assertEquals($expectedBucket, $config['bucket']);
+        $this->assertSame($expectedBucket, $config['bucket']);
 
         $this->assertArrayHasKey('acl', $config);
-        $this->assertEquals($expectedAcl, $config['acl']);
+        $this->assertSame($expectedAcl, $config['acl']);
 
         $this->assertArrayHasKey('client_config', $config);
-        $this->assertEquals($expectedClientConfig, $config['client_config']);
+        $this->assertSame($expectedClientConfig, $config['client_config']);
 
         $this->assertArrayHasKey('get_options', $config);
-        $this->assertEquals($expectedGetOptions, $config['get_options']);
+        $this->assertSame($expectedGetOptions, $config['get_options']);
 
         $this->assertArrayHasKey('put_options', $config);
-        $this->assertEquals($expectedObjectOptions, $config['put_options']);
+        $this->assertSame($expectedObjectOptions, $config['put_options']);
 
         $this->assertArrayHasKey('cache_prefix', $config);
-        $this->assertEquals($expectedCachePrefix, $config['cache_prefix']);
+        $this->assertSame($expectedCachePrefix, $config['cache_prefix']);
     }
 
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
@@ -409,18 +406,18 @@ class AwsS3ResolverFactoryTest extends TestCase
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'aws_s3' => array(
+        $config = $this->processConfigTree($treeBuilder, [
+            'aws_s3' => [
                 'bucket' => 'aBucket',
-                'client_config' => array(),
-            ),
-        ));
+                'client_config' => [],
+            ],
+        ]);
 
         $this->assertArrayHasKey('acl', $config);
-        $this->assertEquals($expectedAcl, $config['acl']);
+        $this->assertSame($expectedAcl, $config['acl']);
 
         $this->assertArrayHasKey('get_options', $config);
-        $this->assertEquals(array(), $config['get_options']);
+        $this->assertSame([], $config['get_options']);
 
         $this->assertArrayHasKey('cache_prefix', $config);
         $this->assertNull($config['cache_prefix']);
@@ -428,23 +425,23 @@ class AwsS3ResolverFactoryTest extends TestCase
 
     public function testSupportAwsV3ClientConfig()
     {
-        $expectedClientConfig = array(
-            'credentials' => array(
+        $expectedClientConfig = [
+            'credentials' => [
                 'key' => 'theKey',
                 'secret' => 'theSecret',
                 'token' => 'theToken',
-            ),
+            ],
             'region' => 'theRegion',
             'version' => 'theVersion',
-        );
-        $expectedGetOptions = array(
+        ];
+        $expectedGetOptions = [
             'theKey' => 'theGetOptionsVal',
             'theOtherKey' => 'theOtherGetOptionsValue',
-        );
-        $expectedObjectOptions = array(
+        ];
+        $expectedObjectOptions = [
             'theKey' => 'theObjectOptionsVal',
             'theOtherKey' => 'theOtherObjectOptionsValue',
-        );
+        ];
         $expectedBucket = 'theBucket';
         $expectedAcl = 'theAcl';
         $expectedCachePrefix = 'theCachePrefix';
@@ -455,34 +452,34 @@ class AwsS3ResolverFactoryTest extends TestCase
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'aws_s3' => array(
+        $config = $this->processConfigTree($treeBuilder, [
+            'aws_s3' => [
                 'bucket' => $expectedBucket,
                 'acl' => $expectedAcl,
                 'client_config' => $expectedClientConfig,
                 'get_options' => $expectedGetOptions,
                 'put_options' => $expectedObjectOptions,
                 'cache_prefix' => $expectedCachePrefix,
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertArrayHasKey('bucket', $config);
-        $this->assertEquals($expectedBucket, $config['bucket']);
+        $this->assertSame($expectedBucket, $config['bucket']);
 
         $this->assertArrayHasKey('acl', $config);
-        $this->assertEquals($expectedAcl, $config['acl']);
+        $this->assertSame($expectedAcl, $config['acl']);
 
         $this->assertArrayHasKey('client_config', $config);
-        $this->assertEquals($expectedClientConfig, $config['client_config']);
+        $this->assertSame($expectedClientConfig, $config['client_config']);
 
         $this->assertArrayHasKey('get_options', $config);
-        $this->assertEquals($expectedGetOptions, $config['get_options']);
+        $this->assertSame($expectedGetOptions, $config['get_options']);
 
         $this->assertArrayHasKey('put_options', $config);
-        $this->assertEquals($expectedObjectOptions, $config['put_options']);
+        $this->assertSame($expectedObjectOptions, $config['put_options']);
 
         $this->assertArrayHasKey('cache_prefix', $config);
-        $this->assertEquals($expectedCachePrefix, $config['cache_prefix']);
+        $this->assertSame($expectedCachePrefix, $config['cache_prefix']);
     }
 
     /**

--- a/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
@@ -17,8 +17,8 @@ use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInter
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Resolver\FlysystemResolverFactory<extended>
@@ -52,7 +52,7 @@ class FlysystemResolverFactoryTest extends TestCase
     {
         $resolver = new FlysystemResolverFactory();
 
-        $this->assertEquals('flysystem', $resolver->getName());
+        $this->assertSame('flysystem', $resolver->getName());
     }
 
     public function testCreateResolverDefinitionOnCreate()
@@ -61,22 +61,22 @@ class FlysystemResolverFactoryTest extends TestCase
 
         $resolver = new FlysystemResolverFactory();
 
-        $resolver->create($container, 'the_resolver_name', array(
+        $resolver->create($container, 'the_resolver_name', [
             'filesystem_service' => 'flyfilesystemservice',
             'root_url' => 'http://images.example.com',
             'cache_prefix' => 'theCachePrefix',
             'visibility' => 'public',
-        ));
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
 
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf(ChildDefinition::class, $resolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.flysystem', $resolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.flysystem', $resolverDefinition->getParent());
 
-        $this->assertEquals('http://images.example.com', $resolverDefinition->getArgument(2));
-        $this->assertEquals('theCachePrefix', $resolverDefinition->getArgument(3));
-        $this->assertEquals('public', $resolverDefinition->getArgument(4));
+        $this->assertSame('http://images.example.com', $resolverDefinition->getArgument(2));
+        $this->assertSame('theCachePrefix', $resolverDefinition->getArgument(3));
+        $this->assertSame('public', $resolverDefinition->getArgument(4));
     }
 
     public function testProcessCorrectlyOptionsOnAddConfiguration()
@@ -92,42 +92,41 @@ class FlysystemResolverFactoryTest extends TestCase
         $resolver = new FlysystemResolverFactory();
         $resolver->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'flysystem' => array(
+        $config = $this->processConfigTree($treeBuilder, [
+            'flysystem' => [
                 'root_url' => $expectedRootUrl,
                 'cache_prefix' => $expectedCachePrefix,
                 'filesystem_service' => $expectedFlysystemService,
                 'visibility' => 'public',
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertArrayHasKey('filesystem_service', $config);
-        $this->assertEquals($expectedFlysystemService, $config['filesystem_service']);
+        $this->assertSame($expectedFlysystemService, $config['filesystem_service']);
 
         $this->assertArrayHasKey('root_url', $config);
-        $this->assertEquals($expectedRootUrl, $config['root_url']);
+        $this->assertSame($expectedRootUrl, $config['root_url']);
 
         $this->assertArrayHasKey('cache_prefix', $config);
-        $this->assertEquals($expectedCachePrefix, $config['cache_prefix']);
+        $this->assertSame($expectedCachePrefix, $config['cache_prefix']);
 
         $this->assertArrayHasKey('visibility', $config);
-        $this->assertEquals($expectedVisibility, $config['visibility']);
+        $this->assertSame($expectedVisibility, $config['visibility']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('flysystem', 'array');
 
         $resolver = new FlysystemResolverFactory();
         $resolver->addConfiguration($rootNode);
 
-        $this->processConfigTree($treeBuilder, array(
-            'flysystem' => array(),
-        ));
+        $this->processConfigTree($treeBuilder, [
+            'flysystem' => [],
+        ]);
     }
 
     /**

--- a/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
@@ -17,8 +17,8 @@ use Liip\ImagineBundle\Utility\Framework\SymfonyFramework;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory<extended>
@@ -43,7 +43,7 @@ class WebPathResolverFactoryTest extends TestCase
     {
         $resolver = new WebPathResolverFactory();
 
-        $this->assertEquals('web_path', $resolver->getName());
+        $this->assertSame('web_path', $resolver->getName());
     }
 
     public function testCreateResolverDefinitionOnCreate()
@@ -52,19 +52,19 @@ class WebPathResolverFactoryTest extends TestCase
 
         $resolver = new WebPathResolverFactory();
 
-        $resolver->create($container, 'the_resolver_name', array(
+        $resolver->create($container, 'the_resolver_name', [
             'web_root' => 'theWebRoot',
             'cache_prefix' => 'theCachePrefix',
-        ));
+        ]);
 
         $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
 
         $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
         $this->assertInstanceOf(ChildDefinition::class, $resolverDefinition);
-        $this->assertEquals('liip_imagine.cache.resolver.prototype.web_path', $resolverDefinition->getParent());
+        $this->assertSame('liip_imagine.cache.resolver.prototype.web_path', $resolverDefinition->getParent());
 
-        $this->assertEquals('theWebRoot', $resolverDefinition->getArgument(2));
-        $this->assertEquals('theCachePrefix', $resolverDefinition->getArgument(3));
+        $this->assertSame('theWebRoot', $resolverDefinition->getArgument(2));
+        $this->assertSame('theCachePrefix', $resolverDefinition->getArgument(3));
     }
 
     public function testProcessCorrectlyOptionsOnAddConfiguration()
@@ -78,18 +78,18 @@ class WebPathResolverFactoryTest extends TestCase
         $resolver = new WebPathResolverFactory();
         $resolver->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'web_path' => array(
+        $config = $this->processConfigTree($treeBuilder, [
+            'web_path' => [
                 'web_root' => $expectedWebPath,
                 'cache_prefix' => $expectedCachePrefix,
-            ),
-        ));
+            ],
+        ]);
 
         $this->assertArrayHasKey('web_root', $config);
-        $this->assertEquals($expectedWebPath, $config['web_root']);
+        $this->assertSame($expectedWebPath, $config['web_root']);
 
         $this->assertArrayHasKey('cache_prefix', $config);
-        $this->assertEquals($expectedCachePrefix, $config['cache_prefix']);
+        $this->assertSame($expectedCachePrefix, $config['cache_prefix']);
     }
 
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
@@ -100,15 +100,15 @@ class WebPathResolverFactoryTest extends TestCase
         $resolver = new WebPathResolverFactory();
         $resolver->addConfiguration($rootNode);
 
-        $config = $this->processConfigTree($treeBuilder, array(
-            'web_path' => array(),
-        ));
+        $config = $this->processConfigTree($treeBuilder, [
+            'web_path' => [],
+        ]);
 
         $this->assertArrayHasKey('web_root', $config);
-        $this->assertEquals(SymfonyFramework::getContainerResolvableRootWebPath(), $config['web_root']);
+        $this->assertSame(SymfonyFramework::getContainerResolvableRootWebPath(), $config['web_root']);
 
         $this->assertArrayHasKey('cache_prefix', $config);
-        $this->assertEquals('media/cache', $config['cache_prefix']);
+        $this->assertSame('media/cache', $config['cache_prefix']);
     }
 
     /**

--- a/Tests/DependencyInjection/LiipImagineExtensionTest.php
+++ b/Tests/DependencyInjection/LiipImagineExtensionTest.php
@@ -16,7 +16,6 @@ use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFacto
 use Liip\ImagineBundle\DependencyInjection\LiipImagineExtension;
 use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
@@ -34,13 +33,12 @@ class LiipImagineExtensionTest extends AbstractTest
      */
     protected $containerBuilder;
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testUserLoadThrowsExceptionUnlessDriverIsValid()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $loader = new LiipImagineExtension();
-        $loader->load(array(array('driver' => 'foo')), new ContainerBuilder());
+        $loader->load([['driver' => 'foo']], new ContainerBuilder());
     }
 
     public function testLoadWithDefaults()
@@ -52,11 +50,11 @@ class LiipImagineExtensionTest extends AbstractTest
         $this->assertHasDefinition('liip_imagine.controller');
         $this->assertDICConstructorArguments(
             $this->containerBuilder->getDefinition('liip_imagine.controller'),
-            array(
+            [
                 new Reference('liip_imagine.service.filter'),
                 new Reference('liip_imagine.data.manager'),
                 new Reference('liip_imagine.cache.signer'),
-            )
+            ]
         );
     }
 
@@ -68,21 +66,21 @@ class LiipImagineExtensionTest extends AbstractTest
         $this->assertTrue(isset($param['small']['filters']['route']['requirements']));
 
         $variable1 = $param['small']['filters']['route']['requirements']['variable1'];
-        $this->assertEquals('value1', $variable1, sprintf('%s parameter is correct', $variable1));
+        $this->assertSame('value1', $variable1, sprintf('%s parameter is correct', $variable1));
     }
 
     public static function provideFactoryData()
     {
-        return array(
-            array(
+        return [
+            [
                 'liip_imagine.mime_type_guesser',
-                array(MimeTypeGuesser::class, 'getInstance'),
-            ),
-            array(
+                [MimeTypeGuesser::class, 'getInstance'],
+            ],
+            [
                 'liip_imagine.extension_guesser',
-                array(ExtensionGuesser::class, 'getInstance'),
-            ),
-        );
+                [ExtensionGuesser::class, 'getInstance'],
+            ],
+        ];
     }
 
     /**
@@ -96,7 +94,7 @@ class LiipImagineExtensionTest extends AbstractTest
         $this->createEmptyConfiguration();
         $definition = $this->containerBuilder->getDefinition($service);
 
-        $this->assertEquals($factory, $definition->getFactory());
+        $this->assertSame($factory, $definition->getFactory());
     }
 
     protected function createEmptyConfiguration()
@@ -105,7 +103,7 @@ class LiipImagineExtensionTest extends AbstractTest
         $loader = new LiipImagineExtension();
         $loader->addLoaderFactory(new FileSystemLoaderFactory());
         $loader->addResolverFactory(new WebPathResolverFactory());
-        $loader->load(array(array()), $this->containerBuilder);
+        $loader->load([[]], $this->containerBuilder);
 
         $this->assertTrue($this->containerBuilder instanceof ContainerBuilder);
     }
@@ -120,7 +118,7 @@ class LiipImagineExtensionTest extends AbstractTest
         $loader = new LiipImagineExtension();
         $loader->addLoaderFactory(new FileSystemLoaderFactory());
         $loader->addResolverFactory(new WebPathResolverFactory());
-        $loader->load(array($this->getFullConfig()), $this->containerBuilder);
+        $loader->load([$this->getFullConfig()], $this->containerBuilder);
 
         $this->assertTrue($this->containerBuilder instanceof ContainerBuilder);
     }
@@ -171,7 +169,7 @@ EOF;
      */
     private function assertAlias($value, $key)
     {
-        $this->assertEquals($value, (string) $this->containerBuilder->getAlias($key), sprintf('%s alias is correct', $key));
+        $this->assertSame($value, (string) $this->containerBuilder->getAlias($key), sprintf('%s alias is correct', $key));
     }
 
     /**
@@ -180,7 +178,7 @@ EOF;
      */
     private function assertParameter($value, $key)
     {
-        $this->assertEquals($value, $this->containerBuilder->getParameter($key), sprintf('%s parameter is correct', $key));
+        $this->assertSame($value, $this->containerBuilder->getParameter($key), sprintf('%s parameter is correct', $key));
     }
 
     /**

--- a/Tests/Events/CacheResolveEventTest.php
+++ b/Tests/Events/CacheResolveEventTest.php
@@ -27,7 +27,7 @@ class CacheResolveEventTest extends TestCase
     {
         $event = new CacheResolveEvent('default_path', 'default_filter');
 
-        $this->assertAttributeEquals('default_path', 'path', $event);
+        $this->assertAttributeSame('default_path', 'path', $event);
     }
 
     public function testShouldAllowSetPathByMethod()
@@ -35,14 +35,14 @@ class CacheResolveEventTest extends TestCase
         $event = new CacheResolveEvent('default_path', 'default_filter');
         $event->setPath('new_path');
 
-        $this->assertAttributeEquals('new_path', 'path', $event);
+        $this->assertAttributeSame('new_path', 'path', $event);
     }
 
     public function testShouldAllowGetPathWhichWasSetInConstruct()
     {
         $event = new CacheResolveEvent('default_path', 'default_filter');
 
-        $this->assertEquals('default_path', $event->getPath());
+        $this->assertSame('default_path', $event->getPath());
     }
 
     public function testShouldAllowGetPathWhichWasSetByMethod()
@@ -50,14 +50,14 @@ class CacheResolveEventTest extends TestCase
         $event = new CacheResolveEvent('default_path', 'default_filter');
         $event->setPath('new_path');
 
-        $this->assertEquals('new_path', $event->getPath());
+        $this->assertSame('new_path', $event->getPath());
     }
 
     public function testShouldAllowSetFilterInConstruct()
     {
         $event = new CacheResolveEvent('default_path', 'default_filter');
 
-        $this->assertAttributeEquals('default_filter', 'filter', $event);
+        $this->assertAttributeSame('default_filter', 'filter', $event);
     }
 
     public function testShouldAllowSetFilterByMethod()
@@ -65,14 +65,14 @@ class CacheResolveEventTest extends TestCase
         $event = new CacheResolveEvent('default_path', 'default_filter');
         $event->setFilter('new_filter');
 
-        $this->assertAttributeEquals('new_filter', 'filter', $event);
+        $this->assertAttributeSame('new_filter', 'filter', $event);
     }
 
     public function testShouldAllowGetFilterWhichWasSetInConstruct()
     {
         $event = new CacheResolveEvent('default_path', 'default_filter');
 
-        $this->assertEquals('default_filter', $event->getFilter());
+        $this->assertSame('default_filter', $event->getFilter());
     }
 
     public function testShouldAllowGetFilterWhichWasSetByMethod()
@@ -80,14 +80,14 @@ class CacheResolveEventTest extends TestCase
         $event = new CacheResolveEvent('default_path', 'default_filter');
         $event->setFilter('new_filter');
 
-        $this->assertEquals('new_filter', $event->getFilter());
+        $this->assertSame('new_filter', $event->getFilter());
     }
 
     public function testShouldAllowSetUrlInConstruct()
     {
         $event = new CacheResolveEvent('default_path', 'default_filter', 'default_url');
 
-        $this->assertAttributeEquals('default_url', 'url', $event);
+        $this->assertAttributeSame('default_url', 'url', $event);
     }
 
     public function testShouldAllowSetUrlByMethod()
@@ -95,14 +95,14 @@ class CacheResolveEventTest extends TestCase
         $event = new CacheResolveEvent('default_path', 'default_filter');
         $event->setUrl('new_url');
 
-        $this->assertAttributeEquals('new_url', 'url', $event);
+        $this->assertAttributeSame('new_url', 'url', $event);
     }
 
     public function testShouldAllowGetUrlWhichWasSetInConstruct()
     {
         $event = new CacheResolveEvent('default_path', 'default_filter', 'default_url');
 
-        $this->assertEquals('default_url', $event->getUrl());
+        $this->assertSame('default_url', $event->getUrl());
     }
 
     public function testShouldAllowGetUrlWhichWasSetByMethod()
@@ -110,6 +110,6 @@ class CacheResolveEventTest extends TestCase
         $event = new CacheResolveEvent('default_path', 'default_filter');
         $event->setUrl('new_url');
 
-        $this->assertEquals('new_url', $event->getUrl());
+        $this->assertSame('new_url', $event->getUrl());
     }
 }

--- a/Tests/Form/Type/ImageTypeTest.php
+++ b/Tests/Form/Type/ImageTypeTest.php
@@ -35,7 +35,7 @@ class ImageTypeTest extends AbstractTest
     {
         $type = new ImageType();
 
-        $this->assertEquals(FileType::class, $type->getParent());
+        $this->assertSame(FileType::class, $type->getParent());
     }
 
     public function testConfigureOptions()
@@ -56,14 +56,14 @@ class ImageTypeTest extends AbstractTest
 
     public function testBuildView()
     {
-        $options = array(
+        $options = [
             'image_path' => 'foo',
             'image_filter' => 'bar',
             'image_attr' => 'bazz',
             'link_url' => 'http://liip.com',
             'link_filter' => 'foo',
             'link_attr' => 'bazz',
-        );
+        ];
 
         $view = new FormView();
         $type = new ImageType();
@@ -73,7 +73,7 @@ class ImageTypeTest extends AbstractTest
 
         foreach ($options as $name => $value) {
             $this->assertArrayHasKey($name, $view->vars);
-            $this->assertEquals($value, $view->vars[$name]);
+            $this->assertSame($value, $view->vars[$name]);
         }
     }
 }

--- a/Tests/Functional/AbstractSetupWebTestCase.php
+++ b/Tests/Functional/AbstractSetupWebTestCase.php
@@ -14,6 +14,9 @@ namespace Liip\ImagineBundle\Tests\Functional;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @coversNothing
+ */
 class AbstractSetupWebTestCase extends AbstractWebTestCase
 {
     /**

--- a/Tests/Functional/AbstractWebTestCase.php
+++ b/Tests/Functional/AbstractWebTestCase.php
@@ -19,10 +19,10 @@ abstract class AbstractWebTestCase extends WebTestCase
     /**
      * {@inheritdoc}
      */
-    public static function createClient(array $options = array(), array $server = array())
+    public static function createClient(array $options = [], array $server = [])
     {
         if (!class_exists(Client::class)) {
-            self::markTestSkipped("Requires the symfony/browser-kit package.");
+            self::markTestSkipped('Requires the symfony/browser-kit package.');
         }
 
         return parent::createClient($options, $server);

--- a/Tests/Functional/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Functional/Binary/Loader/FileSystemLoaderTest.php
@@ -19,16 +19,6 @@ use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
  */
 class FileSystemLoaderTest extends AbstractWebTestCase
 {
-    /**
-     * @param string $name
-     *
-     * @return FileSystemLoader|object
-     */
-    private function getLoader($name)
-    {
-        return $this->getService(sprintf('liip_imagine.binary.loader.%s', $name));
-    }
-
     public function testMultipleLoadersHaveDifferentLocatorInstances()
     {
         static::createClient();
@@ -48,5 +38,15 @@ class FileSystemLoaderTest extends AbstractWebTestCase
 
         $this->assertStringEndsWith('root-01', $fooRoots[0]);
         $this->assertStringEndsWith('root-02', $barRoots[0]);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return FileSystemLoader|object
+     */
+    private function getLoader($name)
+    {
+        return $this->getService(sprintf('liip_imagine.binary.loader.%s', $name));
     }
 }

--- a/Tests/Functional/Binary/Locator/FileSystemLocatorTest.php
+++ b/Tests/Functional/Binary/Locator/FileSystemLocatorTest.php
@@ -20,16 +20,6 @@ use Liip\ImagineBundle\Tests\Functional\AbstractWebTestCase;
  */
 class FileSystemLocatorTest extends AbstractWebTestCase
 {
-    /**
-     * @param string $name
-     *
-     * @return FileSystemLocator
-     */
-    private function getFileSystemLoaderLocator($name)
-    {
-        return $this->getPrivateProperty($this->getService(sprintf('liip_imagine.binary.loader.%s', $name)), 'locator');
-    }
-
     public function testBundleResourcesOnAllLoader()
     {
         static::createClient();
@@ -69,6 +59,16 @@ class FileSystemLocatorTest extends AbstractWebTestCase
         $this->assertStringEndsWith('BarBundle/Resources/public', $roots['LiipBarBundle']);
 
         $this->assertBarBundleResourcesExist($locator, true);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return FileSystemLocator
+     */
+    private function getFileSystemLoaderLocator($name)
+    {
+        return $this->getPrivateProperty($this->getService(sprintf('liip_imagine.binary.loader.%s', $name)), 'locator');
     }
 
     /**

--- a/Tests/Functional/Command/AbstractCommandTestCase.php
+++ b/Tests/Functional/Command/AbstractCommandTestCase.php
@@ -12,10 +12,12 @@
 namespace Liip\ImagineBundle\Tests\Functional\Command;
 
 use Liip\ImagineBundle\Tests\Functional\AbstractSetupWebTestCase;
-
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
+/**
+ * @coversNothing
+ */
 class AbstractCommandTestCase extends AbstractSetupWebTestCase
 {
     /**
@@ -25,9 +27,9 @@ class AbstractCommandTestCase extends AbstractSetupWebTestCase
      *
      * @return string
      */
-    protected function executeConsole(Command $command, array $arguments = array(), array $options = array())
+    protected function executeConsole(Command $command, array $arguments = [], array $options = [])
     {
-        $options = array_replace(array('--env' => 'test'), $options);
+        $options = array_replace(['--env' => 'test'], $options);
 
         $commandTester = new CommandTester($command);
         $commandTester->execute($arguments, $options);

--- a/Tests/Functional/Command/RemoveCacheTest.php
+++ b/Tests/Functional/Command/RemoveCacheTest.php
@@ -29,10 +29,10 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             $this->getService('liip_imagine.command.remove_cache_command'),
-            array(
-                'paths' => array('images/cats.jpeg'),
-                '--filters' => array('thumbnail_web_path'),
-        ));
+            [
+                'paths' => ['images/cats.jpeg'],
+                '--filters' => ['thumbnail_web_path'],
+        ]);
     }
 
     public function testExecuteSuccessfullyWithEmptyCacheAndMultiplePaths()
@@ -41,7 +41,7 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             $this->getService('liip_imagine.command.remove_cache_command'),
-            array('paths' => array('images/cats.jpeg', 'images/cats2.jpeg'))
+            ['paths' => ['images/cats.jpeg', 'images/cats2.jpeg']]
         );
     }
 
@@ -51,7 +51,7 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             $this->getService('liip_imagine.command.remove_cache_command'),
-            array('--filters' => array('thumbnail_web_path', 'thumbnail_default'))
+            ['--filters' => ['thumbnail_web_path', 'thumbnail_default']]
         );
     }
 
@@ -98,7 +98,7 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             $this->getService('liip_imagine.command.remove_cache_command'),
-            array('paths' => array('images/cats.jpeg'))
+            ['paths' => ['images/cats.jpeg']]
         );
 
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -128,7 +128,7 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             $this->getService('liip_imagine.command.remove_cache_command'),
-            array('paths' => array('images/cats.jpeg', 'images/cats2.jpeg'))
+            ['paths' => ['images/cats.jpeg', 'images/cats2.jpeg']]
         );
 
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -158,7 +158,7 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             $this->getService('liip_imagine.command.remove_cache_command'),
-            array('--filters' => array('thumbnail_default'))
+            ['--filters' => ['thumbnail_default']]
         );
 
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_default/images/cats.jpeg');
@@ -188,7 +188,7 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             $this->getService('liip_imagine.command.remove_cache_command'),
-            array('--filters' => array('thumbnail_default', 'thumbnail_web_path'))
+            ['--filters' => ['thumbnail_default', 'thumbnail_web_path']]
         );
 
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -214,9 +214,9 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             $this->getService('liip_imagine.command.remove_cache_command'),
-            array(
-                'paths' => array('images/cats.jpeg'),
-                '--filters' => array('thumbnail_default', 'thumbnail_web_path'), )
+            [
+                'paths' => ['images/cats.jpeg'],
+                '--filters' => ['thumbnail_default', 'thumbnail_web_path'], ]
         );
 
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -241,9 +241,9 @@ class RemoveCacheTest extends AbstractCommandTestCase
 
         $this->executeConsole(
             $this->getService('liip_imagine.command.remove_cache_command'),
-            array(
-                'paths' => array('images/cats.jpeg', 'images/cats2.jpeg'),
-                '--filters' => array('thumbnail_web_path'), )
+            [
+                'paths' => ['images/cats.jpeg', 'images/cats2.jpeg'],
+                '--filters' => ['thumbnail_web_path'], ]
         );
 
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');

--- a/Tests/Functional/Command/ResolveCacheTest.php
+++ b/Tests/Functional/Command/ResolveCacheTest.php
@@ -22,9 +22,9 @@ class ResolveCacheTest extends AbstractCommandTestCase
 
         $output = $this->executeConsole(
             $this->getService('liip_imagine.command.resolve_cache_command'),
-            array(
-                'paths' => array('images/cats.jpeg'),
-                '--filters' => array('thumbnail_web_path'), )
+            [
+                'paths' => ['images/cats.jpeg'],
+                '--filters' => ['thumbnail_web_path'], ]
         );
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -41,9 +41,9 @@ class ResolveCacheTest extends AbstractCommandTestCase
 
         $output = $this->executeConsole(
             $this->getService('liip_imagine.command.resolve_cache_command'),
-            array(
-                'paths' => array('images/cats.jpeg'),
-                '--filters' => array('thumbnail_web_path'), )
+            [
+                'paths' => ['images/cats.jpeg'],
+                '--filters' => ['thumbnail_web_path'], ]
         );
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
@@ -55,9 +55,9 @@ class ResolveCacheTest extends AbstractCommandTestCase
     {
         $output = $this->executeConsole(
             $this->getService('liip_imagine.command.resolve_cache_command'),
-            array(
-                'paths' => array('images/cats.jpeg', 'images/cats2.jpeg'),
-                '--filters' => array('thumbnail_web_path'), )
+            [
+                'paths' => ['images/cats.jpeg', 'images/cats2.jpeg'],
+                '--filters' => ['thumbnail_web_path'], ]
         );
 
         $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
@@ -75,9 +75,9 @@ class ResolveCacheTest extends AbstractCommandTestCase
 
         $output = $this->executeConsole(
             $this->getService('liip_imagine.command.resolve_cache_command'),
-            array(
-                'paths' => array('images/cats.jpeg', 'images/cats2.jpeg'),
-                '--filters' => array('thumbnail_web_path'), )
+            [
+                'paths' => ['images/cats.jpeg', 'images/cats2.jpeg'],
+                '--filters' => ['thumbnail_web_path'], ]
         );
 
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_default/images/cats.jpeg');
@@ -91,9 +91,9 @@ class ResolveCacheTest extends AbstractCommandTestCase
     {
         $output = $this->executeConsole(
             $this->getService('liip_imagine.command.resolve_cache_command'),
-            array(
-                'paths' => array('images/cats.jpeg', 'images/cats2.jpeg'),
-                '--filters' => array('thumbnail_web_path', 'thumbnail_default'), )
+            [
+                'paths' => ['images/cats.jpeg', 'images/cats2.jpeg'],
+                '--filters' => ['thumbnail_web_path', 'thumbnail_default'], ]
         );
 
         $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);
@@ -106,7 +106,7 @@ class ResolveCacheTest extends AbstractCommandTestCase
     {
         $output = $this->executeConsole(
             $this->getService('liip_imagine.command.resolve_cache_command'),
-            array('paths' => array('images/cats.jpeg', 'images/cats2.jpeg'))
+            ['paths' => ['images/cats.jpeg', 'images/cats2.jpeg']]
         );
 
         $this->assertContains('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $output);

--- a/Tests/Functional/Controller/ImagineControllerTest.php
+++ b/Tests/Functional/Controller/ImagineControllerTest.php
@@ -36,8 +36,8 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
     }
@@ -54,52 +54,48 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('http://localhost/media/cache/thumbnail_web_path/images/cats.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
-     * @expectedExceptionMessage Signed url does not pass the sign check for path "images/cats.jpeg" and filter "thumbnail_web_path" and runtime config {"thumbnail":{"size":["50","50"]}}
-     */
     public function testThrowBadRequestIfSignInvalidWhileUsingCustomFilters()
     {
-        $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/rc/invalidHash/images/cats.jpeg?'.http_build_query(array(
-            'filters' => array(
-                'thumbnail' => array('size' => array(50, 50)),
-            ),
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\BadRequestHttpException::class);
+        $this->expectExceptionMessage('Signed url does not pass the sign check for path "images/cats.jpeg" and filter "thumbnail_web_path" and runtime config {"thumbnail":{"size":["50","50"]}}');
+
+        $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/rc/invalidHash/images/cats.jpeg?'.http_build_query([
+            'filters' => [
+                'thumbnail' => ['size' => [50, 50]],
+            ],
             '_hash' => 'invalid',
-        )));
+        ]));
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @expectedExceptionMessage Filters must be an array. Value was "some-string"
-     */
     public function testShouldThrowNotFoundHttpExceptionIfFiltersNotArray()
     {
-        $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/rc/invalidHash/images/cats.jpeg?'.http_build_query(array(
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectExceptionMessage('Filters must be an array. Value was "some-string"');
+
+        $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/rc/invalidHash/images/cats.jpeg?'.http_build_query([
             'filters' => 'some-string',
             '_hash' => 'hash',
-        )));
+        ]));
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @expectedExceptionMessage Source image for path "images/shrodinger_cats_which_not_exist.jpeg" could not be found
-     */
     public function testShouldThrowNotFoundHttpExceptionIfFileNotExists()
     {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectExceptionMessage('Source image for path "images/shrodinger_cats_which_not_exist.jpeg" could not be found');
+
         $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/images/shrodinger_cats_which_not_exist.jpeg');
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
     public function testInvalidFilterShouldThrowNotFoundHttpException()
     {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
         $this->client->request('GET', '/media/cache/resolve/invalid-filter/images/cats.jpeg');
     }
 
@@ -108,11 +104,11 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         /** @var Signer $signer */
         $signer = self::$kernel->getContainer()->get('liip_imagine.cache.signer');
 
-        $params = array(
-            'filters' => array(
-                'thumbnail' => array('size' => array(50, 50)),
-            ),
-        );
+        $params = [
+            'filters' => [
+                'thumbnail' => ['size' => [50, 50]],
+            ],
+        ];
 
         $path = 'images/cats.jpeg';
 
@@ -130,8 +126,8 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/media/cache/'.$expectedCachePath, $response->getTargetUrl());
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('http://localhost/media/cache/'.$expectedCachePath, $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/'.$expectedCachePath);
     }
@@ -141,11 +137,11 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         /** @var Signer $signer */
         $signer = self::$kernel->getContainer()->get('liip_imagine.cache.signer');
 
-        $params = array(
-            'filters' => array(
-                'thumbnail' => array('size' => array(50, 50)),
-            ),
-        );
+        $params = [
+            'filters' => [
+                'thumbnail' => ['size' => [50, 50]],
+            ],
+        ];
 
         $path = 'images/cats.jpeg';
 
@@ -165,8 +161,8 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/media/cache'.'/'.$expectedCachePath, $response->getTargetUrl());
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('http://localhost/media/cache'.'/'.$expectedCachePath, $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/'.$expectedCachePath);
     }
@@ -185,8 +181,8 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $response = $this->client->getResponse();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/media/cache/thumbnail_web_path/images/foo bar.jpeg', $response->getTargetUrl());
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('http://localhost/media/cache/thumbnail_web_path/images/foo bar.jpeg', $response->getTargetUrl());
 
         $this->assertFileExists($this->cacheRoot.'/thumbnail_web_path/images/foo bar.jpeg');
     }

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -21,12 +21,12 @@ class AppKernel extends Kernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Liip\ImagineBundle\LiipImagineBundle(),
             new \Liip\ImagineBundle\Tests\Functional\Fixtures\FooBundle\LiipFooBundle(),
             new \Liip\ImagineBundle\Tests\Functional\Fixtures\BarBundle\LiipBarBundle(),
-        );
+        ];
 
         return $bundles;
     }

--- a/Tests/Imagine/Cache/Resolver/AmazonS3ResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/AmazonS3ResolverTest.php
@@ -46,19 +46,18 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('get_object_url')
-            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, array('torrent' => true));
+            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, ['torrent' => true]);
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->setObjectUrlOption('torrent', true);
         $resolver->resolve('/some-folder/path.jpg', 'thumb');
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotStorableException
-     * @expectedExceptionMessage The object could not be created on Amazon S3
-     */
     public function testThrowsAndLogIfCanNotCreateObjectOnAmazon()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotStorableException::class);
+        $this->expectExceptionMessage('The object could not be created on Amazon S3');
+
         $binary = new Binary('aContent', 'image/jpeg', 'jpeg');
 
         $s3 = $this->createAmazonS3Mock();
@@ -110,12 +109,12 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('get_object_url')
-            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, array())
+            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, [])
             ->will($this->returnValue('http://images.example.com/some-folder/path.jpg'));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
 
-        $this->assertEquals(
+        $this->assertSame(
             'http://images.example.com/some-folder/path.jpg',
             $resolver->resolve('/some-folder/path.jpg', 'thumb')
         );
@@ -135,7 +134,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->method('delete_all_objects');
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-        $resolver->remove(array(), array());
+        $resolver->remove([], []);
     }
 
     public function testRemoveCacheForPathAndFilterOnRemove()
@@ -153,7 +152,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->will($this->returnValue($this->createCFResponseMock(true)));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-        $resolver->remove(array('some-folder/path.jpg'), array('thumb'));
+        $resolver->remove(['some-folder/path.jpg'], ['thumb']);
     }
 
     public function testRemoveCacheForSomePathsAndFilterOnRemove()
@@ -181,7 +180,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->will($this->returnValue($this->createCFResponseMock(true)));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-        $resolver->remove(array('pathOne.jpg', 'pathTwo.jpg'), array('filter'));
+        $resolver->remove(['pathOne.jpg', 'pathTwo.jpg'], ['filter']);
     }
 
     public function testRemoveCacheForSomePathsAndSomeFiltersOnRemove()
@@ -230,8 +229,8 @@ class AmazonS3ResolverTest extends AbstractTest
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->remove(
-            array('pathOne.jpg', 'pathTwo.jpg'),
-            array('filterOne', 'filterTwo')
+            ['pathOne.jpg', 'pathTwo.jpg'],
+            ['filterOne', 'filterTwo']
         );
     }
 
@@ -248,7 +247,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->method('delete_object');
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-        $resolver->remove(array('path.jpg'), array('filter'));
+        $resolver->remove(['path.jpg'], ['filter']);
     }
 
     public function testLogIfNotDeletedForPathAndFilterOnRemove()
@@ -271,7 +270,7 @@ class AmazonS3ResolverTest extends AbstractTest
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->setLogger($logger);
-        $resolver->remove(array('path.jpg'), array('filter'));
+        $resolver->remove(['path.jpg'], ['filter']);
     }
 
     public function testRemoveCacheForFilterOnRemove()
@@ -284,7 +283,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->will($this->returnValue(true));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-        $resolver->remove(array(), array('filter'));
+        $resolver->remove([], ['filter']);
     }
 
     public function testRemoveCacheForSomeFiltersOnRemove()
@@ -297,7 +296,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->will($this->returnValue(true));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
-        $resolver->remove(array(), array('filterOne', 'filterTwo'));
+        $resolver->remove([], ['filterOne', 'filterTwo']);
     }
 
     public function testLogIfBatchNotDeletedForFilterOnRemove()
@@ -316,7 +315,7 @@ class AmazonS3ResolverTest extends AbstractTest
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->setLogger($logger);
-        $resolver->remove(array(), array('filter'));
+        $resolver->remove([], ['filter']);
     }
 
     /**
@@ -326,7 +325,7 @@ class AmazonS3ResolverTest extends AbstractTest
      */
     protected function createCFResponseMock($ok = true)
     {
-        $s3Response = $this->createObjectMock(\CFResponse::class, array('isOK'), false);
+        $s3Response = $this->createObjectMock(\CFResponse::class, ['isOK'], false);
         $s3Response
             ->expects($this->once())
             ->method('isOK')
@@ -343,18 +342,18 @@ class AmazonS3ResolverTest extends AbstractTest
         if (!class_exists(\AmazonS3::class)) {
             $this->markTestSkipped('Requires the amazonwebservices/aws-sdk-for-php package.');
         }
-        
+
         return $this
             ->getMockBuilder(\AmazonS3::class)
             ->disableOriginalConstructor()
-            ->setMethods(array(
+            ->setMethods([
                 'if_object_exists',
                 'create_object',
                 'get_object_url',
                 'delete_object',
                 'delete_all_objects',
                 'authenticate',
-            ))
+            ])
             ->getMock();
     }
 }

--- a/Tests/Imagine/Cache/Resolver/AwsS3ResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/AwsS3ResolverTest.php
@@ -48,19 +48,18 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('getObjectUrl')
-            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, array('torrent' => true));
+            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, ['torrent' => true]);
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
         $resolver->setGetOption('torrent', true);
         $resolver->resolve('/some-folder/path.jpg', 'thumb');
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotStorableException
-     * @expectedExceptionMessage The object could not be created on Amazon S3
-     */
     public function testLogNotCreatedObjects()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotStorableException::class);
+        $this->expectExceptionMessage('The object could not be created on Amazon S3');
+
         $binary = new Binary('aContent', 'image/jpeg', 'jpeg');
 
         $s3 = $this->getS3ClientMock();
@@ -101,14 +100,14 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('putObject')
-            ->with(array(
+            ->with([
                 'CacheControl' => 'max-age=86400',
                 'ACL' => 'public-read',
                 'Bucket' => 'images.example.com',
                 'Key' => 'filter/images/foobar.jpg',
                 'Body' => 'aContent',
                 'ContentType' => 'image/jpeg',
-            ));
+            ]);
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
         $resolver->setPutOption('CacheControl', 'max-age=86400');
@@ -134,12 +133,12 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('getObjectUrl')
-            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, array())
+            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, [])
             ->will($this->returnValue('http://images.example.com/some-folder/path.jpg'));
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
 
-        $this->assertEquals(
+        $this->assertSame(
             'http://images.example.com/some-folder/path.jpg',
             $resolver->resolve('/some-folder/path.jpg', 'thumb')
         );
@@ -159,7 +158,7 @@ class AwsS3ResolverTest extends AbstractTest
             ->method('deleteMatchingObjects');
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
-        $resolver->remove(array(), array());
+        $resolver->remove([], []);
     }
 
     public function testRemoveCacheForPathAndFilterOnRemove()
@@ -173,14 +172,14 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('deleteObject')
-            ->with(array(
+            ->with([
                 'Bucket' => 'images.example.com',
                 'Key' => 'thumb/some-folder/path.jpg',
-            ))
+            ])
             ->will($this->returnValue($this->getS3ResponseMock()));
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
-        $resolver->remove(array('some-folder/path.jpg'), array('thumb'));
+        $resolver->remove(['some-folder/path.jpg'], ['thumb']);
     }
 
     public function testRemoveCacheForSomePathsAndFilterOnRemove()
@@ -194,10 +193,10 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->at(1))
             ->method('deleteObject')
-            ->with(array(
+            ->with([
                 'Bucket' => 'images.example.com',
                 'Key' => 'thumb/pathOne.jpg',
-            ))
+            ])
             ->will($this->returnValue($this->getS3ResponseMock()));
         $s3
             ->expects($this->at(2))
@@ -207,16 +206,16 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->at(3))
             ->method('deleteObject')
-            ->with(array(
+            ->with([
                 'Bucket' => 'images.example.com',
                 'Key' => 'thumb/pathTwo.jpg',
-            ))
+            ])
             ->will($this->returnValue($this->getS3ResponseMock()));
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
         $resolver->remove(
-            array('pathOne.jpg', 'pathTwo.jpg'),
-            array('thumb')
+            ['pathOne.jpg', 'pathTwo.jpg'],
+            ['thumb']
         );
     }
 
@@ -231,10 +230,10 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->at(1))
             ->method('deleteObject')
-            ->with(array(
+            ->with([
                 'Bucket' => 'images.example.com',
                 'Key' => 'filterOne/pathOne.jpg',
-            ))
+            ])
             ->will($this->returnValue($this->getS3ResponseMock()));
         $s3
             ->expects($this->at(2))
@@ -244,10 +243,10 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->at(3))
             ->method('deleteObject')
-            ->with(array(
+            ->with([
                 'Bucket' => 'images.example.com',
                 'Key' => 'filterOne/pathTwo.jpg',
-            ))
+            ])
             ->will($this->returnValue($this->getS3ResponseMock()));
         $s3
             ->expects($this->at(4))
@@ -257,10 +256,10 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->at(5))
             ->method('deleteObject')
-            ->with(array(
+            ->with([
                 'Bucket' => 'images.example.com',
                 'Key' => 'filterTwo/pathOne.jpg',
-            ))
+            ])
             ->will($this->returnValue($this->getS3ResponseMock()));
         $s3
             ->expects($this->at(6))
@@ -270,16 +269,16 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->at(7))
             ->method('deleteObject')
-            ->with(array(
+            ->with([
                 'Bucket' => 'images.example.com',
                 'Key' => 'filterTwo/pathTwo.jpg',
-            ))
+            ])
             ->will($this->returnValue($this->getS3ResponseMock()));
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
         $resolver->remove(
-            array('pathOne.jpg', 'pathTwo.jpg'),
-            array('filterOne', 'filterTwo')
+            ['pathOne.jpg', 'pathTwo.jpg'],
+            ['filterOne', 'filterTwo']
         );
     }
 
@@ -296,7 +295,7 @@ class AwsS3ResolverTest extends AbstractTest
             ->method('deleteObject');
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
-        $resolver->remove(array('some-folder/path.jpg'), array('thumb'));
+        $resolver->remove(['some-folder/path.jpg'], ['thumb']);
     }
 
     public function testCatchAndLogExceptionsForPathAndFilterOnRemove()
@@ -319,7 +318,7 @@ class AwsS3ResolverTest extends AbstractTest
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
         $resolver->setLogger($logger);
-        $resolver->remove(array('some-folder/path.jpg'), array('thumb'));
+        $resolver->remove(['some-folder/path.jpg'], ['thumb']);
     }
 
     public function testRemoveCacheForFilterOnRemove()
@@ -334,7 +333,7 @@ class AwsS3ResolverTest extends AbstractTest
             ->with($expectedBucket, null, "/$expectedFilter/i");
 
         $resolver = new AwsS3Resolver($s3, $expectedBucket);
-        $resolver->remove(array(), array($expectedFilter));
+        $resolver->remove([], [$expectedFilter]);
     }
 
     public function testRemoveCacheForSomeFiltersOnRemove()
@@ -350,7 +349,7 @@ class AwsS3ResolverTest extends AbstractTest
             ->with($expectedBucket, null, "/{$expectedFilterOne}|{$expectedFilterTwo}/i");
 
         $resolver = new AwsS3Resolver($s3, $expectedBucket);
-        $resolver->remove(array(), array($expectedFilterOne, $expectedFilterTwo));
+        $resolver->remove([], [$expectedFilterOne, $expectedFilterTwo]);
     }
 
     public function testCatchAndLogExceptionForFilterOnRemove()
@@ -371,7 +370,7 @@ class AwsS3ResolverTest extends AbstractTest
 
         $resolver = new AwsS3Resolver($s3, $expectedBucket);
         $resolver->setLogger($logger);
-        $resolver->remove(array(), array($expectedFilter));
+        $resolver->remove([], [$expectedFilter]);
     }
 
     /**
@@ -390,13 +389,13 @@ class AwsS3ResolverTest extends AbstractTest
         return $this
             ->getMockBuilder(S3Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(array(
+            ->setMethods([
                 'deleteObject',
                 'deleteMatchingObjects',
                 'createObject',
                 'putObject',
                 'doesObjectExist',
                 'getObjectUrl',
-            ))->getMock();
+            ])->getMock();
     }
 }

--- a/Tests/Imagine/Cache/Resolver/CacheResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/CacheResolverTest.php
@@ -25,7 +25,7 @@ class CacheResolverTest extends AbstractTest
     protected $filter = 'thumbnail';
     protected $path = 'MadCat2.jpeg';
     protected $webPath = '/media/cache/thumbnail/MadCat2.jpeg';
-    
+
     protected function setUp()
     {
         if (!class_exists(ArrayCache::class)) {
@@ -46,11 +46,11 @@ class CacheResolverTest extends AbstractTest
 
         $cacheResolver = new CacheResolver(new ArrayCache(), $resolver);
 
-        $this->assertEquals($this->webPath, $cacheResolver->resolve($this->path, $this->filter));
+        $this->assertSame($this->webPath, $cacheResolver->resolve($this->path, $this->filter));
 
         // Call multiple times to verify the cache is used.
-        $this->assertEquals($this->webPath, $cacheResolver->resolve($this->path, $this->filter));
-        $this->assertEquals($this->webPath, $cacheResolver->resolve($this->path, $this->filter));
+        $this->assertSame($this->webPath, $cacheResolver->resolve($this->path, $this->filter));
+        $this->assertSame($this->webPath, $cacheResolver->resolve($this->path, $this->filter));
     }
 
     public function testNotCallInternalResolverIfCachedOnIsStored()
@@ -148,7 +148,7 @@ class CacheResolverTest extends AbstractTest
          */
         $this->assertCount(2, $this->getCacheEntries($cache));
 
-        $cacheResolver->remove(array($this->path), array($this->filter));
+        $cacheResolver->remove([$this->path], [$this->filter]);
 
         // Cache including index has been removed.
         $this->assertCount(0, $this->getCacheEntries($cache));
@@ -180,7 +180,7 @@ class CacheResolverTest extends AbstractTest
          */
         $this->assertCount(6, $this->getCacheEntries($cache));
 
-        $cacheResolver->remove(array(), array('thumbnail_233x233'));
+        $cacheResolver->remove([], ['thumbnail_233x233']);
 
         // Cache including index has been removed.
         $this->assertCount(3, $this->getCacheEntries($cache));

--- a/Tests/Imagine/Cache/Resolver/FlysystemResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/FlysystemResolverTest.php
@@ -43,7 +43,7 @@ class FlysystemResolverTest extends AbstractTest
     {
         $resolver = new FlysystemResolver($this->createFlySystemMock(), new RequestContext(), 'http://images.example.com');
 
-        $this->assertEquals(
+        $this->assertSame(
             'http://images.example.com/media/cache/thumb/some-folder/path.jpg',
             $resolver->resolve('/some-folder/path.jpg', 'thumb')
         );
@@ -59,7 +59,7 @@ class FlysystemResolverTest extends AbstractTest
             ->with('media/cache/theFilter');
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
-        $resolver->remove(array(), array($expectedFilter));
+        $resolver->remove([], [$expectedFilter]);
     }
 
     public function testCreateObjectInAdapter()
@@ -96,7 +96,7 @@ class FlysystemResolverTest extends AbstractTest
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
 
-        $this->assertEquals(
+        $this->assertSame(
             'http://images.example.com/media/cache/thumb/some-folder/path.jpg',
             $resolver->resolve('/some-folder/path.jpg', 'thumb')
         );
@@ -117,7 +117,7 @@ class FlysystemResolverTest extends AbstractTest
             ->will($this->returnValue(true));
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
-        $resolver->remove(array('some-folder/path.jpg'), array('thumb'));
+        $resolver->remove(['some-folder/path.jpg'], ['thumb']);
     }
 
     public function testRemoveCacheForSomePathsAndFilterOnRemove()
@@ -146,8 +146,8 @@ class FlysystemResolverTest extends AbstractTest
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
         $resolver->remove(
-            array('pathOne.jpg', 'pathTwo.jpg'),
-            array('thumb')
+            ['pathOne.jpg', 'pathTwo.jpg'],
+            ['thumb']
         );
     }
 
@@ -197,8 +197,8 @@ class FlysystemResolverTest extends AbstractTest
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
         $resolver->remove(
-            array('pathOne.jpg', 'pathTwo.jpg'),
-            array('filterOne', 'filterTwo')
+            ['pathOne.jpg', 'pathTwo.jpg'],
+            ['filterOne', 'filterTwo']
         );
     }
 
@@ -215,7 +215,7 @@ class FlysystemResolverTest extends AbstractTest
             ->method('delete');
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
-        $resolver->remove(array('some-folder/path.jpg'), array('thumb'));
+        $resolver->remove(['some-folder/path.jpg'], ['thumb']);
     }
 
     public function testRemoveCacheForFilterOnRemove()
@@ -229,7 +229,7 @@ class FlysystemResolverTest extends AbstractTest
             ->with('media/cache/theFilter');
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
-        $resolver->remove(array(), array($expectedFilter));
+        $resolver->remove([], [$expectedFilter]);
     }
 
     public function testRemoveCacheForSomeFiltersOnRemove()
@@ -248,7 +248,7 @@ class FlysystemResolverTest extends AbstractTest
             ->with('media/cache/theFilterTwo');
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
-        $resolver->remove(array(), array($expectedFilterOne, $expectedFilterTwo));
+        $resolver->remove([], [$expectedFilterOne, $expectedFilterTwo]);
     }
 
     /**
@@ -259,13 +259,13 @@ class FlysystemResolverTest extends AbstractTest
         return $this
             ->getMockBuilder(Filesystem::class)
             ->disableOriginalConstructor()
-            ->setMethods(array(
+            ->setMethods([
                 'delete',
                 'deleteDir',
                 'has',
                 'put',
                 'remove',
-            ))
+            ])
             ->getMock();
     }
 }

--- a/Tests/Imagine/Cache/Resolver/NoCacheWebPathResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/NoCacheWebPathResolverTest.php
@@ -32,7 +32,7 @@ class NoCacheWebPathResolverTest extends AbstractTest
     {
         $resolver = new NoCacheWebPathResolver(new RequestContext('', 'GET', 'thehost', 'theSchema'));
 
-        $this->assertEquals('theschema://thehost/aPath', $resolver->resolve('aPath', 'aFilter'));
+        $this->assertSame('theschema://thehost/aPath', $resolver->resolve('aPath', 'aFilter'));
     }
 
     public function testDoNothingOnStore()
@@ -45,7 +45,7 @@ class NoCacheWebPathResolverTest extends AbstractTest
     public function testDoNothingForPathAndFilterOnRemove()
     {
         $resolver = new NoCacheWebPathResolver(new RequestContext());
-        $resolver->remove(array('a/path'), array('aFilter'));
+        $resolver->remove(['a/path'], ['aFilter']);
 
         $this->assertInstanceOf(NoCacheWebPathResolver::class, $resolver);
     }
@@ -53,7 +53,7 @@ class NoCacheWebPathResolverTest extends AbstractTest
     public function testDoNothingForSomePathsAndSomeFiltersOnRemove()
     {
         $resolver = new NoCacheWebPathResolver(new RequestContext());
-        $resolver->remove(array('foo', 'bar'), array('foo', 'bar'));
+        $resolver->remove(['foo', 'bar'], ['foo', 'bar']);
 
         $this->assertInstanceOf(NoCacheWebPathResolver::class, $resolver);
     }
@@ -61,7 +61,7 @@ class NoCacheWebPathResolverTest extends AbstractTest
     public function testDoNothingForEmptyPathAndEmptyFilterOnRemove()
     {
         $resolver = new NoCacheWebPathResolver(new RequestContext());
-        $resolver->remove(array(), array());
+        $resolver->remove([], []);
 
         $this->assertInstanceOf(NoCacheWebPathResolver::class, $resolver);
     }

--- a/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
@@ -34,7 +34,7 @@ class ProxyResolverTest extends AbstractTest
     public function setUp()
     {
         $this->primaryResolver = $this->createObjectMock(ResolverInterface::class);
-        $this->resolver = new ProxyResolver($this->primaryResolver, array('http://images.example.com'));
+        $this->resolver = new ProxyResolver($this->primaryResolver, ['http://images.example.com']);
     }
 
     public function testProxyCallAndRewriteReturnedUrlOnResolve()
@@ -50,7 +50,7 @@ class ProxyResolverTest extends AbstractTest
 
         $result = $this->resolver->resolve($expectedPath, $expectedFilter);
 
-        $this->assertEquals('http://images.example.com/thumbs/foo/bar/bazz.png', $result);
+        $this->assertSame('http://images.example.com/thumbs/foo/bar/bazz.png', $result);
     }
 
     public function testProxyCallAndRewriteReturnedUrlEvenSchemesDiffersOnResolve()
@@ -66,7 +66,7 @@ class ProxyResolverTest extends AbstractTest
 
         $result = $this->resolver->resolve($expectedPath, $expectedFilter);
 
-        $this->assertEquals('http://images.example.com/thumbs/foo/bar/bazz.png', $result);
+        $this->assertSame('http://images.example.com/thumbs/foo/bar/bazz.png', $result);
     }
 
     public function testProxyCallAndRewriteReturnedUrlWithMatchReplaceOnResolve()
@@ -80,13 +80,13 @@ class ProxyResolverTest extends AbstractTest
             ->with($expectedPath, $expectedFilter)
             ->will($this->returnValue('https://s3-eu-west-1.amazonaws.com/s3-cache.example.com/thumbs/foo/bar/bazz.png'));
 
-        $this->resolver = new ProxyResolver($this->primaryResolver, array(
+        $this->resolver = new ProxyResolver($this->primaryResolver, [
             'https://s3-eu-west-1.amazonaws.com/s3-cache.example.com' => 'http://images.example.com',
-        ));
+        ]);
 
         $result = $this->resolver->resolve($expectedPath, $expectedFilter);
 
-        $this->assertEquals('http://images.example.com/thumbs/foo/bar/bazz.png', $result);
+        $this->assertSame('http://images.example.com/thumbs/foo/bar/bazz.png', $result);
     }
 
     public function testProxyCallAndRewriteReturnedUrlWithRegExpOnResolve()
@@ -100,13 +100,13 @@ class ProxyResolverTest extends AbstractTest
             ->with($expectedPath, $expectedFilter)
             ->will($this->returnValue('http://foo.com/thumbs/foo/bar/bazz.png'));
 
-        $this->resolver = new ProxyResolver($this->primaryResolver, array(
+        $this->resolver = new ProxyResolver($this->primaryResolver, [
             'regexp/http:\/\/.*?\//' => 'http://bar.com/',
-        ));
+        ]);
 
         $result = $this->resolver->resolve($expectedPath, $expectedFilter);
 
-        $this->assertEquals('http://bar.com/thumbs/foo/bar/bazz.png', $result);
+        $this->assertSame('http://bar.com/thumbs/foo/bar/bazz.png', $result);
     }
 
     public function testProxyCallAndReturnedValueOnIsStored()
@@ -139,8 +139,8 @@ class ProxyResolverTest extends AbstractTest
 
     public function testProxyCallOnRemove()
     {
-        $expectedPaths = array('thePath');
-        $expectedFilters = array('theFilter');
+        $expectedPaths = ['thePath'];
+        $expectedFilters = ['theFilter'];
 
         $this->primaryResolver
             ->expects($this->once())

--- a/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
@@ -181,7 +181,7 @@ class WebPathResolverTest extends TestCase
             'aCachePrefix'
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'theschema://thehost/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
@@ -201,7 +201,7 @@ class WebPathResolverTest extends TestCase
             'aCachePrefix'
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'theschema://thehost/theBasePath/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
@@ -221,7 +221,7 @@ class WebPathResolverTest extends TestCase
             'aCachePrefix'
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'theschema://thehost/theBasePath/theSubBasePath/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
@@ -241,7 +241,7 @@ class WebPathResolverTest extends TestCase
             'aCachePrefix'
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'theschema://thehost/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
@@ -261,7 +261,7 @@ class WebPathResolverTest extends TestCase
             'aCachePrefix'
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'http://thehost:88/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
@@ -281,7 +281,7 @@ class WebPathResolverTest extends TestCase
             'aCachePrefix'
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'https://thehost:444/aCachePrefix/aFilter/aPath',
             $resolver->resolve('aPath', 'aFilter')
         );
@@ -321,7 +321,7 @@ class WebPathResolverTest extends TestCase
             'aCachePrefix'
         );
 
-        $resolver->remove(array(), array());
+        $resolver->remove([], []);
     }
 
     public function testRemoveCacheForPathAndFilterOnRemove()
@@ -339,7 +339,7 @@ class WebPathResolverTest extends TestCase
             'aCachePrefix'
         );
 
-        $resolver->remove(array('aPath'), array('aFilter'));
+        $resolver->remove(['aPath'], ['aFilter']);
     }
 
     public function testRemoveCacheForSomePathsAndFilterOnRemove()
@@ -361,7 +361,7 @@ class WebPathResolverTest extends TestCase
             'aCachePrefix'
         );
 
-        $resolver->remove(array('aPathOne', 'aPathTwo'), array('aFilter'));
+        $resolver->remove(['aPathOne', 'aPathTwo'], ['aFilter']);
     }
 
     public function testRemoveCacheForSomePathsAndSomeFiltersOnRemove()
@@ -392,8 +392,8 @@ class WebPathResolverTest extends TestCase
         );
 
         $resolver->remove(
-            array('aPathOne', 'aPathTwo'),
-            array('aFilterOne', 'aFilterTwo')
+            ['aPathOne', 'aPathTwo'],
+            ['aFilterOne', 'aFilterTwo']
         );
     }
 
@@ -403,9 +403,9 @@ class WebPathResolverTest extends TestCase
         $filesystemMock
             ->expects($this->once())
             ->method('remove')
-            ->with(array(
+            ->with([
                 '/aWebRoot/aCachePrefix/aFilter',
-            ));
+            ]);
 
         $resolver = new WebPathResolver(
             $filesystemMock,
@@ -414,7 +414,7 @@ class WebPathResolverTest extends TestCase
             'aCachePrefix'
         );
 
-        $resolver->remove(array(), array('aFilter'));
+        $resolver->remove([], ['aFilter']);
     }
 
     public function testRemoveCacheForSomeFiltersOnRemove()
@@ -423,10 +423,10 @@ class WebPathResolverTest extends TestCase
         $filesystemMock
             ->expects($this->once())
             ->method('remove')
-            ->with(array(
+            ->with([
                 '/aWebRoot/aCachePrefix/aFilterOne',
                 '/aWebRoot/aCachePrefix/aFilterTwo',
-            ));
+            ]);
 
         $resolver = new WebPathResolver(
             $filesystemMock,
@@ -435,7 +435,7 @@ class WebPathResolverTest extends TestCase
             'aCachePrefix'
         );
 
-        $resolver->remove(array(), array('aFilterOne', 'aFilterTwo'));
+        $resolver->remove([], ['aFilterOne', 'aFilterTwo']);
     }
 
     public function testShouldRemoveDoubleSlashInUrl()
@@ -451,9 +451,9 @@ class WebPathResolverTest extends TestCase
         $method = $rc->getMethod('getFileUrl');
         $method->setAccessible(true);
 
-        $result = $method->invokeArgs($resolver, array('/cats.jpg', 'some_filter'));
+        $result = $method->invokeArgs($resolver, ['/cats.jpg', 'some_filter']);
 
-        $this->assertEquals('aCachePrefix/some_filter/cats.jpg', $result);
+        $this->assertSame('aCachePrefix/some_filter/cats.jpg', $result);
     }
 
     public function testShouldSanitizeSeparatorBetweenSchemeAndAuthorityInUrl()
@@ -469,9 +469,9 @@ class WebPathResolverTest extends TestCase
         $method = $rc->getMethod('getFileUrl');
         $method->setAccessible(true);
 
-        $result = $method->invokeArgs($resolver, array('https://some.meme.com/cute/cats.jpg', 'some_filter'));
+        $result = $method->invokeArgs($resolver, ['https://some.meme.com/cute/cats.jpg', 'some_filter']);
 
-        $this->assertEquals('aCachePrefix/some_filter/https---some.meme.com/cute/cats.jpg', $result);
+        $this->assertSame('aCachePrefix/some_filter/https---some.meme.com/cute/cats.jpg', $result);
     }
 
     /**

--- a/Tests/Imagine/Cache/SignerTest.php
+++ b/Tests/Imagine/Cache/SignerTest.php
@@ -38,7 +38,7 @@ class SignerTest extends AbstractTest
     {
         $singer = new Signer('aSecret');
 
-        $this->assertEquals(8, strlen($singer->sign('aPath')));
+        $this->assertSame(8, mb_strlen($singer->sign('aPath')));
     }
 
     public function testShouldSingAndSuccessfullyCheckPathWithoutRuntimeConfig()
@@ -52,26 +52,26 @@ class SignerTest extends AbstractTest
     {
         $singer = new Signer('aSecret');
 
-        $this->assertTrue($singer->check($singer->sign('aPath', array('aConfig')), 'aPath', array('aConfig')));
+        $this->assertTrue($singer->check($singer->sign('aPath', ['aConfig']), 'aPath', ['aConfig']));
     }
 
     public function testShouldConvertRecursivelyToStringAllRuntimeConfigParameters()
     {
         $singer = new Signer('aSecret');
 
-        $runtimeConfigInts = array(
+        $runtimeConfigInts = [
             'foo' => 14,
-            'bar' => array(
+            'bar' => [
                 'bar' => 15,
-            ),
-        );
+            ],
+        ];
 
-        $runtimeConfigStrings = array(
+        $runtimeConfigStrings = [
             'foo' => '14',
-            'bar' => array(
+            'bar' => [
                 'bar' => '15',
-            ),
-        );
+            ],
+        ];
 
         $this->assertTrue($singer->check($singer->sign('aPath', $runtimeConfigInts), 'aPath', $runtimeConfigStrings));
     }

--- a/Tests/Imagine/Data/DataManagerTest.php
+++ b/Tests/Imagine/Data/DataManagerTest.php
@@ -33,11 +33,11 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'size' => array(180, 180),
+            ->will($this->returnValue([
+                'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => null,
-            )));
+            ]));
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -64,11 +64,11 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'size' => array(180, 180),
+            ->will($this->returnValue([
+                'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            )));
+            ]));
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -82,12 +82,11 @@ class DataManagerTest extends AbstractTest
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The mime type of image cats.jpeg was not guessed
-     */
     public function testThrowsIfMimeTypeWasNotGuessedOnFind()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The mime type of image cats.jpeg was not guessed');
+
         $loader = $this->createBinaryLoaderInterfaceMock();
         $loader
             ->expects($this->once())
@@ -99,11 +98,11 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'size' => array(180, 180),
+            ->will($this->returnValue([
+                'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            )));
+            ]));
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -116,12 +115,11 @@ class DataManagerTest extends AbstractTest
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The mime type of image cats.jpeg must be image/xxx got text/plain
-     */
     public function testThrowsIfMimeTypeNotImageOneOnFind()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The mime type of image cats.jpeg must be image/xxx got text/plain');
+
         $loader = $this->createBinaryLoaderInterfaceMock();
         $loader
             ->expects($this->once())
@@ -134,11 +132,11 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'size' => array(180, 180),
+            ->will($this->returnValue([
+                'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            )));
+            ]));
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -151,12 +149,11 @@ class DataManagerTest extends AbstractTest
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The mime type of image cats.jpeg was not guessed
-     */
     public function testThrowsIfLoaderReturnBinaryWithEmtptyMimeTypeOnFind()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The mime type of image cats.jpeg was not guessed');
+
         $loader = $this->createBinaryLoaderInterfaceMock();
         $loader
             ->expects($this->once())
@@ -169,11 +166,11 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'size' => array(180, 180),
+            ->will($this->returnValue([
+                'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            )));
+            ]));
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -185,12 +182,11 @@ class DataManagerTest extends AbstractTest
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The mime type of image cats.jpeg must be image/xxx got text/plain
-     */
     public function testThrowsIfLoaderReturnBinaryWithMimeTypeNotImageOneOnFind()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The mime type of image cats.jpeg must be image/xxx got text/plain');
+
         $binary = new Binary('content', 'text/plain');
 
         $loader = $this->createBinaryLoaderInterfaceMock();
@@ -205,11 +201,11 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'size' => array(180, 180),
+            ->will($this->returnValue([
+                'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            )));
+            ]));
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -221,22 +217,21 @@ class DataManagerTest extends AbstractTest
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Could not find data loader "" for "thumbnail" filter type
-     */
     public function testThrowIfLoaderNotRegisteredForGivenFilterOnFind()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not find data loader "" for "thumbnail" filter type');
+
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'size' => array(180, 180),
+            ->will($this->returnValue([
+                'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => null,
-            )));
+            ]));
 
         $dataManager = new DataManager($this->createMimeTypeGuesserInterfaceMock(), $this->createExtensionGuesserInterfaceMock(), $config);
         $dataManager->find('thumbnail', 'cats.jpeg');
@@ -265,11 +260,11 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'size' => array(180, 180),
+            ->will($this->returnValue([
+                'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => null,
-            )));
+            ]));
 
         $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config, 'default');
         $dataManager->addLoader('default', $loader);
@@ -277,8 +272,8 @@ class DataManagerTest extends AbstractTest
         $binary = $dataManager->find('thumbnail', 'cats.jpeg');
 
         $this->assertInstanceOf(Binary::class, $binary);
-        $this->assertEquals($expectedContent, $binary->getContent());
-        $this->assertEquals($expectedMimeType, $binary->getMimeType());
+        $this->assertSame($expectedContent, $binary->getContent());
+        $this->assertSame($expectedMimeType, $binary->getMimeType());
     }
 
     public function testShouldReturnBinaryWithLoaderContentAndGuessedFormatOnFind()
@@ -312,11 +307,11 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'size' => array(180, 180),
+            ->will($this->returnValue([
+                'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => null,
-            )));
+            ]));
 
         $dataManager = new DataManager($mimeTypeGuesser, $extensionGuesser, $config, 'default');
         $dataManager->addLoader('default', $loader);
@@ -324,7 +319,7 @@ class DataManagerTest extends AbstractTest
         $binary = $dataManager->find('thumbnail', 'cats.jpeg');
 
         $this->assertInstanceOf(Binary::class, $binary);
-        $this->assertEquals($expectedFormat, $binary->getFormat());
+        $this->assertSame($expectedFormat, $binary->getFormat());
     }
 
     public function testUseDefaultGlobalImageUsedIfImageNotFound()
@@ -336,9 +331,9 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
+            ->will($this->returnValue([
                 'default_image' => null,
-            )));
+            ]));
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -350,7 +345,7 @@ class DataManagerTest extends AbstractTest
         $dataManager->addLoader('default', $loader);
 
         $defaultImage = $dataManager->getDefaultImageUrl('thumbnail');
-        $this->assertEquals($defaultImage, $defaultGlobalImage);
+        $this->assertSame($defaultImage, $defaultGlobalImage);
     }
 
     public function testUseDefaultFilterImageUsedIfImageNotFound()
@@ -364,9 +359,9 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
+            ->will($this->returnValue([
                 'default_image' => $defaultFilterImage,
-            )));
+            ]));
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -377,6 +372,6 @@ class DataManagerTest extends AbstractTest
         $dataManager->addLoader('default', $loader);
 
         $defaultImage = $dataManager->getDefaultImageUrl('thumbnail');
-        $this->assertEquals($defaultImage, $defaultFilterImage);
+        $this->assertSame($defaultImage, $defaultFilterImage);
     }
 }

--- a/Tests/Imagine/Filter/FilterConfigurationTest.php
+++ b/Tests/Imagine/Filter/FilterConfigurationTest.php
@@ -21,75 +21,74 @@ class FilterConfigurationTest extends AbstractTest
 {
     public function testSetAndGetFilter()
     {
-        $config = array(
-            'filters' => array(
-                'thumbnail' => array(
-                    'size' => array(180, 180),
+        $config = [
+            'filters' => [
+                'thumbnail' => [
+                    'size' => [180, 180],
                     'mode' => 'outbound',
-                ),
-            ),
+                ],
+            ],
             'cache' => 'web_path',
-        );
+        ];
 
         $filterConfiguration = new FilterConfiguration();
         $filterConfiguration->set('profile_photo', $config);
 
-        $this->assertEquals($config, $filterConfiguration->get('profile_photo'));
+        $this->assertSame($config, $filterConfiguration->get('profile_photo'));
     }
 
     public function testReturnAllFilters()
     {
         $filterConfiguration = new FilterConfiguration();
-        $filterConfiguration->set('foo', array('fooConfig'));
-        $filterConfiguration->set('bar', array('barConfig'));
+        $filterConfiguration->set('foo', ['fooConfig']);
+        $filterConfiguration->set('bar', ['barConfig']);
 
         $filters = $filterConfiguration->all();
 
         $this->assertInternalType('array', $filters);
 
         $this->assertArrayHasKey('foo', $filters);
-        $this->assertEquals(array('fooConfig'), $filters['foo']);
+        $this->assertSame(['fooConfig'], $filters['foo']);
 
         $this->assertArrayHasKey('bar', $filters);
-        $this->assertEquals(array('barConfig'), $filters['bar']);
+        $this->assertSame(['barConfig'], $filters['bar']);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Could not find configuration for a filter: thumbnail
-     */
     public function testGetUndefinedFilter()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Could not find configuration for a filter: thumbnail');
+
         $filterConfiguration = new FilterConfiguration();
         $filterConfiguration->get('thumbnail');
     }
 
     public function testShouldGetSameConfigSetBefore()
     {
-        $config = array(
+        $config = [
             'quality' => 85,
             'format' => 'jpg',
-            'filters' => array(
-                'thumbnail' => array(
-                    'size' => array(180, 180),
+            'filters' => [
+                'thumbnail' => [
+                    'size' => [180, 180],
                     'mode' => 'outbound',
-                ),
-            ),
+                ],
+            ],
             'cache' => 'web_path',
-        );
+        ];
 
         $filterConfiguration = new FilterConfiguration();
         $filterConfiguration->set('profile_photo', $config);
 
-        $this->assertEquals($config, $filterConfiguration->get('profile_photo'));
+        $this->assertSame($config, $filterConfiguration->get('profile_photo'));
     }
 
     public function testGetConfigSetViaConstructor()
     {
-        $filterConfiguration = new FilterConfiguration(array(
-            'profile_photo' => array(),
-            'thumbnail' => array(),
-        ));
+        $filterConfiguration = new FilterConfiguration([
+            'profile_photo' => [],
+            'thumbnail' => [],
+        ]);
 
         $this->assertInternalType('array', $filterConfiguration->get('profile_photo'));
         $this->assertInternalType('array', $filterConfiguration->get('thumbnail'));

--- a/Tests/Imagine/Filter/FilterManagerTest.php
+++ b/Tests/Imagine/Filter/FilterManagerTest.php
@@ -22,26 +22,25 @@ use Liip\ImagineBundle\Tests\AbstractTest;
  */
 class FilterManagerTest extends AbstractTest
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Could not find filter loader for "thumbnail" filter type
-     */
     public function testThrowsIfNoLoadersAddedForFilterOnApplyFilter()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not find filter loader for "thumbnail" filter type');
+
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
-                    'thumbnail' => array(
-                        'size' => array(180, 180),
+            ->will($this->returnValue([
+                'filters' => [
+                    'thumbnail' => [
+                        'size' => [180, 180],
                         'mode' => 'outbound',
-                    ),
-                ),
-                'post_processors' => array(),
-            )));
+                    ],
+                ],
+                'post_processors' => [],
+            ]));
 
         $binary = new Binary('aContent', 'image/png', 'png');
 
@@ -61,22 +60,22 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, 'image/png', 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
+            ->will($this->returnValue([
+                'filters' => [
                     'thumbnail' => $thumbConfig,
-                ),
-                'post_processors' => array(),
-            )));
+                ],
+                'post_processors' => [],
+            ]));
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -108,7 +107,7 @@ class FilterManagerTest extends AbstractTest
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
-        $this->assertEquals($expectedFilteredContent, $filteredBinary->getContent());
+        $this->assertSame($expectedFilteredContent, $filteredBinary->getContent());
     }
 
     public function testReturnFilteredBinaryWithFormatOfOriginalBinaryOnApplyFilter()
@@ -118,22 +117,22 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, 'image/png', $expectedFormat);
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
+            ->will($this->returnValue([
+                'filters' => [
                     'thumbnail' => $thumbConfig,
-                ),
-                'post_processors' => array(),
-            )));
+                ],
+                'post_processors' => [],
+            ]));
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -164,7 +163,7 @@ class FilterManagerTest extends AbstractTest
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
-        $this->assertEquals($expectedFormat, $filteredBinary->getFormat());
+        $this->assertSame($expectedFormat, $filteredBinary->getFormat());
     }
 
     public function testReturnFilteredBinaryWithCustomFormatIfSetOnApplyFilter()
@@ -175,23 +174,23 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, 'image/png', $originalFormat);
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
+            ->will($this->returnValue([
                 'format' => $expectedFormat,
-                'filters' => array(
+                'filters' => [
                     'thumbnail' => $thumbConfig,
-                ),
-                'post_processors' => array(),
-            )));
+                ],
+                'post_processors' => [],
+            ]));
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -222,7 +221,7 @@ class FilterManagerTest extends AbstractTest
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
-        $this->assertEquals($expectedFormat, $filteredBinary->getFormat());
+        $this->assertSame($expectedFormat, $filteredBinary->getFormat());
     }
 
     public function testReturnFilteredBinaryWithMimeTypeOfOriginalBinaryOnApplyFilter()
@@ -232,22 +231,22 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, $expectedMimeType, 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
+            ->will($this->returnValue([
+                'filters' => [
                     'thumbnail' => $thumbConfig,
-                ),
-                'post_processors' => array(),
-            )));
+                ],
+                'post_processors' => [],
+            ]));
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -283,7 +282,7 @@ class FilterManagerTest extends AbstractTest
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
-        $this->assertEquals($expectedMimeType, $filteredBinary->getMimeType());
+        $this->assertSame($expectedMimeType, $filteredBinary->getMimeType());
     }
 
     public function testReturnFilteredBinaryWithMimeTypeOfCustomFormatIfSetOnApplyFilter()
@@ -295,23 +294,23 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, $originalMimeType, 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
+            ->will($this->returnValue([
                 'format' => 'jpg',
-                'filters' => array(
+                'filters' => [
                     'thumbnail' => $thumbConfig,
-                ),
-                'post_processors' => array(),
-            )));
+                ],
+                'post_processors' => [],
+            ]));
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -349,7 +348,7 @@ class FilterManagerTest extends AbstractTest
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
-        $this->assertEquals($expectedMimeType, $filteredBinary->getMimeType());
+        $this->assertSame($expectedMimeType, $filteredBinary->getMimeType());
     }
 
     public function testAltersQualityOnApplyFilter()
@@ -359,29 +358,29 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, 'image/png', 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
+            ->will($this->returnValue([
                 'quality' => $expectedQuality,
-                'filters' => array(
+                'filters' => [
                     'thumbnail' => $thumbConfig,
-                ),
-                'post_processors' => array(),
-            )));
+                ],
+                'post_processors' => [],
+            ]));
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->with('png', array('quality' => $expectedQuality))
+            ->with('png', ['quality' => $expectedQuality])
             ->will($this->returnValue('aFilteredContent'));
 
         $imagine = $this->createImagineInterfaceMock();
@@ -414,28 +413,28 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, 'image/png', 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
+            ->will($this->returnValue([
+                'filters' => [
                     'thumbnail' => $thumbConfig,
-                ),
-                'post_processors' => array(),
-            )));
+                ],
+                'post_processors' => [],
+            ]));
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->with('png', array('quality' => $expectedQuality))
+            ->with('png', ['quality' => $expectedQuality])
             ->will($this->returnValue('aFilteredContent'));
 
         $imagine = $this->createImagineInterfaceMock();
@@ -465,36 +464,36 @@ class FilterManagerTest extends AbstractTest
     {
         $binary = new Binary('aContent', 'image/png', 'png');
 
-        $runtimeConfig = array(
-            'filters' => array(
-                'thumbnail' => array(
-                    'size' => array(100, 100),
-                ),
-            ),
-            'post_processors' => array(),
-        );
+        $runtimeConfig = [
+            'filters' => [
+                'thumbnail' => [
+                    'size' => [100, 100],
+                ],
+            ],
+            'post_processors' => [],
+        ];
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
-        $thumbMergedConfig = array(
-            'size' => array(100, 100),
+        $thumbMergedConfig = [
+            'size' => [100, 100],
             'mode' => 'outbound',
-        );
+        ];
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
+            ->will($this->returnValue([
+                'filters' => [
                     'thumbnail' => $thumbConfig,
-                ),
-                'post_processors' => array(),
-            )));
+                ],
+                'post_processors' => [],
+            ]));
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -527,12 +526,12 @@ class FilterManagerTest extends AbstractTest
             $filterManager->applyFilter($binary, 'thumbnail', $runtimeConfig)
         );
     }
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Could not find filter loader for "thumbnail" filter type
-     */
+
     public function testThrowsIfNoLoadersAddedForFilterOnApply()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not find filter loader for "thumbnail" filter type');
+
         $binary = new Binary('aContent', 'image/png', 'png');
 
         $filterManager = new FilterManager(
@@ -541,14 +540,14 @@ class FilterManagerTest extends AbstractTest
             $this->createMimeTypeGuesserInterfaceMock()
         );
 
-        $filterManager->apply($binary, array(
-            'filters' => array(
-                'thumbnail' => array(
-                    'size' => array(180, 180),
+        $filterManager->apply($binary, [
+            'filters' => [
+                'thumbnail' => [
+                    'size' => [180, 180],
                     'mode' => 'outbound',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
     }
 
     public function testReturnFilteredBinaryWithExpectedContentOnApply()
@@ -558,10 +557,10 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, 'image/png', 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -590,15 +589,15 @@ class FilterManagerTest extends AbstractTest
         );
         $filterManager->addLoader('thumbnail', $loader);
 
-        $filteredBinary = $filterManager->apply($binary, array(
-            'filters' => array(
+        $filteredBinary = $filterManager->apply($binary, [
+            'filters' => [
                 'thumbnail' => $thumbConfig,
-            ),
-            'post_processors' => array(),
-        ));
+            ],
+            'post_processors' => [],
+        ]);
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
-        $this->assertEquals($expectedFilteredContent, $filteredBinary->getContent());
+        $this->assertSame($expectedFilteredContent, $filteredBinary->getContent());
     }
 
     public function testReturnFilteredBinaryWithFormatOfOriginalBinaryOnApply()
@@ -608,10 +607,10 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, 'image/png', $expectedFormat);
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -639,15 +638,15 @@ class FilterManagerTest extends AbstractTest
         );
         $filterManager->addLoader('thumbnail', $loader);
 
-        $filteredBinary = $filterManager->apply($binary, array(
-            'filters' => array(
+        $filteredBinary = $filterManager->apply($binary, [
+            'filters' => [
                 'thumbnail' => $thumbConfig,
-            ),
-            'post_processors' => array(),
-        ));
+            ],
+            'post_processors' => [],
+        ]);
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
-        $this->assertEquals($expectedFormat, $filteredBinary->getFormat());
+        $this->assertSame($expectedFormat, $filteredBinary->getFormat());
     }
 
     public function testReturnFilteredBinaryWithCustomFormatIfSetOnApply()
@@ -658,10 +657,10 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, 'image/png', $originalFormat);
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -689,16 +688,16 @@ class FilterManagerTest extends AbstractTest
         );
         $filterManager->addLoader('thumbnail', $loader);
 
-        $filteredBinary = $filterManager->apply($binary, array(
+        $filteredBinary = $filterManager->apply($binary, [
             'format' => $expectedFormat,
-            'filters' => array(
+            'filters' => [
                 'thumbnail' => $thumbConfig,
-            ),
-            'post_processors' => array(),
-        ));
+            ],
+            'post_processors' => [],
+        ]);
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
-        $this->assertEquals($expectedFormat, $filteredBinary->getFormat());
+        $this->assertSame($expectedFormat, $filteredBinary->getFormat());
     }
 
     public function testReturnFilteredBinaryWithMimeTypeOfOriginalBinaryOnApply()
@@ -708,10 +707,10 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, $expectedMimeType, 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -744,15 +743,15 @@ class FilterManagerTest extends AbstractTest
         );
         $filterManager->addLoader('thumbnail', $loader);
 
-        $filteredBinary = $filterManager->apply($binary, array(
-            'filters' => array(
+        $filteredBinary = $filterManager->apply($binary, [
+            'filters' => [
                 'thumbnail' => $thumbConfig,
-            ),
-            'post_processors' => array(),
-        ));
+            ],
+            'post_processors' => [],
+        ]);
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
-        $this->assertEquals($expectedMimeType, $filteredBinary->getMimeType());
+        $this->assertSame($expectedMimeType, $filteredBinary->getMimeType());
     }
 
     public function testReturnFilteredBinaryWithMimeTypeOfCustomFormatIfSetOnApply()
@@ -764,10 +763,10 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, $originalMimeType, 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -802,16 +801,16 @@ class FilterManagerTest extends AbstractTest
         );
         $filterManager->addLoader('thumbnail', $loader);
 
-        $filteredBinary = $filterManager->apply($binary, array(
+        $filteredBinary = $filterManager->apply($binary, [
             'format' => 'jpg',
-            'filters' => array(
+            'filters' => [
                 'thumbnail' => $thumbConfig,
-            ),
-            'post_processors' => array(),
-        ));
+            ],
+            'post_processors' => [],
+        ]);
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
-        $this->assertEquals($expectedMimeType, $filteredBinary->getMimeType());
+        $this->assertSame($expectedMimeType, $filteredBinary->getMimeType());
     }
 
     public function testAltersQualityOnApply()
@@ -821,16 +820,16 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, 'image/png', 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->with('png', array('quality' => $expectedQuality))
+            ->with('png', ['quality' => $expectedQuality])
             ->will($this->returnValue('aFilteredContent'));
 
         $imagineMock = $this->createImagineInterfaceMock();
@@ -853,13 +852,13 @@ class FilterManagerTest extends AbstractTest
         );
         $filterManager->addLoader('thumbnail', $loader);
 
-        $filteredBinary = $filterManager->apply($binary, array(
+        $filteredBinary = $filterManager->apply($binary, [
             'quality' => $expectedQuality,
-            'filters' => array(
+            'filters' => [
                 'thumbnail' => $thumbConfig,
-            ),
-            'post_processors' => array(),
-        ));
+            ],
+            'post_processors' => [],
+        ]);
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
     }
@@ -871,16 +870,16 @@ class FilterManagerTest extends AbstractTest
 
         $binary = new Binary($originalContent, 'image/png', 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->with('png', array('quality' => $expectedQuality))
+            ->with('png', ['quality' => $expectedQuality])
             ->will($this->returnValue('aFilteredContent'));
 
         $imagineMock = $this->createImagineInterfaceMock();
@@ -903,12 +902,12 @@ class FilterManagerTest extends AbstractTest
         );
         $filterManager->addLoader('thumbnail', $loader);
 
-        $filteredBinary = $filterManager->apply($binary, array(
-            'filters' => array(
+        $filteredBinary = $filterManager->apply($binary, [
+            'filters' => [
                 'thumbnail' => $thumbConfig,
-            ),
-            'post_processors' => array(),
-        ));
+            ],
+            'post_processors' => [],
+        ]);
 
         $this->assertInstanceOf(Binary::class, $filteredBinary);
     }
@@ -919,29 +918,29 @@ class FilterManagerTest extends AbstractTest
         $expectedPostProcessedContent = 'postProcessedContent';
         $binary = new Binary($originalContent, 'image/png', 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
+            ->will($this->returnValue([
+                'filters' => [
                     'thumbnail' => $thumbConfig,
-                ),
-                'post_processors' => array(
-                    'foo' => array(),
-                ),
-            )));
+                ],
+                'post_processors' => [
+                    'foo' => [],
+                ],
+            ]));
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -982,40 +981,40 @@ class FilterManagerTest extends AbstractTest
 
         $filteredBinary = $filterManager->applyFilter($binary, 'thumbnail');
         $this->assertInstanceOf(Binary::class, $filteredBinary);
-        $this->assertEquals($expectedPostProcessedContent, $filteredBinary->getContent());
+        $this->assertSame($expectedPostProcessedContent, $filteredBinary->getContent());
     }
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Could not find post processor "foo"
-     */
+
     public function testThrowsIfNoPostProcessorAddedForFilterOnApplyFilter()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not find post processor "foo"');
+
         $originalContent = 'aContent';
         $binary = new Binary($originalContent, 'image/png', 'png');
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue(array(
-                'filters' => array(
+            ->will($this->returnValue([
+                'filters' => [
                     'thumbnail' => $thumbConfig,
-                ),
-                'post_processors' => array(
-                    'foo' => array(),
-                ),
-            )));
+                ],
+                'post_processors' => [
+                    'foo' => [],
+                ],
+            ]));
 
-        $thumbConfig = array(
-            'size' => array(180, 180),
+        $thumbConfig = [
+            'size' => [180, 180],
             'mode' => 'outbound',
-        );
+        ];
 
         $image = $this->getImageInterfaceMock();
         $image
@@ -1056,7 +1055,7 @@ class FilterManagerTest extends AbstractTest
             $this->createMimeTypeGuesserInterfaceMock()
         );
 
-        $this->assertSame($binary, $filterManager->applyPostProcessors($binary, array()));
+        $this->assertSame($binary, $filterManager->applyPostProcessors($binary, []));
     }
 
     /**

--- a/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
@@ -47,7 +47,7 @@ class CropFilterLoaderTest extends AbstractTest
             ->with(new Point($x, $y), new Box($width, $height))
             ->willReturn($image);
 
-        $options = array();
+        $options = [];
         $options['start'] = $coordinates;
         $options['size'] = $area;
 
@@ -59,10 +59,10 @@ class CropFilterLoaderTest extends AbstractTest
      */
     public function cropDataProvider()
     {
-        return array(
-            array(array(140, 130), array(200, 129)),
-            array(array(30, 60), array(50, 50)),
-            array(array(400, 500), array(1, 30)),
-        );
+        return [
+            [[140, 130], [200, 129]],
+            [[30, 60], [50, 50]],
+            [[400, 500], [1, 30]],
+        ];
     }
 }

--- a/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
@@ -33,6 +33,7 @@ class DownscaleFilterLoaderTest extends AbstractTest
         $this->assertLessThanOrEqual($initialSize->getHeight(), $resultSize->getHeight());
         $this->assertLessThanOrEqual($initialSize->getWidth(), $resultSize->getWidth());
     }
+
     /**
      * @dataProvider provideSizes
      *
@@ -64,7 +65,7 @@ class DownscaleFilterLoaderTest extends AbstractTest
                 $resultSize = $box;
             });
 
-        $loader->load($image, array('max' => array(100, 90)));
+        $loader->load($image, ['max' => [100, 90]]);
 
         yield [$resultSize, $initialSize];
     }

--- a/Tests/Imagine/Filter/Loader/FlipFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/FlipFilterLoaderTest.php
@@ -24,10 +24,10 @@ class FlipFilterLoaderTest extends AbstractTest
      */
     public static function provideLoadWithAxisXOptionData()
     {
-        return array(
-            array('x'),
-            array('horizontal'),
-        );
+        return [
+            ['x'],
+            ['horizontal'],
+        ];
     }
 
     /**
@@ -42,7 +42,7 @@ class FlipFilterLoaderTest extends AbstractTest
             ->method('flipHorizontally')
             ->willReturn($image);
 
-        $this->createFlipFilterLoaderInstance()->load($image, array('axis' => $axis));
+        $this->createFlipFilterLoaderInstance()->load($image, ['axis' => $axis]);
     }
 
     /**
@@ -50,10 +50,10 @@ class FlipFilterLoaderTest extends AbstractTest
      */
     public static function provideLoadWithAxisYOptionData()
     {
-        return array(
-            array('y'),
-            array('vertical'),
-        );
+        return [
+            ['y'],
+            ['vertical'],
+        ];
     }
 
     /**
@@ -68,19 +68,18 @@ class FlipFilterLoaderTest extends AbstractTest
             ->method('flipVertically')
             ->willReturn($image);
 
-        $this->createFlipFilterLoaderInstance()->load($image, array('axis' => $axis));
+        $this->createFlipFilterLoaderInstance()->load($image, ['axis' => $axis]);
     }
 
-    /**
-     * @expectedException \Liip\ImagineBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The "axis" option must be set to "x", "horizontal", "y", or "vertical".
-     */
     public function testThrowsOnInvalidOptions()
     {
+        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "axis" option must be set to "x", "horizontal", "y", or "vertical".');
+
         $loader = new FlipFilterLoader();
-        $loader->load($this->getImageInterfaceMock(), array(
+        $loader->load($this->getImageInterfaceMock(), [
             'axis' => 'invalid',
-        ));
+        ]);
     }
 
     /**

--- a/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundDownscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundDownscaleFilterLoaderTest.php
@@ -30,13 +30,13 @@ class FloatToIntCastByRoundDownscaleFilterLoaderTest extends AbstractTest
         $imagine = new Imagine();
         $image = $imagine->open(__DIR__.'/../../../Fixtures/assets/square-300x300.png');
 
-        $options = array(
-            'max' => array(201, 201),
-        );
+        $options = [
+            'max' => [201, 201],
+        ];
 
         $image = $loader->load($image, $options);
         $size = $image->getSize();
 
-        $this->assertEquals($options['max'], array($size->getWidth(), $size->getHeight()));
+        $this->assertSame($options['max'], [$size->getWidth(), $size->getHeight()]);
     }
 }

--- a/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundUpscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/FloatToIntCastByRoundUpscaleFilterLoaderTest.php
@@ -30,13 +30,13 @@ class FloatToIntCastByRoundUpscaleFilterLoaderTest extends AbstractTest
         $imagine = new Imagine();
         $image = $imagine->open(__DIR__.'/../../../Fixtures/assets/square-50x50.png');
 
-        $options = array(
-            'min' => array(201, 201),
-        );
+        $options = [
+            'min' => [201, 201],
+        ];
 
         $image = $loader->load($image, $options);
         $size = $image->getSize();
 
-        $this->assertEquals($options['min'], array($size->getWidth(), $size->getHeight()));
+        $this->assertSame($options['min'], [$size->getWidth(), $size->getHeight()]);
     }
 }

--- a/Tests/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
@@ -32,13 +32,13 @@ class GrayscaleFilterLoaderTest extends AbstractTest
         $imagine = new Imagine();
 
         // Generate blue image
-        $image = $imagine->create(new Box(20, 20), $palette->color(array(20, 90, 240)));
+        $image = $imagine->create(new Box(20, 20), $palette->color([20, 90, 240]));
 
         //Apply Grayscale filter
         $result = $loader->load($image);
 
         //Test result
         $pixel = $result->getColorAt(new Point(10, 10));
-        $this->assertEquals('#565656', (string) $pixel);
+        $this->assertSame('#565656', (string) $pixel);
     }
 }

--- a/Tests/Imagine/Filter/Loader/InterlaceFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/InterlaceFilterLoaderTest.php
@@ -28,10 +28,9 @@ class InterlaceFilterLoaderTest extends AbstractTest
         $image
             ->expects($this->once())
             ->method('interlace')
-            ->with('TEST')
-        ;
+            ->with('TEST');
 
-        $result = $loader->load($image, array('mode' => 'TEST'));
+        $result = $loader->load($image, ['mode' => 'TEST']);
 
         $this->assertInstanceOf(ImageInterface::class, $result);
     }

--- a/Tests/Imagine/Filter/Loader/PasteFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/PasteFilterLoaderTest.php
@@ -62,8 +62,8 @@ class PasteFilterLoaderTest extends AbstractTest
             ->willReturn($image);
         $loader = new PasteFilterLoader($imagineMock, '');
 
-        $options = array();
-        $options['start'] = array($x, $y);
+        $options = [];
+        $options['start'] = [$x, $y];
         $options['image'] = '';
 
         $loader->load($image, $options);
@@ -74,10 +74,10 @@ class PasteFilterLoaderTest extends AbstractTest
      */
     public function pasteProvider()
     {
-        return array(
-            array(200, 129, new Point(200, 129)),
-            array(50, 50, new Point(50, 50)),
-            array(1, 30, new Point(1, 30)),
-        );
+        return [
+            [200, 129, new Point(200, 129)],
+            [50, 50, new Point(50, 50)],
+            [1, 30, new Point(1, 30)],
+        ];
     }
 }

--- a/Tests/Imagine/Filter/Loader/ResizeFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ResizeFilterLoaderTest.php
@@ -40,8 +40,8 @@ class ResizeFilterLoaderTest extends AbstractTest
             ->with(new Box($width, $height))
             ->willReturn($image);
 
-        $options = array();
-        $options['size'] = array($width, $height);
+        $options = [];
+        $options['size'] = [$width, $height];
 
         $loader->load($image, $options);
     }
@@ -51,10 +51,10 @@ class ResizeFilterLoaderTest extends AbstractTest
      */
     public function resizeDataProvider()
     {
-        return array(
-            array(140, 130),
-            array(30, 60),
-            array(400, 500),
-        );
+        return [
+            [140, 130],
+            [30, 60],
+            [400, 500],
+        ];
     }
 }

--- a/Tests/Imagine/Filter/Loader/RotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/RotateFilterLoaderTest.php
@@ -27,7 +27,7 @@ class RotateFilterLoaderTest extends AbstractTest
 
         $image = $this->getImageInterfaceMock();
 
-        $result = $loader->load($image, array('angle' => 0));
+        $result = $loader->load($image, ['angle' => 0]);
         $this->assertSame($image, $result);
     }
 
@@ -42,10 +42,9 @@ class RotateFilterLoaderTest extends AbstractTest
             ->expects($this->once())
             ->method('rotate')
             ->with(90)
-            ->willReturn($rotatedImage)
-        ;
+            ->willReturn($rotatedImage);
 
-        $result = $loader->load($image, array('angle' => 90));
+        $result = $loader->load($image, ['angle' => 90]);
         $this->assertSame($rotatedImage, $result);
     }
 }

--- a/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
@@ -43,28 +43,6 @@ class ScaleFilterLoaderTest extends AbstractTest
      */
     const UPSCALE_DUMMY_IMAGE_HEIGHT = 400;
 
-    protected function getUpscaleMockImage()
-    {
-        $mockImage = parent::getImageInterfaceMock();
-        $mockImage->method('getSize')->willReturn(new Box(
-            self::UPSCALE_DUMMY_IMAGE_WIDTH,
-            self::UPSCALE_DUMMY_IMAGE_HEIGHT
-        ));
-
-        return $mockImage;
-    }
-
-    protected function getImageInterfaceMock()
-    {
-        $mockImage = parent::getImageInterfaceMock();
-        $mockImage->method('getSize')->willReturn(new Box(
-            self::DUMMY_IMAGE_WIDTH,
-            self::DUMMY_IMAGE_HEIGHT
-        ));
-
-        return $mockImage;
-    }
-
     /**
      * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader::load
      */
@@ -80,9 +58,9 @@ class ScaleFilterLoaderTest extends AbstractTest
             ))
             ->willReturn($image);
 
-        $loader->load($image, array(
+        $loader->load($image, [
           'to' => 1.0,
-        ));
+        ]);
     }
 
     /**
@@ -103,22 +81,22 @@ class ScaleFilterLoaderTest extends AbstractTest
             ->with($expected)
             ->willReturn($image);
 
-        $options = array(
+        $options = [
             'dim' => $dimensions,
-        );
+        ];
 
         $loader->load($image, $options);
     }
 
     /**
      * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\ScaleFilterLoader::load
-     *
-     * @expectedException \InvalidArgumentException
      */
     public function itShouldThrowInvalidArgumentException()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $scale = new ScaleFilterLoader('foo', 'bar');
-        $scale->load($this->getImageInterfaceMock(), array());
+        $scale->load($this->getImageInterfaceMock(), []);
     }
 
     /**
@@ -126,11 +104,11 @@ class ScaleFilterLoaderTest extends AbstractTest
      */
     public function dimensionsDataProvider()
     {
-        return array(
-            array(array(150, 150), new Box(125, 150)),
-            array(array(30, 60), new Box(30, 36)),
-            array(array(1000, 1200), new Box(1000, 1200)),
-        );
+        return [
+            [[150, 150], new Box(125, 150)],
+            [[30, 60], new Box(30, 36)],
+            [[1000, 1200], new Box(1000, 1200)],
+        ];
     }
 
     /**
@@ -148,9 +126,9 @@ class ScaleFilterLoaderTest extends AbstractTest
             ->with($expected)
             ->willReturn($image);
 
-        $options = array(
+        $options = [
             'min' => $dimensions,
-        );
+        ];
 
         $loader->load($image, $options);
     }
@@ -160,10 +138,10 @@ class ScaleFilterLoaderTest extends AbstractTest
      */
     public function minScaleDataProvider()
     {
-        return array(
-            array(array(1000, 600), new Box(1000, 667)),
-            array(array(1200, 300), new Box(1200, 800)),
-        );
+        return [
+            [[1000, 600], new Box(1000, 667)],
+            [[1200, 300], new Box(1200, 800)],
+        ];
     }
 
     /**
@@ -181,9 +159,9 @@ class ScaleFilterLoaderTest extends AbstractTest
             ->with($expected)
             ->willReturn($image);
 
-        $options = array(
+        $options = [
             'min' => $dimensions,
-        );
+        ];
 
         $loader->load($image, $options);
     }
@@ -193,9 +171,31 @@ class ScaleFilterLoaderTest extends AbstractTest
      */
     public function minNotScaleDataProvider()
     {
-        return array(
-            array(array(300, 200), new Box(600, 400)),
-            array(array(600, 400), new Box(600, 400)),
-        );
+        return [
+            [[300, 200], new Box(600, 400)],
+            [[600, 400], new Box(600, 400)],
+        ];
+    }
+
+    protected function getUpscaleMockImage()
+    {
+        $mockImage = parent::getImageInterfaceMock();
+        $mockImage->method('getSize')->willReturn(new Box(
+            self::UPSCALE_DUMMY_IMAGE_WIDTH,
+            self::UPSCALE_DUMMY_IMAGE_HEIGHT
+        ));
+
+        return $mockImage;
+    }
+
+    protected function getImageInterfaceMock()
+    {
+        $mockImage = parent::getImageInterfaceMock();
+        $mockImage->method('getSize')->willReturn(new Box(
+            self::DUMMY_IMAGE_WIDTH,
+            self::DUMMY_IMAGE_HEIGHT
+        ));
+
+        return $mockImage;
     }
 }

--- a/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ThumbnailFilterLoaderTest.php
@@ -57,8 +57,8 @@ class ThumbnailFilterLoaderTest extends AbstractTest
             ->with($expected)
             ->willReturn($image);
 
-        $options = array();
-        $options['size'] = array($width, $height);
+        $options = [];
+        $options['size'] = [$width, $height];
         $options['allow_upscale'] = true;
 
         $loader->load($image, $options);
@@ -69,13 +69,13 @@ class ThumbnailFilterLoaderTest extends AbstractTest
      */
     public function heightWidthProvider()
     {
-        return array(
-            array(200, 129, new Box(200, 129)),
-            array(50, 50, new Box(50, 50)),
-            array(1, 30, new Box(1, 30)),
-            array(null, 60, new Box(50, 60)),
-            array(50, null, new Box(50, 60)),
-            array(1000, 1000, new Box(1000, 1000)),
-        );
+        return [
+            [200, 129, new Box(200, 129)],
+            [50, 50, new Box(50, 50)],
+            [1, 30, new Box(1, 30)],
+            [null, 60, new Box(50, 60)],
+            [50, null, new Box(50, 60)],
+            [1000, 1000, new Box(1000, 1000)],
+        ];
     }
 }

--- a/Tests/Imagine/Filter/PostProcessor/JpegOptimPostProcessorTest.php
+++ b/Tests/Imagine/Filter/PostProcessor/JpegOptimPostProcessorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Tests/Imagine/Filter/PostProcessor/MozJpegPostProcessorTest.php
+++ b/Tests/Imagine/Filter/PostProcessor/MozJpegPostProcessorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Tests/Imagine/Filter/PostProcessor/OptiPngPostProcessorTest.php
+++ b/Tests/Imagine/Filter/PostProcessor/OptiPngPostProcessorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Tests/Imagine/Filter/PostProcessor/PngquantPostProcessorTest.php
+++ b/Tests/Imagine/Filter/PostProcessor/PngquantPostProcessorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Tests\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/Tests/LiipImagineBundleTest.php
+++ b/Tests/LiipImagineBundleTest.php
@@ -223,7 +223,7 @@ class LiipImagineBundleTest extends AbstractTest
      */
     protected function createContainerBuilderMock()
     {
-        return $this->createObjectMock(ContainerBuilder::class, array(), false);
+        return $this->createObjectMock(ContainerBuilder::class, [], false);
     }
 
     /**
@@ -231,10 +231,10 @@ class LiipImagineBundleTest extends AbstractTest
      */
     protected function createLiipImagineExtensionMock()
     {
-        return $this->createObjectMock(LiipImagineExtension::class, array(
+        return $this->createObjectMock(LiipImagineExtension::class, [
             'getNamespace',
             'addResolverFactory',
             'addLoaderFactory',
-        ), false);
+        ], false);
     }
 }

--- a/Tests/Model/BinaryTest.php
+++ b/Tests/Model/BinaryTest.php
@@ -30,20 +30,20 @@ class BinaryTest extends TestCase
     {
         $image = new Binary('theContent', 'image/png', 'png');
 
-        $this->assertEquals('theContent', $image->getContent());
+        $this->assertSame('theContent', $image->getContent());
     }
 
     public function testAllowGetMimeTypeSetInConstructor()
     {
         $image = new Binary('aContent', 'image/png', 'png');
 
-        $this->assertEquals('image/png', $image->getMimeType());
+        $this->assertSame('image/png', $image->getMimeType());
     }
 
     public function testAllowGetFormatSetInConstructor()
     {
         $image = new Binary('aContent', 'image/png', 'png');
 
-        $this->assertEquals('png', $image->getFormat());
+        $this->assertSame('png', $image->getFormat());
     }
 }

--- a/Tests/Templating/AbstractFilterTest.php
+++ b/Tests/Templating/AbstractFilterTest.php
@@ -25,7 +25,7 @@ abstract class AbstractFilterTest extends AbstractTest
 
     public function testInvokeGetNameMethod()
     {
-        $this->assertEquals('liip_imagine', $this->createTemplatingMock()->getName());
+        $this->assertSame('liip_imagine', $this->createTemplatingMock()->getName());
     }
 
     public function testInvokeFilterMethod()
@@ -41,7 +41,7 @@ abstract class AbstractFilterTest extends AbstractTest
             ->with($expectedInputPath, $expectedFilter)
             ->will($this->returnValue($expectedCachePath));
 
-        $this->assertEquals($expectedCachePath, $this->createTemplatingMock($manager)->filter($expectedInputPath, $expectedFilter));
+        $this->assertSame($expectedCachePath, $this->createTemplatingMock($manager)->filter($expectedInputPath, $expectedFilter));
     }
 
     /**

--- a/Tests/Templating/FilterExtensionTest.php
+++ b/Tests/Templating/FilterExtensionTest.php
@@ -40,7 +40,7 @@ class FilterExtensionTest extends AbstractFilterTest
         if (!class_exists(\Twig_Extension::class)) {
             $this->markTestSkipped('Requires the twig/twig package.');
         }
-        
+
         $mock = new FilterExtension($manager ?: $this->createCacheManagerMock());
 
         $this->assertInstanceOf(FilterExtension::class, $mock);


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | `2.0`
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->


This PR is the next step following the previously merged PRs implementing new `php-cs-fixer` rules and related changes (see #1040, #1046, and #1054). Following this PR being merged, #1057 should be rebased and then merged to enforce the new code style rules that have been implemented.

All changes in this PR are automated by `php-cs-fixer` and represent a CLI run of the tool.