### PR TITLE
Remove minimum-stability and prefer-stable configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,11 +55,11 @@ matrix:
     - php: '7.4snapshot'
       env:
         - STABILITY=dev
-        - COMPOSER_FLAGS="--ignore-platform-reqs"
+        - COMPOSER_FLAGS="--ignore-platform-reqs --prefer-stable"
   allow_failures:
     - env:
         - STABILITY=dev
-        - COMPOSER_FLAGS="--ignore-platform-reqs"
+        - COMPOSER_FLAGS="--ignore-platform-reqs --prefer-stable"
     - env:
         - STABILITY=dev
         - SYMFONY_VERSION=4.4.*

--- a/composer.json
+++ b/composer.json
@@ -64,8 +64,6 @@
         "monolog/monolog": "A psr/log compatible logger is required to enable logging",
         "twig/twig": "required to use the provided Twig extension. Version 1.12 or greater needed"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
#1202 expected to remove `minimum-stability` and `prefer-stable` from composer.json.

Those where initially removed but came back while handling a rebase conflict.