### PR TITLE
[Tests] [Deprecation] Updated bundle notation to accommodate Symfony 4.1 and set browser client to not catch exceptions

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Liip\ImagineBundle\DependencyInjection;
 
+use Liip\ImagineBundle\Controller\ImagineController;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -118,8 +119,8 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('controller')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('filter_action')->defaultValue('liip_imagine.controller:filterAction')->end()
-                        ->scalarNode('filter_runtime_action')->defaultValue('liip_imagine.controller:filterRuntimeAction')->end()
+                        ->scalarNode('filter_action')->defaultValue(sprintf('%s::filterAction', ImagineController::class))->end()
+                        ->scalarNode('filter_runtime_action')->defaultValue(sprintf('%s::filterRuntimeAction', ImagineController::class))->end()
                     ->end()
                 ->end()
                 ->arrayNode('filter_sets')

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -69,11 +69,13 @@
 
         <!-- Controller -->
 
-        <service id="liip_imagine.controller" class="Liip\ImagineBundle\Controller\ImagineController" public="true">
+        <service id="Liip\ImagineBundle\Controller\ImagineController" public="true">
             <argument type="service" id="liip_imagine.service.filter" />
             <argument type="service" id="liip_imagine.data.manager" />
             <argument type="service" id="liip_imagine.cache.signer" />
         </service>
+
+        <service id="liip_imagine.controller" alias="Liip\ImagineBundle\Controller\ImagineController" public="true" />
 
         <service id="liip_imagine.meta_data.reader" class="Imagine\Image\Metadata\ExifMetadataReader" public="false" />
 

--- a/Tests/DependencyInjection/LiipImagineExtensionTest.php
+++ b/Tests/DependencyInjection/LiipImagineExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Liip\ImagineBundle\Tests\DependencyInjection;
 
+use Liip\ImagineBundle\Controller\ImagineController;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\FileSystemLoaderFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory;
 use Liip\ImagineBundle\DependencyInjection\LiipImagineExtension;
@@ -49,7 +50,7 @@ class LiipImagineExtensionTest extends AbstractTest
         $this->assertAlias('liip_imagine.gd', 'liip_imagine');
         $this->assertHasDefinition('liip_imagine.controller');
         $this->assertDICConstructorArguments(
-            $this->containerBuilder->getDefinition('liip_imagine.controller'),
+            $this->containerBuilder->getDefinition(ImagineController::class),
             [
                 new Reference('liip_imagine.service.filter'),
                 new Reference('liip_imagine.data.manager'),

--- a/Tests/Functional/AbstractSetupWebTestCase.php
+++ b/Tests/Functional/AbstractSetupWebTestCase.php
@@ -44,6 +44,7 @@ class AbstractSetupWebTestCase extends AbstractWebTestCase
         parent::setUp();
 
         $this->client = $this->createClient();
+        $this->client->catchExceptions(false);
         $this->webRoot = sprintf('%s/public', self::$kernel->getContainer()->getParameter('kernel.root_dir'));
         $this->cacheRoot = $this->webRoot.'/media/cache';
         $this->filesystem = new Filesystem();

--- a/Tests/Functional/Controller/ImagineControllerTest.php
+++ b/Tests/Functional/Controller/ImagineControllerTest.php
@@ -23,7 +23,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
 {
     public function testCouldBeGetFromContainer()
     {
-        $this->assertInstanceOf(ImagineController::class, self::$kernel->getContainer()->get('liip_imagine.controller'));
+        $this->assertInstanceOf(ImagineController::class, self::$kernel->getContainer()->get(ImagineController::class));
     }
 
     public function testShouldResolvePopulatingCacheFirst()

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     "require": {
         "php": "^7.1",
         "imagine/Imagine": "^0.7.1,<0.8",
-        "symfony/asset": "^3.0|^4.0",
-        "symfony/filesystem": "^3.0|^4.0",
-        "symfony/finder": "^3.0|^4.0",
-        "symfony/framework-bundle": "^3.0|^4.0",
-        "symfony/options-resolver": "^3.0|^4.0",
-        "symfony/process": "^3.0|^4.0",
-        "symfony/templating": "^3.0|^4.0",
-        "symfony/translation": "^3.0|^4.0"
+        "symfony/asset": "^3.4|^4.0",
+        "symfony/filesystem": "^3.4|^4.0",
+        "symfony/finder": "^3.4|^4.0",
+        "symfony/framework-bundle": "^3.4|^4.0",
+        "symfony/options-resolver": "^3.4|^4.0",
+        "symfony/process": "^3.4|^4.0",
+        "symfony/templating": "^3.4|^4.0",
+        "symfony/translation": "^3.4|^4.0"
     },
     "require-dev": {
         "ext-gd": "*",
@@ -39,13 +39,13 @@
         "friendsofphp/php-cs-fixer": "^2.10",
         "league/flysystem": "^1.0",
         "psr/log": "^1.0",
-        "symfony/browser-kit": "^3.0|^4.0",
-        "symfony/console": "^3.0|^4.0",
-        "symfony/dependency-injection": "^3.0|^4.0",
-        "symfony/form": "^3.0|^4.0",
-        "symfony/phpunit-bridge": "^3.0|^4.0",
-        "symfony/validator": "^3.0|^4.0",
-        "symfony/yaml": "^3.0|^4.0",
+        "symfony/browser-kit": "^3.4|^4.0",
+        "symfony/console": "^3.4|^4.0",
+        "symfony/dependency-injection": "^3.4|^4.0",
+        "symfony/form": "^3.4|^4.0",
+        "symfony/phpunit-bridge": "^3.4|^4.0",
+        "symfony/validator": "^3.4|^4.0",
+        "symfony/yaml": "^3.4|^4.0",
         "twig/twig": "^1.12|^2.0"
     },
     "suggest": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | `2.0`
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

This PR changes the bundle notation to the fully qualified service name followed by a double colon and the action name. Symfony 4.1 deprecated single colon usage, creating a situation where it was impossible to support pre- and post-4.1 without deprecations if the syntax was not changed. This change required moving to the new service id/class naming conventions and creating a `liip_imagine.controller` alias.

Also, somewhere along the lines the client browser (used in tests) stopped passing exceptions and began throwing them; its configuration was changed to allow exceptions to pass through for tests.

Lastly, the `2.0.0` release was intended to target Symfony >=3.4, but this was never memorialized in the composer configuration.

References:
  - https://symfony.com/blog/new-in-symfony-4-1-deprecated-the-bundle-notation
  - https://github.com/symfony/symfony/pull/26085
  - https://github.com/symfony/symfony/pull/22890