### PR TITLE
Use Twig namespaces

### DIFF
--- a/Templating/FilterExtension.php
+++ b/Templating/FilterExtension.php
@@ -11,7 +11,10 @@
 
 namespace Liip\ImagineBundle\Templating;
 
-class FilterExtension extends \Twig_Extension
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class FilterExtension extends AbstractExtension
 {
     use FilterTrait;
 
@@ -21,7 +24,7 @@ class FilterExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('imagine_filter', [$this, 'filter']),
+            new TwigFilter('imagine_filter', [$this, 'filter']),
         ];
     }
 }

--- a/Tests/Templating/FilterExtensionTest.php
+++ b/Tests/Templating/FilterExtensionTest.php
@@ -13,6 +13,7 @@ namespace Liip\ImagineBundle\Tests\Templating;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Templating\FilterExtension;
+use Twig\Extension\AbstractExtension;
 
 /**
  * @covers \Liip\ImagineBundle\Templating\FilterTrait
@@ -27,7 +28,7 @@ class FilterExtensionTest extends AbstractFilterTest
 
     public function testInstanceOfTwigFilter()
     {
-        $this->assertInstanceOf(\Twig_Extension::class, $this->createTemplatingMock());
+        $this->assertInstanceOf(AbstractExtension::class, $this->createTemplatingMock());
     }
 
     /**
@@ -37,7 +38,7 @@ class FilterExtensionTest extends AbstractFilterTest
      */
     protected function createTemplatingMock(CacheManager $manager = null)
     {
-        if (!class_exists(\Twig_Extension::class)) {
+        if (!class_exists(AbstractExtension::class)) {
             $this->markTestSkipped('Requires the twig/twig package.');
         }
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "symfony/phpunit-bridge": "^4.2",
         "symfony/validator": "^3.4|^4.2",
         "symfony/yaml": "^3.4|^4.2",
-        "twig/twig": "^1.12|^2.0"
+        "twig/twig": "^1.34|^2.4"
     },
     "suggest": {
         "ext-exif": "required to read EXIF metadata from images",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

This is just using namespaces for Twig that were added in 1.34 and 2.4. 

I've increased the twig version because when you update the vendors with `composer update --prefer-lowest` it installs 1.34 because is the version required in the `v3.4.0` of `symfony/framework-bundle`.