### PR TITLE
Handle Symfony templating deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -202,6 +202,14 @@ class Configuration implements ConfigurationInterface
             ->booleanNode('templating')
                 ->defaultTrue()
                 ->info('Enables integration with symfony/templating component')
+                ->validate()
+                    ->ifTrue()
+                    ->then(function ($v) {
+                        @trigger_error('Symfony templating integration has been deprecated since LiipImagineBundle 2.2 and will be removed in 3.0. Use Twig and use "false" as "liip_imagine.templating" value instead.', E_USER_DEPRECATED);
+
+                        return $v;
+                    })
+                ->end()
             ->end()
         ->end();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -199,6 +199,10 @@ class Configuration implements ConfigurationInterface
                 ->defaultFalse()
                 ->info('Enables integration with enqueue if set true. Allows resolve image caches in background by sending messages to MQ.')
             ->end()
+            ->booleanNode('templating')
+                ->defaultTrue()
+                ->info('Enables integration with symfony/templating component')
+            ->end()
         ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -95,6 +95,10 @@ class LiipImagineExtension extends Extension
             $loader->load('enqueue.xml');
         }
 
+        if ($config['templating']) {
+            $loader->load('templating.xml');
+        }
+
         $container->setParameter('liip_imagine.driver_service', 'liip_imagine.'.$config['driver']);
 
         $container

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -190,6 +190,7 @@
         <service id="liip_imagine.templating.filter_helper" class="Liip\ImagineBundle\Templating\Helper\FilterHelper">
             <tag name="templating.helper" alias="imagine" />
             <argument type="service" id="liip_imagine.cache.manager" />
+            <deprecated>The "%service_id%" service is deprecated since LiipImagineBundle 2.2 and will be removed in 3.0.</deprecated>
         </service>
 
         <!-- Filter loaders -->

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -187,12 +187,6 @@
             <argument type="service" id="liip_imagine.cache.manager" />
         </service>
 
-        <service id="liip_imagine.templating.filter_helper" class="Liip\ImagineBundle\Templating\Helper\FilterHelper">
-            <tag name="templating.helper" alias="imagine" />
-            <argument type="service" id="liip_imagine.cache.manager" />
-            <deprecated>The "%service_id%" service is deprecated since LiipImagineBundle 2.2 and will be removed in 3.0.</deprecated>
-        </service>
-
         <!-- Filter loaders -->
 
         <service id="liip_imagine.filter.loader.relative_resize" class="Liip\ImagineBundle\Imagine\Filter\Loader\RelativeResizeFilterLoader">

--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="liip_imagine.templating.filter_helper" class="Liip\ImagineBundle\Templating\Helper\FilterHelper">
+            <tag name="templating.helper" alias="imagine" />
+            <argument type="service" id="liip_imagine.cache.manager" />
+            <deprecated>The "%service_id%" service is deprecated since LiipImagineBundle 2.2 and will be removed in 3.0.</deprecated>
+        </service>
+    </services>
+</container>

--- a/Templating/Helper/FilterHelper.php
+++ b/Templating/Helper/FilterHelper.php
@@ -11,6 +11,8 @@
 
 namespace Liip\ImagineBundle\Templating\Helper;
 
+@trigger_error('The '.FilterHelper::class.' class is deprecated since version 2.2 and will be removed in 3.0; use Twig instead.', E_USER_DEPRECATED);
+
 use Liip\ImagineBundle\Templating\FilterTrait;
 use Symfony\Component\Templating\Helper\Helper;
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -34,6 +34,13 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($rc->implementsInterface(ConfigurationInterface::class));
     }
 
+    public function testTemplatingSupportIsEnabledByDefault()
+    {
+        $config = $this->processConfiguration(new Configuration([], []), []);
+
+        $this->assertTrue($config['templating']);
+    }
+
     public function testCouldBeConstructedWithResolversAndLoadersFactoriesAsArguments()
     {
         $config = new Configuration([], []);

--- a/Tests/DependencyInjection/LiipImagineExtensionTest.php
+++ b/Tests/DependencyInjection/LiipImagineExtensionTest.php
@@ -186,6 +186,14 @@ EOF;
         );
     }
 
