### PR TITLE
Fixes/Refactor for Symfony 4.3

### DIFF
--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -22,15 +22,14 @@ class FileSystemLoader implements LoaderInterface
      */
     protected $mimeTypeGuesser;
 
-
     /**
      * @var LocatorInterface
      */
     protected $locator;
 
     /**
-     * @param MimeTypeGuesserInterface  $mimeGuesser
-     * @param LocatorInterface          $locator
+     * @param MimeTypeGuesserInterface $mimeGuesser
+     * @param LocatorInterface         $locator
      */
     public function __construct(
         MimeTypesInterface $mimeGuesser,

--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -30,7 +30,6 @@ class FileSystemLoader implements LoaderInterface
 
     /**
      * @param MimeTypeGuesserInterface  $mimeGuesser
-     * @param ExtensionGuesserInterface $extensionGuesser
      * @param LocatorInterface          $locator
      */
     public function __construct(
@@ -49,6 +48,6 @@ class FileSystemLoader implements LoaderInterface
         $path = $this->locator->locate($path);
         $mime = $this->mimeTypeGuesser->guessMimeType($path);
 
-        return new FileBinary($path, $mime, $this->mimeTypeGuesser->getExtensions($mime));
+        return new FileBinary($path, $mime, $this->mimeTypeGuesser->getExtensions($mime)[0] ?? null);
     }
 }

--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -13,8 +13,7 @@ namespace Liip\ImagineBundle\Binary\Loader;
 
 use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
 use Liip\ImagineBundle\Model\FileBinary;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
+use Symfony\Component\Mime\MimeTypesInterface;
 
 class FileSystemLoader implements LoaderInterface
 {
@@ -23,10 +22,6 @@ class FileSystemLoader implements LoaderInterface
      */
     protected $mimeTypeGuesser;
 
-    /**
-     * @var ExtensionGuesserInterface
-     */
-    protected $extensionGuesser;
 
     /**
      * @var LocatorInterface
@@ -39,12 +34,10 @@ class FileSystemLoader implements LoaderInterface
      * @param LocatorInterface          $locator
      */
     public function __construct(
-        MimeTypeGuesserInterface $mimeGuesser,
-        ExtensionGuesserInterface $extensionGuesser,
+        MimeTypesInterface $mimeGuesser,
         LocatorInterface $locator
     ) {
         $this->mimeTypeGuesser = $mimeGuesser;
-        $this->extensionGuesser = $extensionGuesser;
         $this->locator = $locator;
     }
 
@@ -54,8 +47,8 @@ class FileSystemLoader implements LoaderInterface
     public function find($path)
     {
         $path = $this->locator->locate($path);
-        $mime = $this->mimeTypeGuesser->guess($path);
+        $mime = $this->mimeTypeGuesser->guessMimeType($path);
 
-        return new FileBinary($path, $mime, $this->extensionGuesser->guess($mime));
+        return new FileBinary($path, $mime, $this->mimeTypeGuesser->getExtensions($mime));
     }
 }

--- a/Binary/Loader/FlysystemLoader.php
+++ b/Binary/Loader/FlysystemLoader.php
@@ -14,7 +14,8 @@ namespace Liip\ImagineBundle\Binary\Loader;
 use League\Flysystem\FilesystemInterface;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Model\Binary;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
+use Symfony\Component\Mime\MimeTypes;
+use Symfony\Component\Mime\MimeTypesInterface;
 
 class FlysystemLoader implements LoaderInterface
 {
@@ -24,15 +25,15 @@ class FlysystemLoader implements LoaderInterface
     protected $filesystem;
 
     /**
-     * @var ExtensionGuesserInterface
+     * @var MimeTypesInterface
      */
-    protected $extensionGuesser;
+    protected $mimeTypeGuesser;
 
     public function __construct(
-        ExtensionGuesserInterface $extensionGuesser,
+        MimeTypesInterface $mimeTypes,
         FilesystemInterface $filesystem)
     {
-        $this->extensionGuesser = $extensionGuesser;
+        $this->mimeTypeGuesser = $mimeTypes;
         $this->filesystem = $filesystem;
     }
 
@@ -50,7 +51,7 @@ class FlysystemLoader implements LoaderInterface
         return new Binary(
             $this->filesystem->read($path),
             $mimeType,
-            $this->extensionGuesser->guess($mimeType)
+            $this->mimeTypeGuesser->getExtensions($mimeType)[0] ?? null
         );
     }
 }

--- a/Binary/Loader/FlysystemLoader.php
+++ b/Binary/Loader/FlysystemLoader.php
@@ -14,7 +14,6 @@ namespace Liip\ImagineBundle\Binary\Loader;
 use League\Flysystem\FilesystemInterface;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Model\Binary;
-use Symfony\Component\Mime\MimeTypes;
 use Symfony\Component\Mime\MimeTypesInterface;
 
 class FlysystemLoader implements LoaderInterface

--- a/Binary/MimeTypeGuesserInterface.php
+++ b/Binary/MimeTypeGuesserInterface.php
@@ -11,7 +11,7 @@
 
 namespace Liip\ImagineBundle\Binary;
 
-interface MimeTypeGuesserInterface
+interface MimeTypeGuesserInterface extends \Symfony\Component\Mime\MimeTypesInterface
 {
     /**
      * @param string $binary The image binary

--- a/Binary/SimpleMimeTypeGuesser.php
+++ b/Binary/SimpleMimeTypeGuesser.php
@@ -28,24 +28,25 @@ class SimpleMimeTypeGuesser implements MimeTypeGuesserInterface
         $this->mimeTypeGuesser = $mimeTypeGuesser;
     }
 
-    public function getExtensions(string $mimeType): array {
-      return $this->mimeTypeGuesser->getExtensions($mimeType);
+    public function getExtensions(string $mimeType): array
+    {
+        return $this->mimeTypeGuesser->getExtensions($mimeType);
     }
 
-    public function guessMimeType(string $path): ?string {
-      return $this->mimeTypeGuesser->guessMimeType($path);
+    public function guessMimeType(string $path): ?string
+    {
+        return $this->mimeTypeGuesser->guessMimeType($path);
     }
 
-
-    public function getMimeTypes(string $ext): array {
-      return $this->mimeTypeGuesser->getMimeTypes($ext);
+    public function getMimeTypes(string $ext): array
+    {
+        return $this->mimeTypeGuesser->getMimeTypes($ext);
     }
 
-    public function isGuesserSupported(): bool {
-      return $this->mimeTypeGuesser->isGuesserSupported();
+    public function isGuesserSupported(): bool
+    {
+        return $this->mimeTypeGuesser->isGuesserSupported();
     }
-
-
 
     /**
      * {@inheritdoc}

--- a/Binary/SimpleMimeTypeGuesser.php
+++ b/Binary/SimpleMimeTypeGuesser.php
@@ -11,7 +11,7 @@
 
 namespace Liip\ImagineBundle\Binary;
 
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface as SymfonyMimeTypeGuesserInterface;
+use Symfony\Component\Mime\MimeTypesInterface as SymfonyMimeTypeGuesserInterface;
 
 class SimpleMimeTypeGuesser implements MimeTypeGuesserInterface
 {
@@ -40,7 +40,7 @@ class SimpleMimeTypeGuesser implements MimeTypeGuesserInterface
         try {
             file_put_contents($tmpFile, $binary);
 
-            $mimeType = $this->mimeTypeGuesser->guess($tmpFile);
+            $mimeType = $this->mimeTypeGuesser->guessMimeType($tmpFile);
 
             unlink($tmpFile);
 

--- a/Binary/SimpleMimeTypeGuesser.php
+++ b/Binary/SimpleMimeTypeGuesser.php
@@ -28,6 +28,25 @@ class SimpleMimeTypeGuesser implements MimeTypeGuesserInterface
         $this->mimeTypeGuesser = $mimeTypeGuesser;
     }
 
+    public function getExtensions(string $mimeType): array {
+      return $this->mimeTypeGuesser->getExtensions($mimeType);
+    }
+
+    public function guessMimeType(string $path): ?string {
+      return $this->mimeTypeGuesser->guessMimeType($path);
+    }
+
+
+    public function getMimeTypes(string $ext): array {
+      return $this->mimeTypeGuesser->getMimeTypes($ext);
+    }
+
+    public function isGuesserSupported(): bool {
+      return $this->mimeTypeGuesser->isGuesserSupported();
+    }
+
+
+
     /**
      * {@inheritdoc}
      */

--- a/DependencyInjection/Factory/Loader/ChainLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/ChainLoaderFactory.php
@@ -26,6 +26,7 @@ class ChainLoaderFactory extends AbstractLoaderFactory
         $definition->replaceArgument(0, $this->createLoaderReferences($config['loaders']));
 
         $r = $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
+
         return $r;
     }
 

--- a/DependencyInjection/Factory/Loader/ChainLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/ChainLoaderFactory.php
@@ -25,7 +25,8 @@ class ChainLoaderFactory extends AbstractLoaderFactory
         $definition = $this->getChildLoaderDefinition();
         $definition->replaceArgument(0, $this->createLoaderReferences($config['loaders']));
 
-        return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
+        $r = $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
+        return $r;
     }
 
     /**

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -28,7 +28,7 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
         $locatorDefinition->replaceArgument(0, $this->resolveDataRoots($config['data_root'], $config['bundle_resources'], $container));
 
         $definition = $this->getChildLoaderDefinition();
-        $definition->replaceArgument(2, $locatorDefinition);
+        $definition->replaceArgument(1, $locatorDefinition);
 
         return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);
     }

--- a/Events/CacheResolveEvent.php
+++ b/Events/CacheResolveEvent.php
@@ -11,7 +11,7 @@
 
 namespace Liip\ImagineBundle\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class CacheResolveEvent extends Event
 {

--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -195,12 +195,12 @@ class CacheManager
         }
 
         $preEvent = new CacheResolveEvent($path, $filter);
-        $this->dispatcher->dispatch(ImagineEvents::PRE_RESOLVE, $preEvent);
+        $this->dispatcher->dispatch($preEvent, ImagineEvents::PRE_RESOLVE);
 
         $url = $this->getResolver($preEvent->getFilter(), $resolver)->resolve($preEvent->getPath(), $preEvent->getFilter());
 
         $postEvent = new CacheResolveEvent($preEvent->getPath(), $preEvent->getFilter(), $url);
-        $this->dispatcher->dispatch(ImagineEvents::POST_RESOLVE, $postEvent);
+        $this->dispatcher->dispatch($postEvent, ImagineEvents::POST_RESOLVE);
 
         return $postEvent->getUrl();
     }

--- a/Imagine/Data/DataManager.php
+++ b/Imagine/Data/DataManager.php
@@ -116,12 +116,16 @@ class DataManager
 
         $binary = $loader->find($path);
         if (!$binary instanceof BinaryInterface) {
-            $mimeType = $this->mimeTypeGuesser->guessMimeType($binary);
+            $mimeType = $this->mimeTypeGuesser->guess($binary);
+
+            if(!$mimeType) {
+              throw new \LogicException(sprintf('The mime type of image %s was not guessed.', $path));
+            }
 
             $binary = new Binary(
                 $binary,
                 $mimeType,
-                $this->extensionGuesser->getExtensions($mimeType)[0] ?? null
+                $this->mimeTypeGuesser->getExtensions($mimeType)[0] ?? null
             );
         }
 

--- a/Imagine/Data/DataManager.php
+++ b/Imagine/Data/DataManager.php
@@ -16,7 +16,6 @@ use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
 use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Liip\ImagineBundle\Model\Binary;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
 
 class DataManager
 {
@@ -24,11 +23,6 @@ class DataManager
      * @var MimeTypeGuesserInterface
      */
     protected $mimeTypeGuesser;
