### PR TITLE
[Docs] Fix link for Gaufrette README file

### DIFF
--- a/Resources/doc/data-loader/stream.rst
+++ b/Resources/doc/data-loader/stream.rst
@@ -63,5 +63,5 @@ The following example will configure the resolver as default.
 
 .. _`StreamWrapper configuration`: https://github.com/KnpLabs/KnpGaufretteBundle#stream-wrapper
 .. _`Gaufrette`: https://github.com/KnpLabs/Gaufrette
-.. _`Gaufrette README`: https://github.com/KnpLabs/Gaufrette/blob/master/README.markdown
+.. _`Gaufrette README`: https://github.com/KnpLabs/Gaufrette/blob/master/README.md
 .. _`KnpGaufretteBundle`: https://github.com/KnpLabs/KnpGaufretteBundle


### PR DESCRIPTION
Fix for Gaufrette README file link in Stream DataLoader doc.

| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | no
| Fixed tickets | no
| License | MIT
| Doc PR | yes
