### PR TITLE
Fix deprecated use of SYMFONY_DEPRECATIONS_HELPER

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 
 env:
   global:
-    - SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
+    - SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
     - PHPUNIT_FLAGS="-v"
     - PHPUNIT_ENABLED="true"
     - SYMFONY_PHPUNIT_VERSION="6.5"

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "symfony/console": "^3.4|^4.2",
         "symfony/dependency-injection": "^3.4|^4.2",
         "symfony/form": "^3.4|^4.2",
-        "symfony/phpunit-bridge": "^4.2",
+        "symfony/phpunit-bridge": "^4.3",
         "symfony/validator": "^3.4|^4.2",
         "symfony/yaml": "^3.4|^4.2",
         "twig/twig": "^1.12|^2.0"


### PR DESCRIPTION
This remove deprecated use of `weak_vendors` as `SYMFONY_DEPRECATIONS_HELPER` value. We are now using `max[self]=0` and using `symfony/phpunit-bridge` `^4.3`.