### PR TITLE
Improve travis-ci matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,8 @@ before_install:
   - if [[ "$COVERALLS_ENABLED" == "true" ]]; then
       travis_retry composer require --dev satooshi/php-coveralls:^2.0 --no-update $COMPOSER_FLAGS;
     fi
+  - pecl channel-update pecl.php.net
+  - yes | pecl install imagick
 
 install:
   - travis_retry composer update --prefer-dist --no-interaction --no-suggest --no-progress --ansi $COMPOSER_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,104 +1,91 @@
 language: php
-
 sudo: false
-
 cache:
-
   directories:
     - $HOME/.composer/cache
+    - $HOME/symfony-bridge/.phpunit
 
 env:
-
   global:
     - SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
     - PHPUNIT_FLAGS="-v"
     - PHPUNIT_ENABLED="true"
     - SYMFONY_PHPUNIT_VERSION="6.5"
-    - PHPCSFIXER_ENABLED="false"
     - COVERALLS_ENABLED="false"
+    - STABILITY=stable
 
 matrix:
-
   fast_finish: true
-
   include:
+    - php: '7.1'
+    - php: '7.2'
 
-    - php: 7.1
-    - php: 7.1
+    # Enable code coverage with the latest supported PHP version
+    - php: '7.3'
       env:
-        - PHPUNIT_ENABLED="false"
-        - PHPCSFIXER_ENABLED="true"
-    - php: 7.1
+        - COVERALLS_ENABLED="true"
+        - PHPUNIT_FLAGS="-v --coverage-text --coverage-clover var/build/clover.xml"
+
+    # Minimum supported dependencies with the latest and oldest supported PHP versions
+    - php: '7.1'
       env:
-        - SYMFONY_VERSION=4.0.*
         - COMPOSER_FLAGS="--prefer-lowest"
-    - php: 7.2
-    - php: 7.2
-      env: SYMFONY_VERSION=3.4.*
-    - php: 7.2
-      env: SYMFONY_VERSION=4.0.*
-    - php: 7.2
+    - php: '7.3'
       env:
-        - DEPENDENCIES="symfony/phpunit-bridge:^4.2"
-        - COMPOSER_UPDATE_FLAGS="--no-dev"
-    - php: 7.2
+        - COMPOSER_FLAGS="--prefer-lowest"
+
+    # Test each supported Symfony version with lowest supported PHP version
+    - php: '7.1'
       env:
-        - COVERALLS_ENABLED="true"
-        - PHPUNIT_FLAGS="-v --coverage-text --coverage-clover var/build/clover.xml"
-    - php: 7.2
+        - SYMFONY_VERSION=3.4.*
+    - php: '7.1'
       env:
-        - SYMFONY_VERSION=dev-master
+        - SYMFONY_VERSION=4.2.*
+    - php: '7.1'
+      env:
+        - SYMFONY_VERSION=4.3.*
+
+    # Test upcoming Symfony versions with lowest supported PHP version and dev dependencies
+    - php: '7.1'
+      env:
         - STABILITY=dev
-    - php: nightly
+        - SYMFONY_VERSION=4.4.*
+
+    # Test upcoming PHP versions with dev dependencies
+    - php: '7.4snapshot'
       env:
-        - SYMFONY_VERSION=4.0.*
+        - STABILITY=dev
         - COMPOSER_FLAGS="--ignore-platform-reqs"
-
   allow_failures:
-
     - env:
-        - COVERALLS_ENABLED="true"
-        - PHPUNIT_FLAGS="-v --coverage-text --coverage-clover var/build/clover.xml"
-    - env:
-        - SYMFONY_VERSION=dev-master
         - STABILITY=dev
-    - php: nightly
-
+        - COMPOSER_FLAGS="--ignore-platform-reqs"
+    - env:
+        - STABILITY=dev
+        - SYMFONY_VERSION=4.4.*
 
 before_install:
-
   - if [[ "$SYMFONY_VERSION" != "" ]]; then
-      travis_retry composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update $COMPOSER_FLAGS;
+      travis_retry composer global require "symfony/flex:^1.4";
+      composer config extra.symfony.require $SYMFONY_VERSION;
     fi
-  - if [[ "$DEPENDENCIES" != "" ]]; then
-      travis_retry composer require $DEPENDENCIES --no-update $COMPOSER_FLAGS;
-    fi
-  - if [[ "$STABILITY" != "" ]]; then
+  - if [[ "$STABILITY" != "stable" ]]; then
       travis_retry composer config minimum-stability $STABILITY;
     fi
   - if [[ "$COVERALLS_ENABLED" != "true" ]]; then
       phpenv config-rm xdebug.ini || true;
     fi
   - if [[ "$COVERALLS_ENABLED" == "true" ]]; then
