### PR TITLE
added pre and post store events

### DIFF
--- a/Events/CacheStoreEvent.php
+++ b/Events/CacheStoreEvent.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Events;
+
+use Liip\ImagineBundle\Binary\BinaryInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+class CacheStoreEvent extends Event
+{
+    /**
+     * Binary.
+     *
+     * @var BinaryInterface
+     */
+    protected $binary;
+
+    /**
+     * Resource path.
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * Filter name.
+     *
+     * @var string
+     */
+    protected $filter;
+
+    /**
+     * Resolver.
+     *
+     * @var null|string
+     */
+    protected $resolver;
+
+    /**
+     * Init default event state.
+     *
+     * @param BinaryInterface $binary
+     * @param string          $path
+     * @param string          $filter
+     * @param null|string     $resolver
+     */
+    public function __construct(BinaryInterface $binary, $path, $filter, $resolver = null)
+    {
+        $this->binary = $binary;
+        $this->path = $path;
+        $this->filter = $filter;
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * Sets the binary
+     *
+     * @param BinaryInterface $binary
+     */
+    public function setBinary(BinaryInterface $binary)
+    {
+        $this->binary = $binary;
+    }
+
+    /**
+     * Returns the binary
+     *
+     * @return BinaryInterface
+     */
+    public function getBinary()
+    {
+        return $this->binary;
+    }
+
+    /**
+     * Sets resource path.
+     *
+     * @param $path
+     */
+    public function setPath($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Returns resource path.
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Sets filter name.
+     *
+     * @param $filter
+     */
+    public function setFilter($filter)
+    {
+        $this->filter = $filter;
+    }
+
+    /**
+     * Returns filter name.
+     *
+     * @return string
+     */
+    public function getFilter()
+    {
+        return $this->filter;
+    }
+
+    /**
+     * Sets the resolver
+     *
+     * @param null|string $resolver
+     */
+    public function setResolver(?string $resolver)
+    {
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * Returns the resolver.
+     *
+     * @return null|string
+     */
+    public function getResolver()
+    {
+        return $this->resolver;
+    }
+}

--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -13,6 +13,7 @@ namespace Liip\ImagineBundle\Imagine\Cache;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Events\CacheResolveEvent;
+use Liip\ImagineBundle\Events\CacheStoreEvent;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Liip\ImagineBundle\ImagineEvents;
@@ -215,7 +216,16 @@ class CacheManager
      */
     public function store(BinaryInterface $binary, $path, $filter, $resolver = null)
     {
+
+        $preEvent = new CacheStoreEvent($binary, $path, $filter, $resolver);
+        $this->dispatcher->dispatch(ImagineEvents::PRE_STORE, $preEvent);
+
         $this->getResolver($filter, $resolver)->store($binary, $path, $filter);
+
+        $postEvent = new CacheStoreEvent($preEvent->getBinary(), $preEvent->getPath(), $preEvent->getFilter(), $preEvent->getResolver());
+        $this->dispatcher->dispatch(ImagineEvents::POST_STORE, $postEvent);
+
+
     }
 
     /**

--- a/ImagineEvents.php
+++ b/ImagineEvents.php
@@ -22,4 +22,14 @@ interface ImagineEvents
      * @Event("Liip\ImagineBundle\Events\CacheResolveEvent")
      */
     const POST_RESOLVE = 'liip_imagine.post_resolve';
+
+    /**
+     * @Event("Liip\ImagineBundle\Events\CacheStoreEvent")
+     */
+    const PRE_STORE = 'liip_imagine.pre_store';
+
+    /**
+     * @Event("Liip\ImagineBundle\Events\CacheStoreEvent")
+     */
+    const POST_STORE = 'liip_imagine.post_store';
 }

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -14,6 +14,7 @@ namespace Liip\ImagineBundle\Tests;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\Metadata\MetadataBag;
+use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
 use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
@@ -152,6 +153,14 @@ abstract class AbstractTest extends TestCase
     protected function createEventDispatcherInterfaceMock()
     {
         return $this->createObjectMock(EventDispatcherInterface::class);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|BinaryInterface
+     */
+    protected function createBinaryInterfaceMock()
+    {
+        return $this->createObjectMock(BinaryInterface::class);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1126
| License | MIT
| Doc PR | <!--highly recommended for new features-->

This PR adds pre and post store events to the cache managers store method