### PR TITLE
Replaced spaceless by apply filter

### DIFF
--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -1,5 +1,5 @@
 {% block liip_imagine_image_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if image_path %}
             <div>
                 {% if link_url %}
@@ -15,5 +15,5 @@
         {% endif %}
 
         {{ block('form_widget_simple') }}
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Tests pass? | yes/no
| Fixed tickets | #1166
| License | MIT
| Doc PR | <!--highly recommended for new features-->

I replaced the `spaceless` tag by the `apply` filter.

This means raising the required Twig version, but that's something `symfony/symfony` already did for all supported versions (3.4 and 4.2).