### PR TITLE
[RFC] removed webpath set to null on unset resolver

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -95,10 +95,6 @@ class Configuration implements ConfigurationInterface
                         throw new \LogicException('Resolvers has to be array');
                     }
 
-                    if (false === \array_key_exists('default', $v['resolvers'])) {
-                        $v['resolvers']['default'] = ['web_path' => null];
-                    }
-
                     return $v;
                 })
             ->end();


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 would maybe also make sense to backport it
| Bug fix? | yes (for me yes)
| New feature? | no
| BC breaks? | yes (kind of, if someone buld upon this fallback)
| Deprecations? | no
| Tests pass? | ?
| Fixed tickets | #1132
| License | MIT
| Doc PR | <!--highly recommended for new features-->

alredy commented in https://github.com/liip/LiipImagineBundle/issues/1132#issuecomment-524867253 but i thought a PR is more visible to get comments.

haven't tried to run or fix tests because first it makes sense to know if you would merge this.