### PR TITLE
[Documentation] Correct indentation in AWS-S3 cache resolver documentation

### DIFF
--- a/Resources/doc/cache-resolver/aws_s3.rst
+++ b/Resources/doc/cache-resolver/aws_s3.rst
@@ -129,13 +129,13 @@ You have to set up the services required:
                         secret: "%amazon.s3.secret%"
                         region: "%amazon.s3.region%"
 
-    acme.amazon_s3:
-        class: Aws\S3\S3Client
-        factory: [Aws\S3\S3Client, factory]
-        arguments:
-            -
-                credentials: { key: %amazon.s3.key%, secret: %amazon.s3.secret% }
-                region: %amazon.s3.region%
+        acme.amazon_s3:
+            class: Aws\S3\S3Client
+            factory: [Aws\S3\S3Client, factory]
+            arguments:
+                -
+                    credentials: { key: %amazon.s3.key%, secret: %amazon.s3.secret% }
+                    region: %amazon.s3.region%
 
 Usage
 -----


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | `2.0`
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Fixes an indentation issue in the AWS-S3 cache resolved documentation that causes a warning during compilation.