### PR TITLE
Fix double slash in WebPathResolver when cache_prefix is empty

### DIFF
--- a/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/Imagine/Cache/Resolver/WebPathResolver.php
@@ -69,8 +69,8 @@ class WebPathResolver implements ResolverInterface
     public function resolve($path, $filter)
     {
         return sprintf('%s/%s',
-            $this->getBaseUrl(),
-            $this->getFileUrl($path, $filter)
+            rtrim($this->getBaseUrl(), '/'),
+            ltrim($this->getFileUrl($path, $filter), '/')
         );
     }
 

--- a/Tests/Imagine/Cache/Resolver/FlysystemResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/FlysystemResolverTest.php
@@ -102,6 +102,16 @@ class FlysystemResolverTest extends AbstractTest
         );
     }
 
+    public function testResolveWithPrefixCacheEmpty()
+    {
+        $resolver = new FlysystemResolver($this->createFlySystemMock(), new RequestContext(), 'http://images.example.com', '');
+
+        $this->assertSame(
+            'http://images.example.com/thumb/some-folder/path.jpg',
+            $resolver->resolve('/some-folder/path.jpg', 'thumb')
+        );
+    }
+
     public function testRemoveCacheForPathAndFilterOnRemove()
     {
         $fs = $this->createFlySystemMock();

--- a/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/WebPathResolverTest.php
@@ -207,6 +207,26 @@ class WebPathResolverTest extends TestCase
         );
     }
 
+    public function testResolveWithPrefixCacheEmpty()
+    {
+        $requestContext = new RequestContext();
+        $requestContext->setScheme('theSchema');
+        $requestContext->setHost('thehost');
+        $requestContext->setBaseUrl('/theBasePath/app.php');
+
+        $resolver = new WebPathResolver(
+            $this->createFilesystemMock(),
+            $requestContext,
+            '/aWebRoot',
+            ''
+        );
+
+        $this->assertSame(
+            'theschema://thehost/theBasePath/aFilter/aPath',
+            $resolver->resolve('aPath', 'aFilter')
+        );
+    }
+
     public function testComposeSchemaHostAndBasePathWithDirsOnlyAndFileUrlOnResolve()
     {
         $requestContext = new RequestContext();


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Same logic as https://github.com/liip/LiipImagineBundle/pull/1195, the `WebPathResolver` resolves it wrong if the `cache_prefix` is empty. I added also a test for `FlysystemResolver`.

https://github.com/liip/LiipImagineBundle/issues/1121 can be closed.