### PR TITLE
Fix TreeBuilder depecations notices

### DIFF
--- a/Tests/DependencyInjection/Factory/Loader/ChainLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/ChainLoaderFactoryTest.php
@@ -62,8 +62,10 @@ class ChainLoaderFactoryTest extends FactoryTestCase
 
     public function testProcessOptionsOnAddConfiguration(): void
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('chain', 'array');
+        $treeBuilder = new TreeBuilder('chain');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('chain');
 
         $loader = new ChainLoaderFactory();
         $loader->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FileSystemLoaderFactoryTest.php
@@ -262,8 +262,10 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
     {
         $expectedDataRoot = ['theDataRoot'];
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('filesystem', 'array');
+        $treeBuilder = new TreeBuilder('filesystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('filesystem');
 
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);
@@ -282,8 +284,10 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
     {
         $expectedDataRoot = [SymfonyFramework::getContainerResolvableRootWebPath()];
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('filesystem', 'array');
+        $treeBuilder = new TreeBuilder('filesystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('filesystem');
 
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);
@@ -300,8 +304,10 @@ class FileSystemLoaderFactoryTest extends FactoryTestCase
     {
         $expectedDataRoot = [SymfonyFramework::getContainerResolvableRootWebPath()];
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('filesystem', 'array');
+        $treeBuilder = new TreeBuilder('filesystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('filesystem');
 
         $loader = new FileSystemLoaderFactory();
         $loader->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
@@ -80,8 +80,10 @@ class FlysystemLoaderFactoryTest extends TestCase
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $this->expectExceptionMessage('The child node "filesystem_service" at path "flysystem" must be configured.');
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('flysystem', 'array');
+        $treeBuilder = new TreeBuilder('flysystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('flysystem');
 
         $resolver = new FlysystemLoaderFactory();
         $resolver->addConfiguration($rootNode);
@@ -93,8 +95,10 @@ class FlysystemLoaderFactoryTest extends TestCase
     {
         $expectedService = 'theService';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('flysystem', 'array');
+        $treeBuilder = new TreeBuilder('flysystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('flysystem');
 
         $loader = new FlysystemLoaderFactory();
         $loader->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
@@ -71,8 +71,10 @@ class StreamLoaderFactoryTest extends TestCase
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $this->expectExceptionMessage('The child node "wrapper" at path "stream" must be configured.');
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('stream', 'array');
+        $treeBuilder = new TreeBuilder('stream');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('stream');
 
         $resolver = new StreamLoaderFactory();
         $resolver->addConfiguration($rootNode);
@@ -85,8 +87,10 @@ class StreamLoaderFactoryTest extends TestCase
         $expectedWrapper = 'theWrapper';
         $expectedContext = 'theContext';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('stream', 'array');
+        $treeBuilder = new TreeBuilder('stream');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('stream');
 
         $loader = new StreamLoaderFactory();
         $loader->addConfiguration($rootNode);
@@ -107,8 +111,10 @@ class StreamLoaderFactoryTest extends TestCase
 
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('stream', 'array');
+        $treeBuilder = new TreeBuilder('stream');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('stream');
 
         $loader = new StreamLoaderFactory();
         $loader->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -296,8 +296,10 @@ class AwsS3ResolverFactoryTest extends TestCase
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $this->expectExceptionMessage('The child node "bucket" at path "aws_s3" must be configured.');
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -310,8 +312,10 @@ class AwsS3ResolverFactoryTest extends TestCase
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $this->expectExceptionMessage('The child node "client_config" at path "aws_s3" must be configured.');
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -328,8 +332,10 @@ class AwsS3ResolverFactoryTest extends TestCase
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
         $this->expectExceptionMessage('Invalid type for path "aws_s3.client_config". Expected array, but got string');
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -360,8 +366,10 @@ class AwsS3ResolverFactoryTest extends TestCase
         $expectedAcl = 'theAcl';
         $expectedCachePrefix = 'theCachePrefix';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -400,8 +408,10 @@ class AwsS3ResolverFactoryTest extends TestCase
     {
         $expectedAcl = 'public-read';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -446,8 +456,10 @@ class AwsS3ResolverFactoryTest extends TestCase
         $expectedAcl = 'theAcl';
         $expectedCachePrefix = 'theCachePrefix';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('aws_s3', 'array');
+        $treeBuilder = new TreeBuilder('aws_s3');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('aws_s3');
 
         $resolver = new AwsS3ResolverFactory();
         $resolver->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/FlysystemResolverFactoryTest.php
@@ -86,8 +86,10 @@ class FlysystemResolverFactoryTest extends TestCase
         $expectedFlysystemService = 'flyfilesystemservice';
         $expectedVisibility = 'public';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('flysystem', 'array');
+        $treeBuilder = new TreeBuilder('flysystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('flysystem');
 
         $resolver = new FlysystemResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -118,8 +120,10 @@ class FlysystemResolverFactoryTest extends TestCase
     {
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('flysystem', 'array');
+        $treeBuilder = new TreeBuilder('flysystem');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('flysystem');
 
         $resolver = new FlysystemResolverFactory();
         $resolver->addConfiguration($rootNode);

--- a/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/WebPathResolverFactoryTest.php
@@ -72,8 +72,10 @@ class WebPathResolverFactoryTest extends TestCase
         $expectedWebPath = 'theWebPath';
         $expectedCachePrefix = 'theCachePrefix';
 
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('web_path', 'array');
+        $treeBuilder = new TreeBuilder('web_path');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('web_path');
 
         $resolver = new WebPathResolverFactory();
         $resolver->addConfiguration($rootNode);
@@ -94,8 +96,10 @@ class WebPathResolverFactoryTest extends TestCase
 
     public function testAddDefaultOptionsIfNotSetOnAddConfiguration()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('web_path', 'array');
+        $treeBuilder = new TreeBuilder('web_path');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('web_path');
 
         $resolver = new WebPathResolverFactory();
         $resolver->addConfiguration($rootNode);


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | partially #1200
| License | MIT
| Doc PR | N/A

This remove deprecated calls to `TreeBuilder::root()`.