### PR TITLE
Fix double slashes in Flysystem cache resolver when cache_prefix is empty

### DIFF
--- a/Imagine/Cache/Resolver/FlysystemResolver.php
+++ b/Imagine/Cache/Resolver/FlysystemResolver.php
@@ -105,8 +105,8 @@ class FlysystemResolver implements ResolverInterface
     {
         return sprintf(
             '%s/%s',
-            $this->webRoot,
-            $this->getFileUrl($path, $filter)
+            rtrim($this->webRoot, '/'),
+            ltrim($this->getFileUrl($path, $filter), '/')
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | any
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | https://github.com/liip/LiipImagineBundle/issues/1121
| License | MIT
| Doc PR | 