+    public function testTemplatingFilterExtensionIsDeprecated()
+    {
+        $this->createEmptyConfiguration();
+
+        $this->assertHasDefinition('liip_imagine.templating.filter_helper');
+        $this->assertDefinitionIsDeprecated('liip_imagine.templating.filter_helper', 'The "liip_imagine.templating.filter_helper" service is deprecated since LiipImagineBundle 2.2 and will be removed in 3.0.');
+    }
+
     public static function provideFactoryData()
     {
         return [
@@ -324,5 +332,13 @@ EOF;
             $implodeArrayElements($providedArguments),
             $implodeArrayElements($expectedArguments),
         ]));
+    }
+
+    private function assertDefinitionIsDeprecated(string $id, string $message)
+    {
+        $definition = $this->containerBuilder->getDefinition($id);
+
+        $this->assertTrue($definition->isDeprecated());
+        $this->assertSame($message, $definition->getDeprecationMessage($id));
     }
 }

--- a/Tests/DependencyInjection/LiipImagineExtensionTest.php
+++ b/Tests/DependencyInjection/LiipImagineExtensionTest.php
@@ -222,6 +222,10 @@ EOF;
         $this->assertSame($factory, $definition->getFactory());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Symfony templating integration has been deprecated since LiipImagineBundle 2.2 and will be removed in 3.0. Use Twig and use "false" as "liip_imagine.templating" value instead.
+     */
     public function testHelperIsRegisteredWhenTemplatingIsEnabled()
     {
         $this->createConfiguration([

--- a/Tests/DependencyInjection/LiipImagineExtensionTest.php
+++ b/Tests/DependencyInjection/LiipImagineExtensionTest.php
@@ -222,6 +222,22 @@ EOF;
         $this->assertSame($factory, $definition->getFactory());
     }
 
+    public function testHelperIsRegisteredWhenTemplatingIsEnabled()
+    {
+        $this->createConfiguration([
+            'templating' => true,
+        ]);
+        $this->assertHasDefinition('liip_imagine.templating.filter_helper');
+    }
+
+    public function testHelperIsNotRegisteredWhenTemplatingIsDisabled()
+    {
+        $this->createConfiguration([
+            'templating' => false,
+        ]);
+        $this->assertHasNotDefinition('liip_imagine.templating.filter_helper');
+    }
+
     protected function createEmptyConfiguration(): void
     {
         $this->createConfiguration([]);
@@ -229,10 +245,6 @@ EOF;
 
     protected function createFullConfiguration(): void
     {
-        if (!class_exists(Parser::class)) {
-            $this->markTestSkipped('Requires the symfony/yaml package.');
-        }
-
         $this->createConfiguration($this->getFullConfig());
     }
 
@@ -309,6 +321,14 @@ EOF;
     private function assertHasDefinition($id)
     {
         $this->assertTrue(($this->containerBuilder->hasDefinition($id) ?: $this->containerBuilder->hasAlias($id)));
+    }
+
+    /**
+     * @param string $id
+     */
+    private function assertHasNotDefinition($id)
+    {
+        $this->assertFalse(($this->containerBuilder->hasDefinition($id) || $this->containerBuilder->hasAlias($id)));
     }
 
     /**

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -14,9 +14,6 @@ framework:
     translator:     ~
     test:           ~
 
-    templating:
-        engines: [ 'php' ]
-
     session:
         storage_id: session.storage.mock_file
 

--- a/Tests/Templating/Helper/FilterHelperTest.php
+++ b/Tests/Templating/Helper/FilterHelperTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Templating\Helper\Helper;
 /**
  * @covers \Liip\ImagineBundle\Templating\FilterTrait
  * @covers \Liip\ImagineBundle\Templating\Helper\FilterHelper
+ *
+ * @group legacy
  */
 class FilterHelperTest extends AbstractFilterTest
 {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,4 +38,8 @@
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
Since 4.3, symfony/templating component is deprecated.

This is a work in progress to handle it gracefully in LiipImagineBundle.

- [x] Deprecate the `Liip\ImagineBundle\Templating\Helper\FilterHelper` class.
- [x] Add an option to disable templating support at LiipImagineBundle level.
- [x] Deprecate using true value for the templating option.
- [x] Deprecate and conditionally load `liip_imagine.templating.filter_helper` service.