### PR TITLE
Set the mime type when uploading cached files

### DIFF
--- a/Imagine/Cache/Resolver/FlysystemResolver.php
+++ b/Imagine/Cache/Resolver/FlysystemResolver.php
@@ -122,7 +122,7 @@ class FlysystemResolver implements ResolverInterface
         $this->flysystem->put(
             $this->getFilePath($path, $filter),
             $binary->getContent(),
-            ['visibility' => $this->visibility]
+            ['visibility' => $this->visibility, 'mimetype' => $binary->getMimeType()]
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Azure Blob Storage doesn't detect the mime type of the uploaded file, so need to provide it explicitly to stop it from being set to `application/octet-stream`