### PR TITLE
[Dependencies] Update imagine/imagine to ^0.7.1,<0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^7.1",
-        "imagine/Imagine": "^0.6.3,<0.7",
+        "imagine/Imagine": "^0.7.1,<0.8",
         "symfony/asset": "^3.0|^4.0",
         "symfony/filesystem": "^3.0|^4.0",
         "symfony/finder": "^3.0|^4.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | `2.0`
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1066
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Changes our [imagine/imagine](https://github.com/avalanche123/Imagine) dependency to require `0.7.*`, while provides the following according to the imagine changelog:

- removes symfony `phpunit` bridge as a dependency (craue)
- fixes memory usage on metadata reading (Seldaek)
- adds official php `7.1` support
- provides latest `imagemagick`/`imagick` compatibility (jdewit)

In addition, this will allow for current fixes (such as avalanche123/Imagine#481 as described in #1066) to be included once new releases are tagged.