### PR TITLE
Support custom HTTP/S port in NoCacheWebPathResolver

### DIFF
--- a/Imagine/Cache/Resolver/NoCacheWebPathResolver.php
+++ b/Imagine/Cache/Resolver/NoCacheWebPathResolver.php
@@ -43,9 +43,18 @@ class NoCacheWebPathResolver implements ResolverInterface
      */
     public function resolve($path, $filter)
     {
-        return sprintf('%s://%s/%s',
+        $port = '';
+        if ('https' === $this->requestContext->getScheme() && 443 !== $this->requestContext->getHttpsPort()) {
+            $port = ":{$this->requestContext->getHttpsPort()}";
+        }
+        if ('http' === $this->requestContext->getScheme() && 80 !== $this->requestContext->getHttpPort()) {
+            $port = ":{$this->requestContext->getHttpPort()}";
+        }
+
+        return sprintf('%s://%s%s/%s',
             $this->requestContext->getScheme(),
             $this->requestContext->getHost(),
+            $port,
             ltrim(PathHelper::filePathToUrlPath($path), '/')
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | any
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | didn't opened one, PR was quicker
| License | MIT
| Doc PR |

I tried using the `NoCacheWebPathResolver` with the local symfony server, but the port (`:8000` for HTTPS)  was missing when generating the URLs. It was already supported in `WebPathResolver`, see https://github.com/liip/LiipImagineBundle/blob/master/Imagine/Cache/Resolver/WebPathResolver.php#L144