-
-    /**
-     * @var ExtensionGuesserInterface
-     */
-    protected $extensionGuesser;
 
     /**
      * @var FilterConfiguration
@@ -59,7 +53,6 @@ class DataManager
      */
     public function __construct(
         MimeTypeGuesserInterface $mimeTypeGuesser,
-        ExtensionGuesserInterface $extensionGuesser,
         FilterConfiguration $filterConfig,
         $defaultLoader = null,
         $globalDefaultImage = null
@@ -67,7 +60,6 @@ class DataManager
         $this->mimeTypeGuesser = $mimeTypeGuesser;
         $this->filterConfig = $filterConfig;
         $this->defaultLoader = $defaultLoader;
-        $this->extensionGuesser = $extensionGuesser;
         $this->globalDefaultImage = $globalDefaultImage;
     }
 
@@ -124,12 +116,12 @@ class DataManager
 
         $binary = $loader->find($path);
         if (!$binary instanceof BinaryInterface) {
-            $mimeType = $this->mimeTypeGuesser->guess($binary);
+            $mimeType = $this->mimeTypeGuesser->guessMimeType($binary);
 
             $binary = new Binary(
                 $binary,
                 $mimeType,
-                $this->extensionGuesser->guess($mimeType)
+                $this->extensionGuesser->getExtensions($mimeType)[0] ?? null
             );
         }
 