-      travis_retry composer require --dev satooshi/php-coveralls:^2.0@dev --no-update $COMPOSER_FLAGS;
+      travis_retry composer require --dev satooshi/php-coveralls:^2.0 --no-update $COMPOSER_FLAGS;
     fi
 
 install:
-
-  - travis_retry composer update --prefer-dist --no-interaction --no-suggest --no-progress --ansi $COMPOSER_FLAGS $COMPOSER_UPDATE_FLAGS
+  - travis_retry composer update --prefer-dist --no-interaction --no-suggest --no-progress --ansi $COMPOSER_FLAGS
   - ./vendor/bin/simple-phpunit install
 
-script:
-
-  - if [[ "$PHPUNIT_ENABLED" == "true" ]]; then
-      ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS;
-    fi
-  - if [[ "$PHPCSFIXER_ENABLED" == "true" ]]; then
-      vendor/bin/php-cs-fixer --dry-run --diff -vvv fix;
-    fi
+script: ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS
 
 after_success:
-
   - if [[ "$PHPUNIT_ENABLED" == "true" && "$COVERALLS_ENABLED" == "true" ]]; then
       ./vendor/bin/php-coveralls -vvv --config .coveralls.yml;
     fi;

--- a/Tests/Config/FilterSetTest.php
+++ b/Tests/Config/FilterSetTest.php
@@ -31,14 +31,20 @@ class FilterSetTest extends TestCase
     public function testSetFiltersWithValidFilterSuccess()
     {
         $filterMock = $this->createMock(FilterInterface::class);
-        $this->buildFilterSet([$filterMock]);
+        $stack = $this->buildFilterSet([$filterMock]);
+
+        $this->assertInstanceOf(Stack::class, $stack);
+        $this->assertSame('filter_name', $stack->getName());
+        $this->assertSame('data_loader', $stack->getDataLoader());
+        $this->assertSame(42, $stack->getQuality());
+        $this->assertSame([$filterMock], $stack->getFilters());
     }
 
     /**
      * @param array $filters
      */
-    private function buildFilterSet(array $filters)
+    private function buildFilterSet(array $filters): Stack
     {
-        new Stack('filter_name', 'data_loader', 42, $filters);
+        return new Stack('filter_name', 'data_loader', 42, $filters);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     "require": {
         "php": "^7.1",
         "imagine/imagine": "^0.7.1|^1.1",
-        "symfony/asset": "^3.4|^4.0",
-        "symfony/filesystem": "^3.4|^4.0",
-        "symfony/finder": "^3.4|^4.0",
-        "symfony/framework-bundle": "^3.4|^4.0",
-        "symfony/options-resolver": "^3.4|^4.0",
-        "symfony/process": "^3.4|^4.0",
-        "symfony/templating": "^3.4|^4.0",
-        "symfony/translation": "^3.4|^4.0"
+        "symfony/asset": "^3.4|^4.2",
+        "symfony/filesystem": "^3.4|^4.2",
+        "symfony/finder": "^3.4|^4.2",
+        "symfony/framework-bundle": "^3.4|^4.2",
+        "symfony/options-resolver": "^3.4|^4.2",
+        "symfony/process": "^3.4|^4.2",
+        "symfony/templating": "^3.4|^4.2",
+        "symfony/translation": "^3.4|^4.2"
     },
     "require-dev": {
         "ext-gd": "*",
@@ -39,13 +39,13 @@
         "friendsofphp/php-cs-fixer": "^2.10",
         "league/flysystem": "^1.0",
         "psr/log": "^1.0",
-        "symfony/browser-kit": "^3.4|^4.0",
-        "symfony/console": "^3.4|^4.0",
-        "symfony/dependency-injection": "^3.4|^4.0",
-        "symfony/form": "^3.4|^4.0",
+        "symfony/browser-kit": "^3.4|^4.2",
+        "symfony/console": "^3.4|^4.2",
+        "symfony/dependency-injection": "^3.4|^4.2",
+        "symfony/form": "^3.4|^4.2",
         "symfony/phpunit-bridge": "^4.2",
-        "symfony/validator": "^3.4|^4.0",
-        "symfony/yaml": "^3.4|^4.0",
+        "symfony/validator": "^3.4|^4.2",
+        "symfony/yaml": "^3.4|^4.2",
         "twig/twig": "^1.12|^2.0"
     },
     "suggest": {


### PR DESCRIPTION
- Drop support for Symfony 4.0 and 4.1 wich are no longer supported.
- Remove php-cs-fixer travis job as the project use styleci.
- Add PHP 7.4 in the matrix as allowed failure.
- Test against each supported Symfony versions.
- Test against upcoming Symfony 4.4 with allowed failure.
- Run code coverage with highest supported PHP version (7.3).
- Install `imagick` extension to avoid skipped tests.
- Fix risky `FilterSetTest::testSetFiltersWithValidFilterSuccess` test.