### PR TITLE
Add routing removal in Upgrade file

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -85,6 +85,8 @@ given release.
       $producer->sendCommand(\Liip\ImagineBundle\Async\Commands::RESOLVE_CACHE /* ... */);
     ```
 
+  - __[Routing]__ The `Resources/config/routing.xml` file has been removed. Use the new `Resources/config/routing.yaml` YAML file instead.
+
 
 ## [1.9.1](https://github.com/liip/LiipImagineBundle/blob/2.0/CHANGELOG.md#191)
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

As we added a deprecation for the routing xml file in 1.9.x, I added the removal entry in the 2.0.0 section 