### PR TITLE
Dependency Injection: add aliases for data and filter manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ for a given releases. Unreleased, upcoming changes will be updated here periodic
 [milestones](https://github.com/liip/LiipImagineBundle/milestones) page for the latest changes.
 
 ## [Unreleased](https://github.com/liip/LiipImagineBundle/tree/HEAD)
+- __\[Dependency Injection\]__ Add aliases for data and filter manager ([fpaterno](https://github.com/fpaterno))
 
 ## [2.1.0](https://github.com/liip/LiipImagineBundle/tree/2.1.0) (2018-07-10)
 [Full Changelog](https://github.com/liip/LiipImagineBundle/compare/2.0.0...2.1.0)

--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -14,6 +14,8 @@ namespace Liip\ImagineBundle\DependencyInjection;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Liip\ImagineBundle\Imagine\Data\DataManager;
+use Liip\ImagineBundle\Imagine\Filter\FilterManager;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -87,6 +89,8 @@ class LiipImagineExtension extends Extension
 
         $container->setAlias('liip_imagine', new Alias('liip_imagine.'.$config['driver']));
         $container->setAlias(CacheManager::class, new Alias('liip_imagine.cache.manager', false));
+        $container->setAlias(DataManager::class, new Alias('liip_imagine.data.manager', false));
+        $container->setAlias(FilterManager::class, new Alias('liip_imagine.filter.manager', false));
 
         $container->setParameter('liip_imagine.cache.resolver.default', $config['cache']);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Tests pass? | yes
| Fixed tickets | none
| License | MIT
| Doc PR | none

Without proposed alias, this bundle is not working on Symfony 4.0, and logging a deprecation notice on Symfony 3.4

This deprecation is about DataManager and FilterManager
