### PR TITLE
Add missing ImageType::getBlockPrefix() method

### DIFF
--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -58,6 +58,14 @@ class ImageType extends AbstractType
     /**
      * {@inheritdoc}
      */
+    public function getBlockPrefix()
+    {
+        return 'liip_imagine_image';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getParent()
     {
         return FileType::class;


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? |
| Fixed tickets | None
| License | MIT

The `liip_imagine_image_widget` twig block is now used, instead of the standard `file` one.