### PR TITLE
[Docs] Correct a tyop in the filters section of RST documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ $resolvedPath = $imagineCacheManager->getBrowserPath('/relative/path/to/image.jp
 
 ## Filters
 
-This bundle provides a set of built-in filters andy ou may easily
+This bundle provides a set of built-in filters and you may easily
 define your own filters as well. Reference the
 [filters chapter](http://symfony.com/doc/master/bundles/LiipImagineBundle/filters.html)
 from our documentation.


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | no
| New feature? |no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | no
| License | MIT
| Doc PR | no

Fix tyop in Filters section