### PR TITLE
[Data Locator] Add toggle to allow invalid paths for filesystem locator

### DIFF
--- a/Binary/Locator/FileSystemLocator.php
+++ b/Binary/Locator/FileSystemLocator.php
@@ -29,9 +29,7 @@ class FileSystemLocator implements LocatorInterface
     {
         $this->roots = array_filter(array_map(function (string $root) use ($allowUnresolvable): ?string {
             return $this->sanitizeRootPath($root, $allowUnresolvable);
-        }, $roots), function (string $root = null): bool {
-            return null !== $root;
-        });
+        }, $roots));
     }
 
     /**

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -26,6 +26,7 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
     {
         $locatorDefinition = new ChildDefinition(sprintf('liip_imagine.binary.locator.%s', $config['locator']));
         $locatorDefinition->replaceArgument(0, $this->resolveDataRoots($config['data_root'], $config['bundle_resources'], $container));
+        $locatorDefinition->replaceArgument(1, $config['allow_unresolvable_data_roots']);
 
         $definition = $this->getChildLoaderDefinition();
         $definition->replaceArgument(2, $locatorDefinition);
@@ -66,6 +67,9 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
                     ->prototype('scalar')
                         ->cannotBeEmpty()
                     ->end()
+                ->end()
+                ->booleanNode('allow_unresolvable_data_roots')
+                    ->defaultFalse()
                 ->end()
                 ->arrayNode('bundle_resources')
                     ->addDefaultsIfNotSet()

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -194,10 +194,12 @@
 
         <service id="liip_imagine.binary.locator.filesystem" class="Liip\ImagineBundle\Binary\Locator\FileSystemLocator" public="false" shared="false">
             <argument><!-- will be injected by FilesystemLoaderFactory --></argument>
+            <argument><!-- will be injected by FilesystemLoaderFactory --></argument>
             <tag name="liip_imagine.binary.locator" shared="false" />
         </service>
 
         <service id="liip_imagine.binary.locator.filesystem_insecure" class="Liip\ImagineBundle\Binary\Locator\FileSystemInsecureLocator" public="false" shared="false">
+            <argument><!-- will be injected by FilesystemLoaderFactory --></argument>
             <argument><!-- will be injected by FilesystemLoaderFactory --></argument>
             <tag name="liip_imagine.binary.locator" shared="false" />
         </service>

--- a/Resources/doc/data-loader/filesystem.rst
+++ b/Resources/doc/data-loader/filesystem.rst
@@ -56,6 +56,25 @@ will search each for the requested file.
                         - /path/foo
                         - /path/bar
 
+As of version ``2.1.0`` you can allow invalid data roots (which are removed at runtime)
+in your configuration (normally invalid data roots will cause an exception to be thrown).
+This allows you to configure your data roots for production and development environments
+without relying on multiple configurations.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        loaders:
+            default:
+                filesystem:
+                    data_root:
+                        - /path/foo
+                        - /path/bar
+                        - /invalid/path/will/be/removed/at/runtime
+                    allow_unresolvable_data_roots: true
+
 As of version ``1.7.3`` you ask for the public resource paths from all registered bundles
 to be auto-registered as data roots. This allows you to load assets from the
 ``Resources/public`` folders that reside within the loaded bundles. To enable this

--- a/Tests/Binary/Locator/FileSystemLocatorTest.php
+++ b/Tests/Binary/Locator/FileSystemLocatorTest.php
@@ -19,6 +19,21 @@ use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
  */
 class FileSystemLocatorTest extends AbstractFileSystemLocatorTest
 {
+    public function testAllowInvalidPaths()
+    {
+        $locator = new FileSystemLocator(['/does/not/exist/foo', '/does/not/exist/bar', $temp = sys_get_temp_dir()], true);
+        $roots = (new \ReflectionObject($locator))->getProperty('roots');
+        $roots->setAccessible(true);
+        $array = [
+            '',
+            '',
+            realpath($temp),
+        ];
+        unset($array[0], $array[1]);
+
+        $this->assertSame($array, $roots->getValue($locator));
+    }
+
     public function testThrowsIfPathHasSymbolicLinksPointOutsideRoot()
     {
         $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -54,6 +54,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $loader = new FileSystemLoaderFactory();
         $loader->create($container, 'the_loader_name', [
             'data_root' => ['theDataRoot'],
+            'allow_unresolvable_data_roots' => false,
             'locator' => 'filesystem',
             'bundle_resources' => [
                 'enabled' => false,
@@ -70,6 +71,34 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $this->assertSame('liip_imagine.binary.loader.prototype.filesystem', $loaderDefinition->getParent());
 
         $this->assertSame(['theDataRoot'], $loaderDefinition->getArgument(2)->getArgument(0));
+        $this->assertFalse($loaderDefinition->getArgument(2)->getArgument(1));
+    }
+
+    public function testCreateLoaderDefinitionWithUnresolvableRoots()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new FileSystemLoaderFactory();
+        $loader->create($container, 'the_loader_name', [
+            'data_root' => ['theDataRoot'],
+            'allow_unresolvable_data_roots' => true,
+            'locator' => 'filesystem',
+            'bundle_resources' => [
+                'enabled' => false,
+                'access_control_type' => 'blacklist',
+                'access_control_list' => [],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('liip_imagine.binary.loader.the_loader_name'));
+
+        $loaderDefinition = $container->getDefinition('liip_imagine.binary.loader.the_loader_name');
+
+        $this->assertInstanceOfChildDefinition($loaderDefinition);
+        $this->assertSame('liip_imagine.binary.loader.prototype.filesystem', $loaderDefinition->getParent());
+
+        $this->assertSame(['theDataRoot'], $loaderDefinition->getArgument(2)->getArgument(0));
+        $this->assertTrue($loaderDefinition->getArgument(2)->getArgument(1));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadata()
@@ -90,6 +119,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $loader = new FileSystemLoaderFactory();
         $loader->create($container, 'the_loader_name', [
             'data_root' => ['theDataRoot'],
+            'allow_unresolvable_data_roots' => false,
             'locator' => 'filesystem',
             'bundle_resources' => [
                 'enabled' => true,
@@ -125,6 +155,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $loader = new FileSystemLoaderFactory();
         $loader->create($container, 'the_loader_name', [
             'data_root' => ['theDataRoot'],
+            'allow_unresolvable_data_roots' => false,
             'locator' => 'filesystem',
             'bundle_resources' => [
                 'enabled' => true,
@@ -161,6 +192,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $loader = new FileSystemLoaderFactory();
         $loader->create($container, 'the_loader_name', [
             'data_root' => ['theDataRoot'],
+            'allow_unresolvable_data_roots' => false,
             'locator' => 'filesystem',
             'bundle_resources' => [
                 'enabled' => true,
@@ -193,6 +225,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $loader = new FileSystemLoaderFactory();
         $loader->create($container, 'the_loader_name', [
             'data_root' => ['theDataRoot'],
+            'allow_unresolvable_data_roots' => false,
             'locator' => 'filesystem',
             'bundle_resources' => [
                 'enabled' => true,
@@ -217,6 +250,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $loader = new FileSystemLoaderFactory();
         $loader->create($container, 'first_loader', [
             'data_root' => ['firstLoaderDataroot'],
+            'allow_unresolvable_data_roots' => false,
             'locator' => 'filesystem',
             'bundle_resources' => [
                 'enabled' => false,
@@ -225,6 +259,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
 
         $loader->create($container, 'second_loader', [
             'data_root' => ['secondLoaderDataroot'],
+            'allow_unresolvable_data_roots' => false,
             'locator' => 'filesystem',
             'bundle_resources' => [
                 'enabled' => false,
@@ -255,6 +290,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $loader = new FileSystemLoaderFactory();
         $loader->create($container, 'the_loader_name', [
             'data_root' => ['theDataRoot'],
+            'allow_unresolvable_data_roots' => false,
             'locator' => 'filesystem',
             'bundle_resources' => [
                 'enabled' => true,


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | `2.0`
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1018 
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Add `allow_unresolvable_data_roots` option to filesystem loader to allow invalid paths in your configuration.