### PR TITLE
Type-hint on FilesystemInterface in FlysystemResolver

### DIFF
--- a/Imagine/Cache/Resolver/FlysystemResolver.php
+++ b/Imagine/Cache/Resolver/FlysystemResolver.php
@@ -12,7 +12,7 @@
 namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
 
 use League\Flysystem\AdapterInterface;
-use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemInterface;
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;
 use Symfony\Component\Routing\RequestContext;
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\RequestContext;
 class FlysystemResolver implements ResolverInterface
 {
     /**
-     * @var Filesystem
+     * @var FilesystemInterface
      */
     protected $flysystem;
 
@@ -56,14 +56,14 @@ class FlysystemResolver implements ResolverInterface
     /**
      * FlysystemResolver constructor.
      *
-     * @param Filesystem     $flysystem
-     * @param RequestContext $requestContext
-     * @param string         $rootUrl
-     * @param string         $cachePrefix
-     * @param string         $visibility
+     * @param FilesystemInterface $flysystem
+     * @param RequestContext      $requestContext
+     * @param string              $rootUrl
+     * @param string              $cachePrefix
+     * @param string              $visibility
      */
     public function __construct(
-        Filesystem $flysystem,
+        FilesystemInterface $flysystem,
         RequestContext $requestContext,
         $rootUrl,
         $cachePrefix = 'media/cache',


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | none
| License | MIT
| Doc PR | none

Type-hint on `FilesystemInterface` instead of `Filesystem` class in `FlysystemResolver`. `FilesystemInterface` fully satisfies `FlysystemResolver` needs. 