--- a/Imagine/Data/DataManager.php
+++ b/Imagine/Data/DataManager.php
@@ -118,8 +118,8 @@ class DataManager
         if (!$binary instanceof BinaryInterface) {
             $mimeType = $this->mimeTypeGuesser->guess($binary);
 
-            if(!$mimeType) {
-              throw new \LogicException(sprintf('The mime type of image %s was not guessed.', $path));
+            if (!$mimeType) {
+                throw new \LogicException(sprintf('The mime type of image %s was not guessed.', $path));
             }
 
             $binary = new Binary(

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -260,7 +260,6 @@
 
         <service id="liip_imagine.binary.loader.prototype.filesystem" class="Liip\ImagineBundle\Binary\Loader\FileSystemLoader">
             <argument type="service" id="liip_imagine.mime_type_guesser" />
-            <argument type="service" id="liip_imagine.extension_guesser" />
             <argument><!-- will be injected by FileSystemLoaderFactory --></argument>
         </service>
 
@@ -338,8 +337,7 @@
 
         <!-- Guessers -->
 
-        <service id="liip_imagine.mime_type_guesser" class="Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface">
-            <factory class="Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser" method="getInstance" />
+        <service id="liip_imagine.mime_type_guesser" class="Symfony\Component\Mime\MimeTypes">
         </service>
 
         <service id="liip_imagine.extension_guesser" class="Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface">

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -114,7 +114,6 @@
 
         <service id="liip_imagine.data.manager" class="Liip\ImagineBundle\Imagine\Data\DataManager" public="true">
             <argument type="service" id="liip_imagine.binary.mime_type_guesser" />
-            <argument type="service" id="liip_imagine.extension_guesser" />
             <argument type="service" id="liip_imagine.filter.configuration" />
             <argument>%liip_imagine.binary.loader.default%</argument>
             <argument>%liip_imagine.default_image%</argument>
@@ -269,7 +268,6 @@
         </service>
 
         <service id="liip_imagine.binary.loader.prototype.flysystem" class="Liip\ImagineBundle\Binary\Loader\FlysystemLoader" abstract="true">
-            <argument type="service" id="liip_imagine.extension_guesser" />
             <argument><!-- will be injected by FlysystemLoaderFactory --></argument>
         </service>
 
@@ -338,10 +336,6 @@
         <!-- Guessers -->
 
         <service id="liip_imagine.mime_type_guesser" class="Symfony\Component\Mime\MimeTypes">
-        </service>
-
-        <service id="liip_imagine.extension_guesser" class="Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface">
-            <factory class="Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser" method="getInstance" />
         </service>
 
         <service id="liip_imagine.binary.mime_type_guesser" class="Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser">

--- a/Templating/FilterExtension.php
+++ b/Templating/FilterExtension.php
@@ -11,7 +11,7 @@
 
 namespace Liip\ImagineBundle\Templating;
 
-class FilterExtension extends \Twig_Extension
+class FilterExtension extends Twig\Extension\AbstractExtension
 {
     use FilterTrait;
 
@@ -21,7 +21,7 @@ class FilterExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('imagine_filter', [$this, 'filter']),
+            new \Twig\TwigFilter('imagine_filter', [$this, 'filter']),
         ];
     }
 }

--- a/Templating/FilterExtension.php
+++ b/Templating/FilterExtension.php
@@ -11,7 +11,7 @@
 
 namespace Liip\ImagineBundle\Templating;
 
-class FilterExtension extends Twig\Extension\AbstractExtension
+class FilterExtension extends \Twig\Extension\AbstractExtension
 {
     use FilterTrait;
 

--- a/Templating/Helper/FilterHelper.php
+++ b/Templating/Helper/FilterHelper.php
@@ -12,9 +12,8 @@
 namespace Liip\ImagineBundle\Templating\Helper;
 
 use Liip\ImagineBundle\Templating\FilterTrait;
-use Symfony\Component\Templating\Helper\Helper;
 
-class FilterHelper extends Helper
+class FilterHelper
 {
     use FilterTrait;
 }

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -15,7 +15,6 @@ use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\Metadata\MetadataBag;
 use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
-use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Cache\SignerInterface;
@@ -28,7 +27,6 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 abstract class AbstractTest extends TestCase
@@ -199,7 +197,7 @@ abstract class AbstractTest extends TestCase
      */
     protected function createMimeTypeGuesserInterfaceMock()
     {
-        return $this->createObjectMock(MimeTypeGuesserInterface::class);
+        return $this->createObjectMock(MimeTypesInterface::class);
     }
 
     /**

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -28,6 +28,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Routing\RouterInterface;
+use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
 
 abstract class AbstractTest extends TestCase
 {
@@ -197,7 +198,7 @@ abstract class AbstractTest extends TestCase
      */
     protected function createMimeTypeGuesserInterfaceMock()
     {
-        return $this->createObjectMock(MimeTypesInterface::class);
+        return $this->createObjectMock(MimeTypeGuesserInterface::class);
     }
 
     /**

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -15,6 +15,7 @@ use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\Metadata\MetadataBag;
 use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
+use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Cache\SignerInterface;
@@ -28,7 +29,6 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Routing\RouterInterface;
-use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
 
 abstract class AbstractTest extends TestCase
 {

--- a/Tests/Binary/Loader/AbstractDoctrineLoaderTest.php
+++ b/Tests/Binary/Loader/AbstractDoctrineLoaderTest.php
@@ -55,19 +55,19 @@ class AbstractDoctrineLoaderTest extends TestCase
             ->expects($this->atLeastOnce())
             ->method('mapPathToId')
             ->with('/foo/bar')
-            ->will($this->returnValue(1337));
+            ->willReturn(1337);
 
         $this->loader
             ->expects($this->atLeastOnce())
             ->method('getStreamFromImage')
             ->with($image)
-            ->will($this->returnValue(fopen('data://text/plain,foo', 'r')));
+            ->willReturn(fopen('data://text/plain,foo', 'r'));
 
         $this->om
             ->expects($this->atLeastOnce())
             ->method('find')
             ->with(null, 1337)
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $this->assertSame('foo', $this->loader->find('/foo/bar'));
     }
@@ -79,24 +79,24 @@ class AbstractDoctrineLoaderTest extends TestCase
         $this->loader
             ->expects($this->atLeastOnce())
             ->method('mapPathToId')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['/foo/bar.png', 1337],
                 ['/foo/bar', 4711],
-            ]));
+            ]);
 
         $this->loader
             ->expects($this->atLeastOnce())
             ->method('getStreamFromImage')
             ->with($image)
-            ->will($this->returnValue(fopen('data://text/plain,foo', 'r')));
+            ->willReturn(fopen('data://text/plain,foo', 'r'));
 
         $this->om
             ->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 [null, 1337, null],
                 [null, 4711, $image],
-            ]));
+            ]);
 
         $this->assertSame('foo', $this->loader->find('/foo/bar.png'));
     }
@@ -109,7 +109,7 @@ class AbstractDoctrineLoaderTest extends TestCase
             ->expects($this->atLeastOnce())
             ->method('mapPathToId')
             ->with('/foo/bar')
-            ->will($this->returnValue(1337));
+            ->willReturn(1337);
 
         $this->loader
             ->expects($this->never())
@@ -119,7 +119,7 @@ class AbstractDoctrineLoaderTest extends TestCase
             ->expects($this->atLeastOnce())
             ->method('find')
             ->with(null, 1337)
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $this->loader->find('/foo/bar');
     }

--- a/Tests/Binary/Loader/ChainLoaderTest.php
+++ b/Tests/Binary/Loader/ChainLoaderTest.php
@@ -18,8 +18,7 @@ use Liip\ImagineBundle\Binary\Locator\FileSystemLocator;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Model\FileBinary;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
+use Symfony\Component\Mime\MimeTypes;
 
 /**
  * @covers \Liip\ImagineBundle\Binary\Loader\ChainLoader
@@ -108,20 +107,20 @@ class ChainLoaderTest extends TestCase
      */
     public function testThrowsIfFileDoesNotExistWithMultipleLoaders(string $path): void
     {
+
+        $mimeTypes =  new MimeTypes();
         $this->expectException(NotLoadableException::class);
         $this->expectExceptionMessageRegExp('{Source image not resolvable "[^"]+" using "FileSystemLoader=\[foo\], FileSystemLoader=\[bar\]" 2 loaders \(internal exceptions: FileSystemLoader=\[.+\], FileSystemLoader=\[.+\]\)\.}');
 
         $this->getChainLoader([], [
             'foo' => new FileSystemLoader(
-                MimeTypeGuesser::getInstance(),
-                ExtensionGuesser::getInstance(),
+                $mimeTypes,
                 $this->getFileSystemLocator([
                     realpath(__DIR__.'/../../'),
                 ])
             ),
             'bar' => new FileSystemLoader(
-                MimeTypeGuesser::getInstance(),
-                ExtensionGuesser::getInstance(),
+                $mimeTypes,
                 $this->getFileSystemLocator([
                     realpath(__DIR__.'/../../../'),
                 ])
@@ -147,11 +146,11 @@ class ChainLoaderTest extends TestCase
      */
     private function getChainLoader(array $paths = [], array $loaders = null): ChainLoader
     {
+        $mimeTypes =  new MimeTypes();
         if (null === $loaders) {
             $loaders = [
                 'foo' => new FileSystemLoader(
-                    MimeTypeGuesser::getInstance(),
-                    ExtensionGuesser::getInstance(),
+                    $mimeTypes,
                     $this->getFileSystemLocator($paths ?: [__DIR__])
                 ),
             ];

--- a/Tests/Binary/Loader/ChainLoaderTest.php
+++ b/Tests/Binary/Loader/ChainLoaderTest.php
@@ -107,8 +107,7 @@ class ChainLoaderTest extends TestCase
      */
     public function testThrowsIfFileDoesNotExistWithMultipleLoaders(string $path): void
     {
-
-        $mimeTypes =  new MimeTypes();
+        $mimeTypes = new MimeTypes();
         $this->expectException(NotLoadableException::class);
         $this->expectExceptionMessageRegExp('{Source image not resolvable "[^"]+" using "FileSystemLoader=\[foo\], FileSystemLoader=\[bar\]" 2 loaders \(internal exceptions: FileSystemLoader=\[.+\], FileSystemLoader=\[.+\]\)\.}');
 
@@ -146,7 +145,7 @@ class ChainLoaderTest extends TestCase
      */
     private function getChainLoader(array $paths = [], array $loaders = null): ChainLoader
     {
-        $mimeTypes =  new MimeTypes();
+        $mimeTypes = new MimeTypes();
         if (null === $loaders) {
             $loaders = [
                 'foo' => new FileSystemLoader(

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -17,8 +17,7 @@ use Liip\ImagineBundle\Binary\Locator\FileSystemLocator;
 use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
 use Liip\ImagineBundle\Model\FileBinary;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
+use Symfony\Component\Mime\MimeTypes;
 
 /**
  * @covers \Liip\ImagineBundle\Binary\Loader\FileSystemLoader
@@ -194,9 +193,9 @@ class FileSystemLoaderTest extends TestCase
      */
     private function getFileSystemLoader(array $roots = [], LocatorInterface $locator = null)
     {
+        $mimetype = new MimeTypes();
         return new FileSystemLoader(
-            MimeTypeGuesser::getInstance(),
-            ExtensionGuesser::getInstance(),
+            $mimetype,
             null !== $locator ? $locator : $this->getFileSystemLocator(\count($roots) ? $roots : $this->getDefaultDataRoots())
         );
     }

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -194,6 +194,7 @@ class FileSystemLoaderTest extends TestCase
     private function getFileSystemLoader(array $roots = [], LocatorInterface $locator = null)
     {
         $mimetype = new MimeTypes();
+
         return new FileSystemLoader(
             $mimetype,
             null !== $locator ? $locator : $this->getFileSystemLocator(\count($roots) ? $roots : $this->getDefaultDataRoots())

--- a/Tests/Binary/Loader/FlysystemLoaderTest.php
+++ b/Tests/Binary/Loader/FlysystemLoaderTest.php
@@ -16,7 +16,8 @@ use League\Flysystem\Filesystem;
 use Liip\ImagineBundle\Binary\Loader\FlysystemLoader;
 use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
 use Liip\ImagineBundle\Tests\AbstractTest;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
+use Symfony\Component\Mime\MimeTypes;
+use Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser;
 
 /**
  * @requires PHP 5.4
@@ -43,7 +44,8 @@ class FlysystemLoaderTest extends AbstractTest
      */
     public function getFlysystemLoader()
     {
-        return new FlysystemLoader(ExtensionGuesser::getInstance(), $this->flyFilesystem);
+        $mimetypes = new SimpleMimeTypeGuesser(new MimeTypes());
+        return new FlysystemLoader($mimetypes, $this->flyFilesystem);
     }
 
     public function testShouldImplementLoaderInterface()

--- a/Tests/Binary/Loader/FlysystemLoaderTest.php
+++ b/Tests/Binary/Loader/FlysystemLoaderTest.php
@@ -15,9 +15,9 @@ use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
 use Liip\ImagineBundle\Binary\Loader\FlysystemLoader;
 use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
+use Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser;
 use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\Mime\MimeTypes;
-use Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser;
 
 /**
  * @requires PHP 5.4
@@ -45,6 +45,7 @@ class FlysystemLoaderTest extends AbstractTest
     public function getFlysystemLoader()
     {
         $mimetypes = new SimpleMimeTypeGuesser(new MimeTypes());
+
         return new FlysystemLoader($mimetypes, $this->flyFilesystem);
     }
 

--- a/Tests/Binary/SimpleMimeTypeGuesserTest.php
+++ b/Tests/Binary/SimpleMimeTypeGuesserTest.php
@@ -14,7 +14,7 @@ namespace Liip\ImagineBundle\Tests\Binary;
 use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
 use Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
+use Symfony\Component\Mime\MimeTypes;
 
 /**
  * @covers \Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser<extended>
@@ -65,6 +65,6 @@ class SimpleMimeTypeGuesserTest extends TestCase
      */
     private function getSimpleMimeTypeGuesser()
     {
-        return new SimpleMimeTypeGuesser(MimeTypeGuesser::getInstance());
+        return new SimpleMimeTypeGuesser(new MimeTypes());
     }
 }

--- a/Tests/Config/FilterSetBuilderTest.php
+++ b/Tests/Config/FilterSetBuilderTest.php
@@ -59,7 +59,7 @@ class FilterSetBuilderTest extends TestCase
         $this->filterSetFactoryMock->expects($this->once())
             ->method('create')
             ->with($name, $dataLoader, $quality, $filters)
-            ->will($this->returnValue($filterSetMock));
+            ->willReturn($filterSetMock);
 
         $this->filterFactoryCollectionMock->expects($this->never())
             ->method('getFilterFactoryByName');
@@ -91,16 +91,16 @@ class FilterSetBuilderTest extends TestCase
         $filterFactoryMock->expects($this->once())
             ->method('create')
             ->with($filterData)
-            ->will($this->returnValue($filterMock));
+            ->willReturn($filterMock);
 
         $this->filterSetFactoryMock->expects($this->once())
             ->method('create')
-            ->will($this->returnValue($filterSetMock));
+            ->willReturn($filterSetMock);
 
         $this->filterFactoryCollectionMock->expects($this->once())
             ->method('getFilterFactoryByName')
             ->with($filterCode)
-            ->will($this->returnValue($filterFactoryMock));
+            ->willReturn($filterFactoryMock);
 
         $filterSet = $this->model->build($name, [
             'data_loader' => $dataLoader,

--- a/Tests/Config/FilterSetCollectionTest.php
+++ b/Tests/Config/FilterSetCollectionTest.php
@@ -32,7 +32,7 @@ class FilterSetCollectionTest extends TestCase
         $stackBuilderMock->expects($this->once())
             ->method('build')
             ->with($filterSetName, $filterSetData)
-            ->will($this->returnValue($filterSetMock));
+            ->willReturn($filterSetMock);
 
         $model = new StackCollection($stackBuilderMock, [$filterSetName => $filterSetData]);
         $this->assertSame([$filterSetMock], $model->getStacks());

--- a/Tests/DependencyInjection/Factory/Loader/ChainLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/ChainLoaderFactoryTest.php
@@ -67,8 +67,6 @@ class ChainLoaderFactoryTest extends FactoryTestCase
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('chain');
 
-
-
         $loader = new ChainLoaderFactory();
         $loader->addConfiguration($rootNode);
 

--- a/Tests/DependencyInjection/Factory/Loader/ChainLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/ChainLoaderFactoryTest.php
@@ -62,8 +62,12 @@ class ChainLoaderFactoryTest extends FactoryTestCase
 
     public function testProcessOptionsOnAddConfiguration(): void
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('chain', 'array');
+        $treeBuilder = new TreeBuilder('chain');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('chain');
+
+
 
         $loader = new ChainLoaderFactory();
         $loader->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -65,7 +65,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
         $this->assertInstanceOfChildDefinition($loaderDefinition);
         $this->assertSame('liip_imagine.binary.loader.prototype.filesystem', $loaderDefinition->getParent());
 
-        $this->assertSame(['theDataRoot'], $loaderDefinition->getArgument(2)->getArgument(0));
+        $this->assertSame(['theDataRoot'], $loaderDefinition->getArgument(1)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadata()
@@ -100,7 +100,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
         ];
 
-        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2)->getArgument(0));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(1)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadataAndBlacklisting()
@@ -136,7 +136,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
         ];
 
-        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2)->getArgument(0));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(1)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingMetadataAndWhitelisting()
@@ -172,7 +172,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipFooBundle' => $fooBundleRootPath.'/Resources/public',
         ];
 
-        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2)->getArgument(0));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(1)->getArgument(0));
     }
 
     public function testCreateLoaderDefinitionOnCreateWithBundlesEnabledUsingNamedObj()
@@ -203,7 +203,7 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             'LiipBarBundle' => $barBundleRootPath.'/Resources/public',
         ];
 
-        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(2)->getArgument(0));
+        $this->assertSame($expected, $container->getDefinition('liip_imagine.binary.loader.the_loader_name')->getArgument(1)->getArgument(0));
     }
 
     public function testAbleToCreateTwoDistinctLoaders()
@@ -229,12 +229,12 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
 
         $this->assertSame(
             ['firstLoaderDataroot'],
-            $container->getDefinition('liip_imagine.binary.loader.first_loader')->getArgument(2)->getArgument(0)
+            $container->getDefinition('liip_imagine.binary.loader.first_loader')->getArgument(1)->getArgument(0)
         );
 
         $this->assertSame(
             ['secondLoaderDataroot'],
-            $container->getDefinition('liip_imagine.binary.loader.second_loader')->getArgument(2)->getArgument(0)
+            $container->getDefinition('liip_imagine.binary.loader.second_loader')->getArgument(1)->getArgument(0)
         );
     }
 

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -262,8 +262,11 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
     {
         $expectedDataRoot = ['theDataRoot'];
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('filesystem', 'array');
+        $treeBuilder = new TreeBuilder('filesystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('filesystem');
+
 
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);
@@ -282,8 +285,13 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
     {
         $expectedDataRoot = [SymfonyFramework::getContainerResolvableRootWebPath()];
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('filesystem', 'array');
+
+        $treeBuilder = new TreeBuilder('filesystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('filesystem');
+
+
 
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);
@@ -300,8 +308,12 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
     {
         $expectedDataRoot = [SymfonyFramework::getContainerResolvableRootWebPath()];
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('filesystem', 'array');
+
+        $treeBuilder = new TreeBuilder('filesystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('filesystem');
+
 
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -267,7 +267,6 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('filesystem');
 
-
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);
 
@@ -285,13 +284,10 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
     {
         $expectedDataRoot = [SymfonyFramework::getContainerResolvableRootWebPath()];
 
-
         $treeBuilder = new TreeBuilder('filesystem');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('filesystem');
-
-
 
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);
@@ -308,12 +304,10 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
     {
         $expectedDataRoot = [SymfonyFramework::getContainerResolvableRootWebPath()];
 
-
         $treeBuilder = new TreeBuilder('filesystem');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('filesystem');
-
 
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
@@ -80,8 +80,11 @@ class FlysystemLoaderFactoryTest extends TestCase
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $this->expectExceptionMessage('The child node "filesystem_service" at path "flysystem" must be configured.');
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('flysystem', 'array');
+        $treeBuilder = new TreeBuilder('flysystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('flysystem');
+
 
         $resolver = new FlysystemLoaderFactory();
         $resolver->addConfiguration($rootNode);
@@ -93,8 +96,11 @@ class FlysystemLoaderFactoryTest extends TestCase
     {
         $expectedService = 'theService';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('flysystem', 'array');
+        $treeBuilder = new TreeBuilder('flysystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('flysystem');
+
 
         $loader = new FlysystemLoaderFactory();
         $loader->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
@@ -85,7 +85,6 @@ class FlysystemLoaderFactoryTest extends TestCase
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('flysystem');
 
-
         $resolver = new FlysystemLoaderFactory();
         $resolver->addConfiguration($rootNode);
 
@@ -100,7 +99,6 @@ class FlysystemLoaderFactoryTest extends TestCase
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('flysystem');
-
 
         $loader = new FlysystemLoaderFactory();
         $loader->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
@@ -71,8 +71,12 @@ class StreamLoaderFactoryTest extends TestCase
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $this->expectExceptionMessage('The child node "wrapper" at path "stream" must be configured.');
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('stream', 'array');
+        $treeBuilder = new TreeBuilder('stream');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('stream');
+
+
 
         $resolver = new StreamLoaderFactory();
         $resolver->addConfiguration($rootNode);
@@ -85,8 +89,11 @@ class StreamLoaderFactoryTest extends TestCase
         $expectedWrapper = 'theWrapper';
         $expectedContext = 'theContext';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('stream', 'array');
+        $treeBuilder = new TreeBuilder('stream');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('stream');
+
 
         $loader = new StreamLoaderFactory();
         $loader->addConfiguration($rootNode);
@@ -107,8 +114,11 @@ class StreamLoaderFactoryTest extends TestCase
 
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('stream', 'array');
+        $treeBuilder = new TreeBuilder('stream');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('stream');
+
 
         $loader = new StreamLoaderFactory();
         $loader->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
@@ -76,8 +76,6 @@ class StreamLoaderFactoryTest extends TestCase
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('stream');
 
-
-
         $resolver = new StreamLoaderFactory();
         $resolver->addConfiguration($rootNode);
 
@@ -93,7 +91,6 @@ class StreamLoaderFactoryTest extends TestCase
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('stream');
-
 
         $loader = new StreamLoaderFactory();
         $loader->addConfiguration($rootNode);
@@ -118,7 +115,6 @@ class StreamLoaderFactoryTest extends TestCase
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('stream');
-
 
         $loader = new StreamLoaderFactory();
         $loader->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -301,7 +301,6 @@ class AwsS3ResolverFactoryTest extends TestCase
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('aws_s3');
 
-
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
 
@@ -317,7 +316,6 @@ class AwsS3ResolverFactoryTest extends TestCase
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('aws_s3');
-
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -338,8 +336,6 @@ class AwsS3ResolverFactoryTest extends TestCase
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('aws_s3');
-
-
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -370,12 +366,10 @@ class AwsS3ResolverFactoryTest extends TestCase
         $expectedAcl = 'theAcl';
         $expectedCachePrefix = 'theCachePrefix';
 
-
         $treeBuilder = new TreeBuilder('aws_s3');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('aws_s3');
-
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -414,13 +408,10 @@ class AwsS3ResolverFactoryTest extends TestCase
     {
         $expectedAcl = 'public-read';
 
-
         $treeBuilder = new TreeBuilder('aws_s3');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('aws_s3');
-
-
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -465,13 +456,10 @@ class AwsS3ResolverFactoryTest extends TestCase
         $expectedAcl = 'theAcl';
         $expectedCachePrefix = 'theCachePrefix';
 
-
         $treeBuilder = new TreeBuilder('aws_s3');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('aws_s3');
-
-
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -296,8 +296,11 @@ class AwsS3ResolverFactoryTest extends TestCase
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $this->expectExceptionMessage('The child node "bucket" at path "aws_s3" must be configured.');
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
+
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -310,8 +313,11 @@ class AwsS3ResolverFactoryTest extends TestCase
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $this->expectExceptionMessage('The child node "client_config" at path "aws_s3" must be configured.');
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
+
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -328,8 +334,12 @@ class AwsS3ResolverFactoryTest extends TestCase
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $this->expectExceptionMessage('Invalid type for path "aws_s3.client_config". Expected array, but got string');
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
+
+
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -360,8 +370,12 @@ class AwsS3ResolverFactoryTest extends TestCase
         $expectedAcl = 'theAcl';
         $expectedCachePrefix = 'theCachePrefix';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
+
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -400,8 +414,13 @@ class AwsS3ResolverFactoryTest extends TestCase
     {
         $expectedAcl = 'public-read';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
+
+
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -446,8 +465,13 @@ class AwsS3ResolverFactoryTest extends TestCase
         $expectedAcl = 'theAcl';
         $expectedCachePrefix = 'theCachePrefix';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
+
+
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
@@ -86,12 +86,10 @@ class FlysystemResolverFactoryTest extends TestCase
         $expectedFlysystemService = 'flyfilesystemservice';
         $expectedVisibility = 'public';
 
-
         $treeBuilder = new TreeBuilder('flysystem');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('flysystem');
-
 
         $resolver = new FlysystemResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -122,12 +120,10 @@ class FlysystemResolverFactoryTest extends TestCase
     {
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
 
-
         $treeBuilder = new TreeBuilder('flysystem');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('flysystem');
-
 
         $resolver = new FlysystemResolverFactory();
         $resolver->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
@@ -86,8 +86,12 @@ class FlysystemResolverFactoryTest extends TestCase
         $expectedFlysystemService = 'flyfilesystemservice';
         $expectedVisibility = 'public';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('flysystem', 'array');
+
+        $treeBuilder = new TreeBuilder('flysystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('flysystem');
+
 
         $resolver = new FlysystemResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -118,8 +122,12 @@ class FlysystemResolverFactoryTest extends TestCase
     {
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('flysystem', 'array');
+
+        $treeBuilder = new TreeBuilder('flysystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('flysystem');
+
 
         $resolver = new FlysystemResolverFactory();
         $resolver->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
@@ -72,8 +72,12 @@ class WebPathResolverFactoryTest extends TestCase
         $expectedWebPath = 'theWebPath';
         $expectedCachePrefix = 'theCachePrefix';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('web_path', 'array');
+        $treeBuilder = new TreeBuilder('web_path');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('web_path');
+
+
 
         $resolver = new WebPathResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -94,8 +98,12 @@ class WebPathResolverFactoryTest extends TestCase
 
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('web_path', 'array');
+
+        $treeBuilder = new TreeBuilder('web_path');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('web_path');
+
 
         $resolver = new WebPathResolverFactory();
         $resolver->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
@@ -77,8 +77,6 @@ class WebPathResolverFactoryTest extends TestCase
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('web_path');
 
-
-
         $resolver = new WebPathResolverFactory();
         $resolver->addConfiguration($rootNode);
 
@@ -98,12 +96,10 @@ class WebPathResolverFactoryTest extends TestCase
 
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
     {
-
         $treeBuilder = new TreeBuilder('web_path');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
             ? $treeBuilder->getRootNode()
             : $treeBuilder->root('web_path');
-
 
         $resolver = new WebPathResolverFactory();
         $resolver->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/LiipImagineExtensionTest.php
+++ b/Tests/DependencyInjection/LiipImagineExtensionTest.php
@@ -70,33 +70,6 @@ class LiipImagineExtensionTest extends AbstractTest
         $this->assertSame('value1', $variable1, sprintf('%s parameter is correct', $variable1));
     }
 
-    public static function provideFactoryData()
-    {
-        return [
-            [
-                'liip_imagine.mime_type_guesser',
-                [MimeTypeGuesser::class, 'getInstance'],
-            ],
-            [
-                'liip_imagine.extension_guesser',
-                [ExtensionGuesser::class, 'getInstance'],
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFactoryData
-     *
-     * @param string $service
-     * @param string $factory
-     */
-    public function testFactoriesConfiguration($service, $factory)
-    {
-        $this->createEmptyConfiguration();
-        $definition = $this->containerBuilder->getDefinition($service);
-
-        $this->assertSame($factory, $definition->getFactory());
-    }
 
     protected function createEmptyConfiguration()
     {

--- a/Tests/DependencyInjection/LiipImagineExtensionTest.php
+++ b/Tests/DependencyInjection/LiipImagineExtensionTest.php
@@ -19,8 +19,6 @@ use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 use Symfony\Component\Yaml\Parser;
 
 /**
@@ -69,7 +67,6 @@ class LiipImagineExtensionTest extends AbstractTest
         $variable1 = $param['small']['filters']['route']['requirements']['variable1'];
         $this->assertSame('value1', $variable1, sprintf('%s parameter is correct', $variable1));
     }
-
 
     protected function createEmptyConfiguration()
     {

--- a/Tests/Functional/AbstractSetupWebTestCase.php
+++ b/Tests/Functional/AbstractSetupWebTestCase.php
@@ -22,7 +22,7 @@ class AbstractSetupWebTestCase extends AbstractWebTestCase
     /**
      * @var Client
      */
-    protected $client;
+    protected static $client;
 
     /**
      * @var Filesystem
@@ -43,8 +43,8 @@ class AbstractSetupWebTestCase extends AbstractWebTestCase
     {
         parent::setUp();
 
-        $this->client = $this->createClient();
-        $this->client->catchExceptions(false);
+        self::$client = $this->createClient();
+        self::$client->catchExceptions(false);
         $this->webRoot = sprintf('%s/public', self::$kernel->getContainer()->getParameter('kernel.root_dir'));
         $this->cacheRoot = $this->webRoot.'/media/cache';
         $this->filesystem = new Filesystem();

--- a/Tests/Functional/Controller/ImagineControllerTest.php
+++ b/Tests/Functional/Controller/ImagineControllerTest.php
@@ -31,9 +31,9 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         //guard
         $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
 
-        $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/images/cats.jpeg');
+        self::$client->request('GET', '/media/cache/resolve/thumbnail_web_path/images/cats.jpeg');
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(301, $response->getStatusCode());
@@ -49,9 +49,9 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
             'anImageContent'
         );
 
-        $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/images/cats.jpeg');
+        self::$client->request('GET', '/media/cache/resolve/thumbnail_web_path/images/cats.jpeg');
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(301, $response->getStatusCode());
@@ -65,7 +65,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $this->expectException(\Symfony\Component\HttpKernel\Exception\BadRequestHttpException::class);
         $this->expectExceptionMessage('Signed url does not pass the sign check for path "images/cats.jpeg" and filter "thumbnail_web_path" and runtime config {"thumbnail":{"size":["50","50"]}}');
 
-        $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/rc/invalidHash/images/cats.jpeg?'.http_build_query([
+        self::$client->request('GET', '/media/cache/resolve/thumbnail_web_path/rc/invalidHash/images/cats.jpeg?'.http_build_query([
             'filters' => [
                 'thumbnail' => ['size' => [50, 50]],
             ],
@@ -78,7 +78,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
         $this->expectExceptionMessage('Filters must be an array. Value was "some-string"');
 
-        $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/rc/invalidHash/images/cats.jpeg?'.http_build_query([
+        self::$client->request('GET', '/media/cache/resolve/thumbnail_web_path/rc/invalidHash/images/cats.jpeg?'.http_build_query([
             'filters' => 'some-string',
             '_hash' => 'hash',
         ]));
@@ -89,14 +89,14 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
         $this->expectExceptionMessage('Source image for path "images/shrodinger_cats_which_not_exist.jpeg" could not be found');
 
-        $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/images/shrodinger_cats_which_not_exist.jpeg');
+        self::$client->request('GET', '/media/cache/resolve/thumbnail_web_path/images/shrodinger_cats_which_not_exist.jpeg');
     }
 
     public function testInvalidFilterShouldThrowNotFoundHttpException()
     {
         $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
 
-        $this->client->request('GET', '/media/cache/resolve/invalid-filter/images/cats.jpeg');
+        self::$client->request('GET', '/media/cache/resolve/invalid-filter/images/cats.jpeg');
     }
 
     public function testShouldResolveWithCustomFiltersPopulatingCacheFirst()
@@ -121,9 +121,9 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         //guard
         $this->assertFileNotExists($this->cacheRoot.'/'.$expectedCachePath);
 
-        $this->client->request('GET', $url);
+        self::$client->request('GET', $url);
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(301, $response->getStatusCode());
@@ -156,9 +156,9 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
             'anImageContent'
         );
 
-        $this->client->request('GET', $url);
+        self::$client->request('GET', $url);
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(301, $response->getStatusCode());
@@ -176,9 +176,9 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
 
         // we are calling url with encoded file name as it will be called by browser
         $urlEncodedFileName = 'foo+bar';
-        $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/images/'.$urlEncodedFileName.'.jpeg');
+        self::$client->request('GET', '/media/cache/resolve/thumbnail_web_path/images/'.$urlEncodedFileName.'.jpeg');
 
-        $response = $this->client->getResponse();
+        $response = self::$client->getResponse();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(301, $response->getStatusCode());

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -14,9 +14,6 @@ framework:
     translator:     ~
     test:           ~
 
-    templating:
-        engines: [ 'php' ]
-
     session:
         storage_id: session.storage.mock_file
 

--- a/Tests/Imagine/Cache/CacheManagerTest.php
+++ b/Tests/Imagine/Cache/CacheManagerTest.php
@@ -547,7 +547,7 @@ class CacheManagerTest extends AbstractTest
         $dispatcher
             ->expects($this->at(0))
             ->method('dispatch')
-            ->with(ImagineEvents::PRE_RESOLVE, new CacheResolveEvent('cats.jpg', 'thumbnail'));
+            ->with(new CacheResolveEvent('cats.jpg', 'thumbnail'), ImagineEvents::PRE_RESOLVE);
 
         $cacheManager = new CacheManager(
             $this->createFilterConfigurationMock(),
@@ -566,7 +566,7 @@ class CacheManagerTest extends AbstractTest
         $dispatcher
             ->expects($this->at(1))
             ->method('dispatch')
-            ->with(ImagineEvents::POST_RESOLVE, new CacheResolveEvent('cats.jpg', 'thumbnail'));
+            ->with(new CacheResolveEvent('cats.jpg', 'thumbnail'), ImagineEvents::POST_RESOLVE);
 
         $cacheManager = new CacheManager(
             $this->createFilterConfigurationMock(),
@@ -585,8 +585,8 @@ class CacheManagerTest extends AbstractTest
         $dispatcher
             ->expects($this->at(0))
             ->method('dispatch')
-            ->with(ImagineEvents::PRE_RESOLVE, $this->isInstanceOf(CacheResolveEvent::class))
-            ->will($this->returnCallback(function ($name, $event) {
+            ->with($this->isInstanceOf(CacheResolveEvent::class), ImagineEvents::PRE_RESOLVE)
+            ->will($this->returnCallback(function ($event, $name) {
                 $event->setPath('changed_path');
                 $event->setFilter('changed_filter');
             }));
@@ -614,7 +614,7 @@ class CacheManagerTest extends AbstractTest
         $dispatcher
             ->expects($this->at(0))
             ->method('dispatch')
-            ->will($this->returnCallback(function ($name, $event) {
+            ->will($this->returnCallback(function ($event, $name) {
                 $event->setFilter('thumbnail');
             }));
 
@@ -643,8 +643,8 @@ class CacheManagerTest extends AbstractTest
         $dispatcher
             ->expects($this->at(0))
             ->method('dispatch')
-            ->with(ImagineEvents::PRE_RESOLVE, $this->isInstanceOf(CacheResolveEvent::class))
-            ->will($this->returnCallback(function ($name, $event) {
+            ->with($this->isInstanceOf(CacheResolveEvent::class), ImagineEvents::PRE_RESOLVE)
+            ->will($this->returnCallback(function ($event, $name) {
                 $event->setPath('changed_path');
                 $event->setFilter('changed_filter');
             }));
@@ -652,12 +652,15 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->at(1))
             ->method('dispatch')
             ->with(
-                ImagineEvents::POST_RESOLVE,
+
                 $this->logicalAnd(
                     $this->isInstanceOf(CacheResolveEvent::class),
                     $this->attributeEqualTo('path', 'changed_path'),
                     $this->attributeEqualTo('filter', 'changed_filter')
-            ));
+                  ),
+              ImagineEvents::POST_RESOLVE);
+                
+
 
         $cacheManager = new CacheManager(
             $this->createFilterConfigurationMock(),
@@ -676,8 +679,8 @@ class CacheManagerTest extends AbstractTest
         $dispatcher
             ->expects($this->at(1))
             ->method('dispatch')
-            ->with(ImagineEvents::POST_RESOLVE, $this->isInstanceOf(CacheResolveEvent::class))
-            ->will($this->returnCallback(function ($name, $event) {
+            ->with($this->isInstanceOf(CacheResolveEvent::class), ImagineEvents::POST_RESOLVE)
+            ->will($this->returnCallback(function ($event, $name) {
                 $event->setUrl('changed_url');
             }));
 

--- a/Tests/Imagine/Cache/CacheManagerTest.php
+++ b/Tests/Imagine/Cache/CacheManagerTest.php
@@ -49,11 +49,11 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'cache' => null,
-            ]));
+            ]);
 
         $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
         $cacheManager->getBrowserPath('cats.jpeg', 'thumbnail');
@@ -80,23 +80,23 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('isStored')
             ->with('cats.jpeg', 'thumbnail')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $resolver
             ->expects($this->once())
             ->method('resolve')
             ->with('cats.jpeg', 'thumbnail')
-            ->will($this->returnValue('http://a/path/to/an/image.png'));
+            ->willReturn('http://a/path/to/an/image.png');
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->exactly(2))
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'cache' => null,
-            ]));
+            ]);
 
         $router = $this->createRouterInterfaceMock();
         $router
@@ -118,7 +118,7 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('isStored')
             ->with('cats.jpeg', 'thumbnail')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $resolver
             ->expects($this->never())
             ->method('resolve');
@@ -128,17 +128,17 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'cache' => null,
-            ]));
+            ]);
 
         $router = $this->createRouterInterfaceMock();
         $router
             ->expects($this->once())
             ->method('generate')
-            ->will($this->returnValue('/media/cache/thumbnail/cats.jpeg'));
+            ->willReturn('/media/cache/thumbnail/cats.jpeg');
 
         $cacheManager = new CacheManager($config, $router, new Signer('secret'), $this->createEventDispatcherInterfaceMock());
         $cacheManager->addResolver('default', $resolver);
@@ -161,7 +161,7 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('isStored')
             ->with('rc/VhOzTGRB/cats.jpeg', 'thumbnail')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $resolver
             ->expects($this->never())
             ->method('resolve');
@@ -171,17 +171,17 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'cache' => null,
-            ]));
+            ]);
 
         $router = $this->createRouterInterfaceMock();
         $router
             ->expects($this->once())
             ->method('generate')
-            ->will($this->returnValue('/media/cache/thumbnail/rc/VhOzTGRB/cats.jpeg'));
+            ->willReturn('/media/cache/thumbnail/rc/VhOzTGRB/cats.jpeg');
 
         $cacheManager = new CacheManager($config, $router, new Signer('secret'), $this->createEventDispatcherInterfaceMock());
         $cacheManager->addResolver('default', $resolver);
@@ -234,7 +234,7 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('resolve')
             ->with('cats.jpeg', 'thumbnail')
-            ->will($this->returnValue('/thumbs/cats.jpeg'));
+            ->willReturn('/thumbs/cats.jpeg');
         $resolver
             ->expects($this->once())
             ->method('store')
@@ -243,18 +243,18 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('remove')
             ->with(['/thumbs/cats.jpeg'], ['thumbnail'])
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->exactly(3))
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'cache' => null,
-            ]));
+            ]);
 
         $cacheManager = new CacheManager(
             $config,
@@ -290,7 +290,7 @@ class CacheManagerTest extends AbstractTest
                 ],
                 UrlGeneratorInterface::ABSOLUTE_URL
             )
-            ->will($this->returnValue($expectedUrl));
+            ->willReturn($expectedUrl);
 
         $cacheManager = new CacheManager(
             $this->createFilterConfigurationMock(),
@@ -320,11 +320,11 @@ class CacheManagerTest extends AbstractTest
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
-            ->will($this->returnCallback(function ($filter) {
+            ->willReturnCallback(function ($filter) {
                 return [
                     'cache' => $filter,
                 ];
-            }));
+            });
 
         $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
         $cacheManager->addResolver($expectedFilter, $resolver);
@@ -353,11 +353,11 @@ class CacheManagerTest extends AbstractTest
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
-            ->will($this->returnCallback(function ($filter) {
+            ->willReturnCallback(function ($filter) {
                 return [
                     'cache' => $filter,
                 ];
-            }));
+            });
 
         $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
         $cacheManager->addResolver($expectedFilterOne, $resolverOne);
@@ -384,11 +384,11 @@ class CacheManagerTest extends AbstractTest
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
-            ->will($this->returnCallback(function ($filter) {
+            ->willReturnCallback(function ($filter) {
                 return [
                     'cache' => $filter,
                 ];
-            }));
+            });
 
         $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
         $cacheManager->addResolver($expectedFilter, $resolver);
@@ -418,11 +418,11 @@ class CacheManagerTest extends AbstractTest
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
-            ->will($this->returnCallback(function ($filter) {
+            ->willReturnCallback(function ($filter) {
                 return [
                     'cache' => $filter,
                 ];
-            }));
+            });
 
         $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
         $cacheManager->addResolver($expectedFilterOne, $resolverOne);
@@ -454,18 +454,18 @@ class CacheManagerTest extends AbstractTest
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
-            ->will($this->returnCallback(function ($filter) {
+            ->willReturnCallback(function ($filter) {
                 return [
                     'cache' => $filter,
                 ];
-            }));
+            });
         $config
             ->expects($this->once())
             ->method('all')
-            ->will($this->returnValue([
+            ->willReturn([
                 $expectedFilterOne => [],
                 $expectedFilterTwo => [],
-            ]));
+            ]);
 
         $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
         $cacheManager->addResolver($expectedFilterOne, $resolverOne);
@@ -495,18 +495,18 @@ class CacheManagerTest extends AbstractTest
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
-            ->will($this->returnCallback(function ($filter) {
+            ->willReturnCallback(function ($filter) {
                 return [
                     'cache' => $filter,
                 ];
-            }));
+            });
         $config
             ->expects($this->once())
             ->method('all')
-            ->will($this->returnValue([
+            ->willReturn([
                 $expectedFilterOne => [],
                 $expectedFilterTwo => [],
-            ]));
+            ]);
 
         $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
         $cacheManager->addResolver($expectedFilterOne, $resolverOne);
@@ -529,11 +529,11 @@ class CacheManagerTest extends AbstractTest
         $config
             ->expects($this->atLeastOnce())
             ->method('get')
-            ->will($this->returnCallback(function ($filter) {
+            ->willReturnCallback(function ($filter) {
                 return [
                     'cache' => $filter,
                 ];
-            }));
+            });
 
         $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
         $cacheManager->addResolver($expectedFilterOne, $resolver);
@@ -586,10 +586,10 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->at(0))
             ->method('dispatch')
             ->with($this->isInstanceOf(CacheResolveEvent::class), ImagineEvents::PRE_RESOLVE)
-            ->will($this->returnCallback(function ($event, $name) {
+            ->willReturnCallback(function ($event, $name) {
                 $event->setPath('changed_path');
                 $event->setFilter('changed_filter');
-            }));
+            });
 
         $resolver = $this->createCacheResolverInterfaceMock();
         $resolver
@@ -614,9 +614,9 @@ class CacheManagerTest extends AbstractTest
         $dispatcher
             ->expects($this->at(0))
             ->method('dispatch')
-            ->will($this->returnCallback(function ($event, $name) {
+            ->willReturnCallback(function ($event, $name) {
                 $event->setFilter('thumbnail');
-            }));
+            });
 
         $cacheManager = $this
             ->getMockBuilder(CacheManager::class)
@@ -632,7 +632,7 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('getResolver')
             ->with('thumbnail')
-            ->will($this->returnValue($this->createCacheResolverInterfaceMock()));
+            ->willReturn($this->createCacheResolverInterfaceMock());
 
         $cacheManager->resolve('cats.jpg', 'default');
     }
@@ -644,23 +644,20 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->at(0))
             ->method('dispatch')
             ->with($this->isInstanceOf(CacheResolveEvent::class), ImagineEvents::PRE_RESOLVE)
-            ->will($this->returnCallback(function ($event, $name) {
+            ->willReturnCallback(function ($event, $name) {
                 $event->setPath('changed_path');
                 $event->setFilter('changed_filter');
-            }));
+            });
         $dispatcher
             ->expects($this->at(1))
             ->method('dispatch')
             ->with(
-
                 $this->logicalAnd(
                     $this->isInstanceOf(CacheResolveEvent::class),
                     $this->attributeEqualTo('path', 'changed_path'),
                     $this->attributeEqualTo('filter', 'changed_filter')
                   ),
               ImagineEvents::POST_RESOLVE);
-                
-
 
         $cacheManager = new CacheManager(
             $this->createFilterConfigurationMock(),
@@ -680,9 +677,9 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->at(1))
             ->method('dispatch')
             ->with($this->isInstanceOf(CacheResolveEvent::class), ImagineEvents::POST_RESOLVE)
-            ->will($this->returnCallback(function ($event, $name) {
+            ->willReturnCallback(function ($event, $name) {
                 $event->setUrl('changed_url');
-            }));
+            });
 
         $cacheManager = new CacheManager(
             $this->createFilterConfigurationMock(),

--- a/Tests/Imagine/Cache/Resolver/AmazonS3ResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/AmazonS3ResolverTest.php
@@ -64,7 +64,7 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('create_object')
-            ->will($this->returnValue($this->createCFResponseMock(false)));
+            ->willReturn($this->createCFResponseMock(false));
 
         $logger = $this->createLoggerInterfaceMock();
         $logger
@@ -84,7 +84,7 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('create_object')
-            ->will($this->returnValue($this->createCFResponseMock(true)));
+            ->willReturn($this->createCFResponseMock(true));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->store($binary, 'foobar.jpg', 'thumb');
@@ -96,7 +96,7 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('if_object_exists')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
 
@@ -110,7 +110,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('get_object_url')
             ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, [])
-            ->will($this->returnValue('http://images.example.com/some-folder/path.jpg'));
+            ->willReturn('http://images.example.com/some-folder/path.jpg');
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
 
@@ -144,12 +144,12 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('if_object_exists')
             ->with('images.example.com', 'thumb/some-folder/path.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->once())
             ->method('delete_object')
             ->with('images.example.com', 'thumb/some-folder/path.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)));
+            ->willReturn($this->createCFResponseMock(true));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->remove(['some-folder/path.jpg'], ['thumb']);
@@ -162,22 +162,22 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->at(0))
             ->method('if_object_exists')
             ->with('images.example.com', 'filter/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(1))
             ->method('delete_object')
             ->with('images.example.com', 'filter/pathOne.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)));
+            ->willReturn($this->createCFResponseMock(true));
         $s3
             ->expects($this->at(2))
             ->method('if_object_exists')
             ->with('images.example.com', 'filter/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(3))
             ->method('delete_object')
             ->with('images.example.com', 'filter/pathTwo.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)));
+            ->willReturn($this->createCFResponseMock(true));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->remove(['pathOne.jpg', 'pathTwo.jpg'], ['filter']);
@@ -190,42 +190,42 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->at(0))
             ->method('if_object_exists')
             ->with('images.example.com', 'filterOne/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(1))
             ->method('delete_object')
             ->with('images.example.com', 'filterOne/pathOne.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)));
+            ->willReturn($this->createCFResponseMock(true));
         $s3
             ->expects($this->at(2))
             ->method('if_object_exists')
             ->with('images.example.com', 'filterOne/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(3))
             ->method('delete_object')
             ->with('images.example.com', 'filterOne/pathTwo.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)));
+            ->willReturn($this->createCFResponseMock(true));
         $s3
             ->expects($this->at(4))
             ->method('if_object_exists')
             ->with('images.example.com', 'filterTwo/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(5))
             ->method('delete_object')
             ->with('images.example.com', 'filterTwo/pathOne.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)));
+            ->willReturn($this->createCFResponseMock(true));
         $s3
             ->expects($this->at(6))
             ->method('if_object_exists')
             ->with('images.example.com', 'filterTwo/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(7))
             ->method('delete_object')
             ->with('images.example.com', 'filterTwo/pathTwo.jpg')
-            ->will($this->returnValue($this->createCFResponseMock(true)));
+            ->willReturn($this->createCFResponseMock(true));
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->remove(
@@ -241,7 +241,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('if_object_exists')
             ->with('images.example.com', 'filter/path.jpg')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $s3
             ->expects($this->never())
             ->method('delete_object');
@@ -257,11 +257,11 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('if_object_exists')
             ->with('images.example.com', 'filter/path.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->once())
             ->method('delete_object')
-            ->will($this->returnValue($this->createCFResponseMock(false)));
+            ->willReturn($this->createCFResponseMock(false));
 
         $logger = $this->createLoggerInterfaceMock();
         $logger
@@ -280,7 +280,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('delete_all_objects')
             ->with('images.example.com', '/filter/i')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->remove([], ['filter']);
@@ -293,7 +293,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('delete_all_objects')
             ->with('images.example.com', '/filterOne|filterTwo/i')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->remove([], ['filterOne', 'filterTwo']);
@@ -306,7 +306,7 @@ class AmazonS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('delete_all_objects')
             ->with('images.example.com', '/filter/i')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $logger = $this->createLoggerInterfaceMock();
         $logger
@@ -329,7 +329,7 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3Response
             ->expects($this->once())
             ->method('isOK')
-            ->will($this->returnValue($ok));
+            ->willReturn($ok);
 
         return $s3Response;
     }

--- a/Tests/Imagine/Cache/Resolver/AwsS3ResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/AwsS3ResolverTest.php
@@ -86,7 +86,7 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('putObject')
-            ->will($this->returnValue($this->getS3ResponseMock()));
+            ->willReturn($this->getS3ResponseMock());
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
         $resolver->store($binary, 'thumb/foobar.jpg', 'thumb');
@@ -120,7 +120,7 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('doesObjectExist')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
 
@@ -134,7 +134,7 @@ class AwsS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('getObjectUrl')
             ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, [])
-            ->will($this->returnValue('http://images.example.com/some-folder/path.jpg'));
+            ->willReturn('http://images.example.com/some-folder/path.jpg');
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
 
@@ -168,7 +168,7 @@ class AwsS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('doesObjectExist')
             ->with('images.example.com', 'thumb/some-folder/path.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->once())
             ->method('deleteObject')
@@ -176,7 +176,7 @@ class AwsS3ResolverTest extends AbstractTest
                 'Bucket' => 'images.example.com',
                 'Key' => 'thumb/some-folder/path.jpg',
             ])
-            ->will($this->returnValue($this->getS3ResponseMock()));
+            ->willReturn($this->getS3ResponseMock());
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
         $resolver->remove(['some-folder/path.jpg'], ['thumb']);
@@ -189,7 +189,7 @@ class AwsS3ResolverTest extends AbstractTest
             ->expects($this->at(0))
             ->method('doesObjectExist')
             ->with('images.example.com', 'thumb/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(1))
             ->method('deleteObject')
@@ -197,12 +197,12 @@ class AwsS3ResolverTest extends AbstractTest
                 'Bucket' => 'images.example.com',
                 'Key' => 'thumb/pathOne.jpg',
             ])
-            ->will($this->returnValue($this->getS3ResponseMock()));
+            ->willReturn($this->getS3ResponseMock());
         $s3
             ->expects($this->at(2))
             ->method('doesObjectExist')
             ->with('images.example.com', 'thumb/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(3))
             ->method('deleteObject')
@@ -210,7 +210,7 @@ class AwsS3ResolverTest extends AbstractTest
                 'Bucket' => 'images.example.com',
                 'Key' => 'thumb/pathTwo.jpg',
             ])
-            ->will($this->returnValue($this->getS3ResponseMock()));
+            ->willReturn($this->getS3ResponseMock());
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
         $resolver->remove(
@@ -226,7 +226,7 @@ class AwsS3ResolverTest extends AbstractTest
             ->expects($this->at(0))
             ->method('doesObjectExist')
             ->with('images.example.com', 'filterOne/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(1))
             ->method('deleteObject')
@@ -234,12 +234,12 @@ class AwsS3ResolverTest extends AbstractTest
                 'Bucket' => 'images.example.com',
                 'Key' => 'filterOne/pathOne.jpg',
             ])
-            ->will($this->returnValue($this->getS3ResponseMock()));
+            ->willReturn($this->getS3ResponseMock());
         $s3
             ->expects($this->at(2))
             ->method('doesObjectExist')
             ->with('images.example.com', 'filterOne/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(3))
             ->method('deleteObject')
@@ -247,12 +247,12 @@ class AwsS3ResolverTest extends AbstractTest
                 'Bucket' => 'images.example.com',
                 'Key' => 'filterOne/pathTwo.jpg',
             ])
-            ->will($this->returnValue($this->getS3ResponseMock()));
+            ->willReturn($this->getS3ResponseMock());
         $s3
             ->expects($this->at(4))
             ->method('doesObjectExist')
             ->with('images.example.com', 'filterTwo/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(5))
             ->method('deleteObject')
@@ -260,12 +260,12 @@ class AwsS3ResolverTest extends AbstractTest
                 'Bucket' => 'images.example.com',
                 'Key' => 'filterTwo/pathOne.jpg',
             ])
-            ->will($this->returnValue($this->getS3ResponseMock()));
+            ->willReturn($this->getS3ResponseMock());
         $s3
             ->expects($this->at(6))
             ->method('doesObjectExist')
             ->with('images.example.com', 'filterTwo/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->at(7))
             ->method('deleteObject')
@@ -273,7 +273,7 @@ class AwsS3ResolverTest extends AbstractTest
                 'Bucket' => 'images.example.com',
                 'Key' => 'filterTwo/pathTwo.jpg',
             ])
-            ->will($this->returnValue($this->getS3ResponseMock()));
+            ->willReturn($this->getS3ResponseMock());
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
         $resolver->remove(
@@ -289,7 +289,7 @@ class AwsS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('doesObjectExist')
             ->with('images.example.com', 'thumb/some-folder/path.jpg')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $s3
             ->expects($this->never())
             ->method('deleteObject');
@@ -305,7 +305,7 @@ class AwsS3ResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('doesObjectExist')
             ->with('images.example.com', 'thumb/some-folder/path.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $s3
             ->expects($this->once())
             ->method('deleteObject')

--- a/Tests/Imagine/Cache/Resolver/CacheResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/CacheResolverTest.php
@@ -42,7 +42,7 @@ class CacheResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('resolve')
             ->with($this->path, $this->filter)
-            ->will($this->returnValue($this->webPath));
+            ->willReturn($this->webPath);
 
         $cacheResolver = new CacheResolver(new ArrayCache(), $resolver);
 
@@ -60,7 +60,7 @@ class CacheResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('resolve')
             ->with($this->path, $this->filter)
-            ->will($this->returnValue($this->webPath));
+            ->willReturn($this->webPath);
         $resolver
             ->expects($this->never())
             ->method('isStored');
@@ -80,7 +80,7 @@ class CacheResolverTest extends AbstractTest
         $resolver
             ->expects($this->exactly(2))
             ->method('isStored')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $cacheResolver = new CacheResolver(new ArrayCache(), $resolver);
 
@@ -112,7 +112,7 @@ class CacheResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('resolve')
             ->with($this->path, $this->filter)
-            ->will($this->returnValue('/the/expected/browser'));
+            ->willReturn('/the/expected/browser');
 
         $cache = $this->getMockBuilder(Cache::class)->getMock();
         $cache
@@ -131,7 +131,7 @@ class CacheResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('resolve')
             ->with($this->path, $this->filter)
-            ->will($this->returnValue($this->webPath));
+            ->willReturn($this->webPath);
         $resolver
             ->expects($this->once())
             ->method('remove');
@@ -160,7 +160,7 @@ class CacheResolverTest extends AbstractTest
         $resolver
             ->expects($this->exactly(4))
             ->method('resolve')
-            ->will($this->returnValue('aCachePath'));
+            ->willReturn('aCachePath');
         $resolver
             ->expects($this->once())
             ->method('remove');

--- a/Tests/Imagine/Cache/Resolver/FlysystemResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/FlysystemResolverTest.php
@@ -70,7 +70,7 @@ class FlysystemResolverTest extends AbstractTest
         $fs
             ->expects($this->once())
             ->method('put')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
 
@@ -83,7 +83,7 @@ class FlysystemResolverTest extends AbstractTest
         $fs
             ->expects($this->once())
             ->method('has')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
 
@@ -109,12 +109,12 @@ class FlysystemResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('has')
             ->with('media/cache/thumb/some-folder/path.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $fs
             ->expects($this->once())
             ->method('delete')
             ->with('media/cache/thumb/some-folder/path.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
         $resolver->remove(['some-folder/path.jpg'], ['thumb']);
@@ -127,22 +127,22 @@ class FlysystemResolverTest extends AbstractTest
             ->expects($this->at(0))
             ->method('has')
             ->with('media/cache/thumb/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $fs
             ->expects($this->at(1))
             ->method('delete')
             ->with('media/cache/thumb/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $fs
             ->expects($this->at(2))
             ->method('has')
             ->with('media/cache/thumb/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $fs
             ->expects($this->at(3))
             ->method('delete')
             ->with('media/cache/thumb/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
         $resolver->remove(
@@ -158,42 +158,42 @@ class FlysystemResolverTest extends AbstractTest
             ->expects($this->at(0))
             ->method('has')
             ->with('media/cache/filterOne/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $fs
             ->expects($this->at(1))
             ->method('delete')
             ->with('media/cache/filterOne/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $fs
             ->expects($this->at(2))
             ->method('has')
             ->with('media/cache/filterTwo/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $fs
             ->expects($this->at(3))
             ->method('delete')
             ->with('media/cache/filterTwo/pathOne.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $fs
             ->expects($this->at(4))
             ->method('has')
             ->with('media/cache/filterOne/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $fs
             ->expects($this->at(5))
             ->method('delete')
             ->with('media/cache/filterOne/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $fs
             ->expects($this->at(6))
             ->method('has')
             ->with('media/cache/filterTwo/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $fs
             ->expects($this->at(7))
             ->method('delete')
             ->with('media/cache/filterTwo/pathTwo.jpg')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $resolver = new FlysystemResolver($fs, new RequestContext(), 'http://images.example.com');
         $resolver->remove(
@@ -209,7 +209,7 @@ class FlysystemResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('has')
             ->with('media/cache/thumb/some-folder/path.jpg')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $fs
             ->expects($this->never())
             ->method('delete');

--- a/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
@@ -46,7 +46,7 @@ class ProxyResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('resolve')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue('http://foo.com/thumbs/foo/bar/bazz.png'));
+            ->willReturn('http://foo.com/thumbs/foo/bar/bazz.png');
 
         $result = $this->resolver->resolve($expectedPath, $expectedFilter);
 
@@ -62,7 +62,7 @@ class ProxyResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('resolve')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue('http://foo.com/thumbs/foo/bar/bazz.png'));
+            ->willReturn('http://foo.com/thumbs/foo/bar/bazz.png');
 
         $result = $this->resolver->resolve($expectedPath, $expectedFilter);
 
@@ -78,7 +78,7 @@ class ProxyResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('resolve')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue('https://s3-eu-west-1.amazonaws.com/s3-cache.example.com/thumbs/foo/bar/bazz.png'));
+            ->willReturn('https://s3-eu-west-1.amazonaws.com/s3-cache.example.com/thumbs/foo/bar/bazz.png');
 
         $this->resolver = new ProxyResolver($this->primaryResolver, [
             'https://s3-eu-west-1.amazonaws.com/s3-cache.example.com' => 'http://images.example.com',
@@ -98,7 +98,7 @@ class ProxyResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('resolve')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue('http://foo.com/thumbs/foo/bar/bazz.png'));
+            ->willReturn('http://foo.com/thumbs/foo/bar/bazz.png');
 
         $this->resolver = new ProxyResolver($this->primaryResolver, [
             'regexp/http:\/\/.*?\//' => 'http://bar.com/',
@@ -118,7 +118,7 @@ class ProxyResolverTest extends AbstractTest
             ->expects($this->once())
             ->method('isStored')
             ->with($expectedPath, $expectedFilter)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->assertTrue($this->resolver->isStored($expectedPath, $expectedFilter));
     }

--- a/Tests/Imagine/Data/DataManagerTest.php
+++ b/Tests/Imagine/Data/DataManagerTest.php
@@ -33,17 +33,17 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => null,
-            ]));
+            ]);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
-            ->will($this->returnValue('image/png'));
+            ->willReturn('image/png');
 
         $dataManager = new DataManager($mimeTypeGuesser, $config, 'default');
         $dataManager->addLoader('default', $loader);
@@ -64,17 +64,17 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            ]));
+            ]);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
-            ->will($this->returnValue('image/png'));
+            ->willReturn('image/png');
 
         $dataManager = new DataManager($mimeTypeGuesser, $config);
         $dataManager->addLoader('the_loader', $loader);
@@ -98,17 +98,17 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            ]));
+            ]);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dataManager = new DataManager($mimeTypeGuesser, $config);
         $dataManager->addLoader('the_loader', $loader);
@@ -125,24 +125,24 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('find')
             ->with('cats.jpeg')
-            ->will($this->returnValue('content'));
+            ->willReturn('content');
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            ]));
+            ]);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
-            ->will($this->returnValue('text/plain'));
+            ->willReturn('text/plain');
 
         $dataManager = new DataManager($mimeTypeGuesser, $config);
         $dataManager->addLoader('the_loader', $loader);
@@ -159,18 +159,18 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('find')
             ->with('cats.jpeg')
-            ->will($this->returnValue(new Binary('content', null)));
+            ->willReturn(new Binary('content', null));
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            ]));
+            ]);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -194,18 +194,18 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('find')
             ->with('cats.jpeg')
-            ->will($this->returnValue($binary));
+            ->willReturn($binary);
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => 'the_loader',
-            ]));
+            ]);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -227,11 +227,11 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => null,
-            ]));
+            ]);
 
         $dataManager = new DataManager($this->createMimeTypeGuesserInterfaceMock(), $config);
         $dataManager->find('thumbnail', 'cats.jpeg');
@@ -246,25 +246,25 @@ class DataManagerTest extends AbstractTest
         $loader
             ->expects($this->once())
             ->method('find')
-            ->will($this->returnValue($expectedContent));
+            ->willReturn($expectedContent);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
             ->with($expectedContent)
-            ->will($this->returnValue($expectedMimeType));
+            ->willReturn($expectedMimeType);
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => null,
-            ]));
+            ]);
 
         $dataManager = new DataManager($mimeTypeGuesser, $config, 'default');
         $dataManager->addLoader('default', $loader);
@@ -286,32 +286,31 @@ class DataManagerTest extends AbstractTest
         $loader
             ->expects($this->once())
             ->method('find')
-            ->will($this->returnValue($content));
+            ->willReturn($content);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
             ->with($content)
-            ->will($this->returnValue($mimeType));
-
+            ->willReturn($mimeType);
 
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('getExtensions')
             ->with($mimeType)
-            ->will($this->returnValue([$expectedFormat]));
+            ->willReturn([$expectedFormat]);
 
         $config = $this->createFilterConfigurationMock();
         $config
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'size' => [180, 180],
                 'mode' => 'outbound',
                 'data_loader' => null,
-            ]));
+            ]);
 
         $dataManager = new DataManager($mimeTypeGuesser, $config, 'default');
         $dataManager->addLoader('default', $loader);
@@ -331,9 +330,9 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'default_image' => null,
-            ]));
+            ]);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -359,9 +358,9 @@ class DataManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'default_image' => $defaultFilterImage,
-            ]));
+            ]);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser

--- a/Tests/Imagine/Data/DataManagerTest.php
+++ b/Tests/Imagine/Data/DataManagerTest.php
@@ -45,7 +45,7 @@ class DataManagerTest extends AbstractTest
             ->method('guess')
             ->will($this->returnValue('image/png'));
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config, 'default');
+        $dataManager = new DataManager($mimeTypeGuesser, $config, 'default');
         $dataManager->addLoader('default', $loader);
 
         $dataManager->find('thumbnail', 'cats.jpeg');
@@ -76,7 +76,7 @@ class DataManagerTest extends AbstractTest
             ->method('guess')
             ->will($this->returnValue('image/png'));
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config);
+        $dataManager = new DataManager($mimeTypeGuesser, $config);
         $dataManager->addLoader('the_loader', $loader);
 
         $dataManager->find('thumbnail', 'cats.jpeg');
@@ -110,7 +110,7 @@ class DataManagerTest extends AbstractTest
             ->method('guess')
             ->will($this->returnValue(null));
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config);
+        $dataManager = new DataManager($mimeTypeGuesser, $config);
         $dataManager->addLoader('the_loader', $loader);
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
@@ -144,7 +144,7 @@ class DataManagerTest extends AbstractTest
             ->method('guess')
             ->will($this->returnValue('text/plain'));
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config);
+        $dataManager = new DataManager($mimeTypeGuesser, $config);
         $dataManager->addLoader('the_loader', $loader);
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
@@ -177,7 +177,7 @@ class DataManagerTest extends AbstractTest
             ->expects($this->never())
             ->method('guess');
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config);
+        $dataManager = new DataManager($mimeTypeGuesser, $config);
         $dataManager->addLoader('the_loader', $loader);
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
@@ -212,7 +212,7 @@ class DataManagerTest extends AbstractTest
             ->expects($this->never())
             ->method('guess');
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config);
+        $dataManager = new DataManager($mimeTypeGuesser, $config);
         $dataManager->addLoader('the_loader', $loader);
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
@@ -233,7 +233,7 @@ class DataManagerTest extends AbstractTest
                 'data_loader' => null,
             ]));
 
-        $dataManager = new DataManager($this->createMimeTypeGuesserInterfaceMock(), $this->createExtensionGuesserInterfaceMock(), $config);
+        $dataManager = new DataManager($this->createMimeTypeGuesserInterfaceMock(), $config);
         $dataManager->find('thumbnail', 'cats.jpeg');
     }
 
@@ -266,7 +266,7 @@ class DataManagerTest extends AbstractTest
                 'data_loader' => null,
             ]));
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config, 'default');
+        $dataManager = new DataManager($mimeTypeGuesser, $config, 'default');
         $dataManager->addLoader('default', $loader);
 
         $binary = $dataManager->find('thumbnail', 'cats.jpeg');
@@ -295,12 +295,12 @@ class DataManagerTest extends AbstractTest
             ->with($content)
             ->will($this->returnValue($mimeType));
 
-        $extensionGuesser = $this->createExtensionGuesserInterfaceMock();
-        $extensionGuesser
+
+        $mimeTypeGuesser
             ->expects($this->once())
-            ->method('guess')
+            ->method('getExtensions')
             ->with($mimeType)
-            ->will($this->returnValue($expectedFormat));
+            ->will($this->returnValue([$expectedFormat]));
 
         $config = $this->createFilterConfigurationMock();
         $config
@@ -313,7 +313,7 @@ class DataManagerTest extends AbstractTest
                 'data_loader' => null,
             ]));
 
-        $dataManager = new DataManager($mimeTypeGuesser, $extensionGuesser, $config, 'default');
+        $dataManager = new DataManager($mimeTypeGuesser, $config, 'default');
         $dataManager->addLoader('default', $loader);
 
         $binary = $dataManager->find('thumbnail', 'cats.jpeg');
@@ -341,7 +341,7 @@ class DataManagerTest extends AbstractTest
             ->method('guess');
 
         $defaultGlobalImage = 'cats.jpeg';
-        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config, 'default', 'cats.jpeg');
+        $dataManager = new DataManager($mimeTypeGuesser, $config, 'default', 'cats.jpeg');
         $dataManager->addLoader('default', $loader);
 
         $defaultImage = $dataManager->getDefaultImageUrl('thumbnail');
@@ -368,7 +368,7 @@ class DataManagerTest extends AbstractTest
             ->expects($this->never())
             ->method('guess');
 
-        $dataManager = new DataManager($mimeTypeGuesser, $this->createExtensionGuesserInterfaceMock(), $config, 'default', null);
+        $dataManager = new DataManager($mimeTypeGuesser, $config, 'default', null);
         $dataManager->addLoader('default', $loader);
 
         $defaultImage = $dataManager->getDefaultImageUrl('thumbnail');

--- a/Tests/Imagine/Filter/FilterManagerTest.php
+++ b/Tests/Imagine/Filter/FilterManagerTest.php
@@ -32,7 +32,7 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'filters' => [
                     'thumbnail' => [
                         'size' => [180, 180],
@@ -40,7 +40,7 @@ class FilterManagerTest extends AbstractTest
                     ],
                 ],
                 'post_processors' => [],
-            ]));
+            ]);
 
         $binary = new Binary('aContent', 'image/png', 'png');
 
@@ -70,32 +70,32 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'filters' => [
                     'thumbnail' => $thumbConfig,
                 ],
                 'post_processors' => [],
-            ]));
+            ]);
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($expectedFilteredContent));
+            ->willReturn($expectedFilteredContent);
 
         $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
             ->with($originalContent)
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $config,
@@ -127,31 +127,31 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'filters' => [
                     'thumbnail' => $thumbConfig,
                 ],
                 'post_processors' => [],
-            ]));
+            ]);
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'));
+            ->willReturn('aFilteredContent');
 
         $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $config,
@@ -184,32 +184,32 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'format' => $expectedFormat,
                 'filters' => [
                     'thumbnail' => $thumbConfig,
                 ],
                 'post_processors' => [],
-            ]));
+            ]);
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'));
+            ->willReturn('aFilteredContent');
 
         $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $config,
@@ -241,24 +241,24 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'filters' => [
                     'thumbnail' => $thumbConfig,
                 ],
                 'post_processors' => [],
-            ]));
+            ]);
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'));
+            ->willReturn('aFilteredContent');
 
         $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -270,7 +270,7 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $config,
@@ -304,39 +304,39 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'format' => 'jpg',
                 'filters' => [
                     'thumbnail' => $thumbConfig,
                 ],
                 'post_processors' => [],
-            ]));
+            ]);
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($expectedContent));
+            ->willReturn($expectedContent);
 
         $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
             ->with($expectedContent)
-            ->will($this->returnValue($expectedMimeType));
+            ->willReturn($expectedMimeType);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $config,
@@ -368,33 +368,33 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'quality' => $expectedQuality,
                 'filters' => [
                     'thumbnail' => $thumbConfig,
                 ],
                 'post_processors' => [],
-            ]));
+            ]);
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
             ->with('png', ['quality' => $expectedQuality])
-            ->will($this->returnValue('aFilteredContent'));
+            ->willReturn('aFilteredContent');
 
         $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $config,
@@ -423,32 +423,32 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'filters' => [
                     'thumbnail' => $thumbConfig,
                 ],
                 'post_processors' => [],
-            ]));
+            ]);
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
             ->with('png', ['quality' => $expectedQuality])
-            ->will($this->returnValue('aFilteredContent'));
+            ->willReturn('aFilteredContent');
 
         $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $config,
@@ -488,31 +488,31 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'filters' => [
                     'thumbnail' => $thumbConfig,
                 ],
                 'post_processors' => [],
-            ]));
+            ]);
 
         $image = $this->getImageInterfaceMock();
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'));
+            ->willReturn('aFilteredContent');
 
         $imagine = $this->createImagineInterfaceMock();
         $imagine
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbMergedConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $config,
@@ -566,21 +566,21 @@ class FilterManagerTest extends AbstractTest
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($expectedFilteredContent));
+            ->willReturn($expectedFilteredContent);
 
         $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
             ->with($originalContent)
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
@@ -616,20 +616,20 @@ class FilterManagerTest extends AbstractTest
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'));
+            ->willReturn('aFilteredContent');
 
         $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
@@ -666,20 +666,20 @@ class FilterManagerTest extends AbstractTest
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'));
+            ->willReturn('aFilteredContent');
 
         $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
@@ -716,13 +716,13 @@ class FilterManagerTest extends AbstractTest
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue('aFilteredContent'));
+            ->willReturn('aFilteredContent');
 
         $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
@@ -734,7 +734,7 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
@@ -772,27 +772,27 @@ class FilterManagerTest extends AbstractTest
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($expectedContent));
+            ->willReturn($expectedContent);
 
         $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
         $mimeTypeGuesser
             ->expects($this->once())
             ->method('guess')
             ->with($expectedContent)
-            ->will($this->returnValue($expectedMimeType));
+            ->willReturn($expectedMimeType);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
@@ -830,20 +830,20 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('png', ['quality' => $expectedQuality])
-            ->will($this->returnValue('aFilteredContent'));
+            ->willReturn('aFilteredContent');
 
         $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
@@ -880,20 +880,20 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('get')
             ->with('png', ['quality' => $expectedQuality])
-            ->will($this->returnValue('aFilteredContent'));
+            ->willReturn('aFilteredContent');
 
         $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $this->createFilterConfigurationMock(),
@@ -928,14 +928,14 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'filters' => [
                     'thumbnail' => $thumbConfig,
                 ],
                 'post_processors' => [
                     'foo' => [],
                 ],
-            ]));
+            ]);
 
         $thumbConfig = [
             'size' => [180, 180],
@@ -946,21 +946,21 @@ class FilterManagerTest extends AbstractTest
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($originalContent));
+            ->willReturn($originalContent);
 
         $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
             ->with($originalContent)
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $processedBinary = new Binary($expectedPostProcessedContent, 'image/png', 'png');
 
@@ -969,7 +969,7 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->once())
             ->method('process')
             ->with($binary)
-            ->will($this->returnValue($processedBinary));
+            ->willReturn($processedBinary);
 
         $filterManager = new FilterManager(
             $config,
@@ -1002,14 +1002,14 @@ class FilterManagerTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('get')
             ->with('thumbnail')
-            ->will($this->returnValue([
+            ->willReturn([
                 'filters' => [
                     'thumbnail' => $thumbConfig,
                 ],
                 'post_processors' => [
                     'foo' => [],
                 ],
-            ]));
+            ]);
 
         $thumbConfig = [
             'size' => [180, 180],
@@ -1020,21 +1020,21 @@ class FilterManagerTest extends AbstractTest
         $image
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($originalContent));
+            ->willReturn($originalContent);
 
         $imagineMock = $this->createImagineInterfaceMock();
         $imagineMock
             ->expects($this->once())
             ->method('load')
             ->with($originalContent)
-            ->will($this->returnValue($image));
+            ->willReturn($image);
 
         $loader = $this->createFilterLoaderInterfaceMock();
         $loader
             ->expects($this->once())
             ->method('load')
             ->with($this->identicalTo($image), $thumbConfig)
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $filterManager = new FilterManager(
             $config,

--- a/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/AutoRotateFilterLoaderTest.php
@@ -169,7 +169,7 @@ class AutoRotateFilterLoaderTest extends AbstractTest
                 ->expects($this->once())
                 ->method('get')
                 ->with('jpg')
-                ->will($this->returnValue($jpg));
+                ->willReturn($jpg);
         }
 
         // Checks that rotate is called with $expectCallRotateValue, or not called at all if $expectCallRotateValue is null.

--- a/Tests/LiipImagineBundleTest.php
+++ b/Tests/LiipImagineBundleTest.php
@@ -44,7 +44,7 @@ class LiipImagineBundleTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createLiipImagineExtensionMock()));
+            ->willReturn($this->createLiipImagineExtensionMock());
         $containerMock
             ->expects($this->at(1))
             ->method('addCompilerPass')
@@ -61,7 +61,7 @@ class LiipImagineBundleTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createLiipImagineExtensionMock()));
+            ->willReturn($this->createLiipImagineExtensionMock());
         $containerMock
             ->expects($this->at(2))
             ->method('addCompilerPass')
@@ -78,7 +78,7 @@ class LiipImagineBundleTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createLiipImagineExtensionMock()));
+            ->willReturn($this->createLiipImagineExtensionMock());
         $containerMock
             ->expects($this->at(3))
             ->method('addCompilerPass')
@@ -95,7 +95,7 @@ class LiipImagineBundleTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($this->createLiipImagineExtensionMock()));
+            ->willReturn($this->createLiipImagineExtensionMock());
         $containerMock
             ->expects($this->at(4))
             ->method('addCompilerPass')
@@ -118,7 +118,7 @@ class LiipImagineBundleTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock));
+            ->willReturn($extensionMock);
 
         $bundle = new LiipImagineBundle();
         $bundle->build($containerMock);
@@ -137,7 +137,7 @@ class LiipImagineBundleTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock));
+            ->willReturn($extensionMock);
 
         $bundle = new LiipImagineBundle();
         $bundle->build($containerMock);
@@ -156,7 +156,7 @@ class LiipImagineBundleTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock));
+            ->willReturn($extensionMock);
 
         $bundle = new LiipImagineBundle();
         $bundle->build($containerMock);
@@ -174,7 +174,7 @@ class LiipImagineBundleTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock));
+            ->willReturn($extensionMock);
         $bundle = new LiipImagineBundle();
         $bundle->build($containerMock);
     }
@@ -192,7 +192,7 @@ class LiipImagineBundleTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock));
+            ->willReturn($extensionMock);
 
         $bundle = new LiipImagineBundle();
         $bundle->build($containerMock);
@@ -211,7 +211,7 @@ class LiipImagineBundleTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock));
+            ->willReturn($extensionMock);
 
         $bundle = new LiipImagineBundle();
         $bundle->build($containerMock);
@@ -230,7 +230,7 @@ class LiipImagineBundleTest extends AbstractTest
             ->expects($this->atLeastOnce())
             ->method('getExtension')
             ->with('liip_imagine')
-            ->will($this->returnValue($extensionMock));
+            ->willReturn($extensionMock);
 
         $bundle = new LiipImagineBundle();
         $bundle->build($containerMock);

--- a/Tests/Templating/AbstractFilterTest.php
+++ b/Tests/Templating/AbstractFilterTest.php
@@ -39,7 +39,7 @@ abstract class AbstractFilterTest extends AbstractTest
             ->expects($this->once())
             ->method('getBrowserPath')
             ->with($expectedInputPath, $expectedFilter)
-            ->will($this->returnValue($expectedCachePath));
+            ->willReturn($expectedCachePath);
 
         $this->assertSame($expectedCachePath, $this->createTemplatingMock($manager)->filter($expectedInputPath, $expectedFilter));
     }

--- a/Tests/Templating/FilterExtensionTest.php
+++ b/Tests/Templating/FilterExtensionTest.php
@@ -27,7 +27,7 @@ class FilterExtensionTest extends AbstractFilterTest
 
     public function testInstanceOfTwigFilter()
     {
-        $this->assertInstanceOf(\Twig_Extension::class, $this->createTemplatingMock());
+        $this->assertInstanceOf(Twig\Extension\AbstractExtension::class, $this->createTemplatingMock());
     }
 
     /**
@@ -37,7 +37,7 @@ class FilterExtensionTest extends AbstractFilterTest
      */
     protected function createTemplatingMock(CacheManager $manager = null)
     {
-        if (!class_exists(\Twig_Extension::class)) {
+        if (!class_exists(Twig\Extension\AbstractExtension::class)) {
             $this->markTestSkipped('Requires the twig/twig package.');
         }
 

--- a/Tests/Templating/Helper/FilterHelperTest.php
+++ b/Tests/Templating/Helper/FilterHelperTest.php
@@ -14,7 +14,6 @@ namespace Liip\ImagineBundle\Tests\Templating\Helper;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Templating\Helper\FilterHelper;
 use Liip\ImagineBundle\Tests\Templating\AbstractFilterTest;
-use Symfony\Component\Templating\Helper\Helper;
 
 /**
  * @covers \Liip\ImagineBundle\Templating\FilterTrait
@@ -24,7 +23,7 @@ class FilterHelperTest extends AbstractFilterTest
 {
     public function testInstanceOfSymfonyHelper()
     {
-        $this->assertInstanceOf(Helper::class, $this->createTemplatingMock());
+        $this->assertInstanceOf(FilterHelper::class, $this->createTemplatingMock());
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "symfony/framework-bundle": "^3.4|^4.0",
         "symfony/options-resolver": "^3.4|^4.0",
         "symfony/process": "^3.4|^4.0",
-        "symfony/templating": "^3.4|^4.0",
         "symfony/translation": "^3.4|^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | master
| Bug fix? | no
| New feature? | no
| BC breaks? |  🤔
| Deprecations? | no
| Tests pass? | yes
| License | MIT

hey there 🤚,
we really love this project, and highly depend on it, we are in the process of upgrading all our symfony apps to `4.3` and stumbled upon some issues.


this PR - refactors the bundle and solves following things:

  - remove all deprecation notes
    - Event from Contract
    - EventDispatcher signature
    - MimeType Guesser
    - rootBuilder (i did the initial PR, but somehow missed the tests, https://github.com/liip/LiipImagineBundle/pull/1139)
    - remove `symfony/template` dependency (reference: https://symfony.com/blog/new-in-symfony-4-3-deprecated-the-templating-component-integration)


let me know what you think, and if you'd need me to change anything.
