### PR TITLE
Prevent Twig 2.7 spaceless deprecation notice

### DIFF
--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -1,19 +1,17 @@
 {% block liip_imagine_image_widget %}
-    {% spaceless %}
-        {% if image_path %}
-            <div>
-                {% if link_url %}
-                    <a href="{{ link_filter ? link_url|imagine_filter(link_filter): link_url }}" {% for attrname, attrvalue in link_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}>
-                {% endif %}
+    {%- if image_path -%}
+        <div>
+            {%- if link_url -%}
+                <a href="{{ link_filter ? link_url|imagine_filter(link_filter): link_url }}" {% for attrname, attrvalue in link_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}>
+            {%- endif -%}
 
-                <img src="{{ image_path|imagine_filter(image_filter) }}" {% for attrname, attrvalue in image_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %} />
+            <img src="{{ image_path|imagine_filter(image_filter) }}" {% for attrname, attrvalue in image_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %} />
 
-                {% if link_url %}
-                    </a>
-                {% endif %}
-            </div>
-        {% endif %}
+            {%- if link_url -%}
+                </a>
+            {%- endif -%}
+        </div>
+    {%- endif -%}
 
-        {{ block('form_widget_simple') }}
-    {% endspaceless %}
+    {{ block('form_widget_simple') -}}
 {% endblock %}


### PR DESCRIPTION
The spaceless tag has been deprecated in Twig 2.7 and is going to be removed in 3.0

| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1166
| License | MIT
| Doc PR | 

To keep backward compatibility we have to stop using `spaceless` at all.