### PR TITLE
Fix Mime deprecations for Symfony 4.3

### DIFF
--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -12,6 +12,7 @@
 namespace Liip\ImagineBundle\Binary\Loader;
 
 use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
+use Liip\ImagineBundle\Exception\InvalidArgumentException;
 use Liip\ImagineBundle\Model\FileBinary;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface as DeprecatedExtensionGuesserInterface;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface as DeprecatedMimeTypeGuesserInterface;
@@ -45,6 +46,14 @@ class FileSystemLoader implements LoaderInterface
         $extensionGuesser,
         LocatorInterface $locator
     ) {
+        if (!$mimeGuesser instanceof MimeTypeGuesserInterface && !$mimeGuesser instanceof DeprecatedMimeTypeGuesserInterface) {
+            throw new InvalidArgumentException('$mimeGuesser must be an instance of Symfony\Component\Mime\MimeTypeGuesserInterface or Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface');
+        }
+
+        if (!$extensionGuesser instanceof MimeTypesInterface && !$extensionGuesser instanceof DeprecatedExtensionGuesserInterface) {
+            throw new InvalidArgumentException('$extensionGuesser must be an instance of Symfony\Component\Mime\MimeTypesInterface or Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface');
+        }
+
         if (interface_exists(MimeTypeGuesserInterface::class) && $mimeGuesser instanceof DeprecatedMimeTypeGuesserInterface) {
             @trigger_error(sprintf('Passing a %s to "%s()" is deprecated since Symfony 4.3, pass a "%s" instead.', DeprecatedMimeTypeGuesserInterface::class, __METHOD__, MimeTypeGuesserInterface::class), E_USER_DEPRECATED);
         }

--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -13,18 +13,20 @@ namespace Liip\ImagineBundle\Binary\Loader;
 
 use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
 use Liip\ImagineBundle\Model\FileBinary;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface as DeprecatedExtensionGuesserInterface;
+use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface as DeprecatedMimeTypeGuesserInterface;
+use Symfony\Component\Mime\MimeTypeGuesserInterface;
+use Symfony\Component\Mime\MimeTypesInterface;
 
 class FileSystemLoader implements LoaderInterface
 {
     /**
-     * @var MimeTypeGuesserInterface
+     * @var MimeTypeGuesserInterface|DeprecatedMimeTypeGuesserInterface
      */
     protected $mimeTypeGuesser;
 
     /**
-     * @var ExtensionGuesserInterface
+     * @var MimeTypesInterface|DeprecatedExtensionGuesserInterface
      */
     protected $extensionGuesser;
 
@@ -34,15 +36,23 @@ class FileSystemLoader implements LoaderInterface
     protected $locator;
 
     /**
-     * @param MimeTypeGuesserInterface  $mimeGuesser
-     * @param ExtensionGuesserInterface $extensionGuesser
-     * @param LocatorInterface          $locator
+     * @param MimeTypeGuesserInterface|DeprecatedMimeTypeGuesserInterface $mimeGuesser
+     * @param MimeTypesInterface|DeprecatedExtensionGuesserInterface      $extensionGuesser
+     * @param LocatorInterface                                            $locator
      */
     public function __construct(
-        MimeTypeGuesserInterface $mimeGuesser,
-        ExtensionGuesserInterface $extensionGuesser,
+        $mimeGuesser,
+        $extensionGuesser,
         LocatorInterface $locator
     ) {
+        if (interface_exists(MimeTypeGuesserInterface::class) && $mimeGuesser instanceof DeprecatedMimeTypeGuesserInterface) {
+            @trigger_error(sprintf('Passing a %s to "%s()" is deprecated since Symfony 4.3, pass a "%s" instead.', DeprecatedMimeTypeGuesserInterface::class, __METHOD__, MimeTypeGuesserInterface::class), E_USER_DEPRECATED);
+        }
+
+        if (interface_exists(MimeTypesInterface::class) && $extensionGuesser instanceof DeprecatedExtensionGuesserInterface) {
+            @trigger_error(sprintf('Passing a %s to "%s()" is deprecated since Symfony 4.3, pass a "%s" instead.', DeprecatedExtensionGuesserInterface::class, __METHOD__, MimeTypesInterface::class), E_USER_DEPRECATED);
+        }
+
         $this->mimeTypeGuesser = $mimeGuesser;
         $this->extensionGuesser = $extensionGuesser;
         $this->locator = $locator;
@@ -54,8 +64,22 @@ class FileSystemLoader implements LoaderInterface
     public function find($path)
     {
         $path = $this->locator->locate($path);
-        $mime = $this->mimeTypeGuesser->guess($path);
+        $mimeType = $this->mimeTypeGuesser instanceof DeprecatedMimeTypeGuesserInterface ? $this->mimeTypeGuesser->guess($path) : $this->mimeTypeGuesser->guessMimeType($path);
+        $extension = $this->getExtension($mimeType);
 
-        return new FileBinary($path, $mime, $this->extensionGuesser->guess($mime));
+        return new FileBinary($path, $mimeType, $extension);
+    }
+
+    private function getExtension(?string $mimeType): ?string
+    {
+        if ($this->extensionGuesser instanceof DeprecatedExtensionGuesserInterface) {
+            return $this->extensionGuesser->guess($mimeType);
+        }
+
+        if (null === $mimeType) {
+            return null;
+        }
+
+        return $this->extensionGuesser->getExtensions($mimeType)[0] ?? null;
     }
 }

--- a/Binary/Loader/FlysystemLoader.php
+++ b/Binary/Loader/FlysystemLoader.php
@@ -13,6 +13,7 @@ namespace Liip\ImagineBundle\Binary\Loader;
 
 use League\Flysystem\FilesystemInterface;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
+use Liip\ImagineBundle\Exception\InvalidArgumentException;
 use Liip\ImagineBundle\Model\Binary;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface as DeprecatedExtensionGuesserInterface;
 use Symfony\Component\Mime\MimeTypesInterface;
@@ -33,6 +34,10 @@ class FlysystemLoader implements LoaderInterface
         $extensionGuesser,
         FilesystemInterface $filesystem)
     {
+        if (!$extensionGuesser instanceof MimeTypesInterface && !$extensionGuesser instanceof DeprecatedExtensionGuesserInterface) {
+            throw new InvalidArgumentException('$extensionGuesser must be an instance of Symfony\Component\Mime\MimeTypesInterface or Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface');
+        }
+
         if (interface_exists(MimeTypesInterface::class) && $extensionGuesser instanceof DeprecatedExtensionGuesserInterface) {
             @trigger_error(sprintf('Passing a %s to "%s()" is deprecated since Symfony 4.3, pass a "%s" instead.', DeprecatedExtensionGuesserInterface::class, __METHOD__, MimeTypesInterface::class), E_USER_DEPRECATED);
         }

--- a/Binary/SimpleMimeTypeGuesser.php
+++ b/Binary/SimpleMimeTypeGuesser.php
@@ -11,6 +11,7 @@
 
 namespace Liip\ImagineBundle\Binary;
 
+use Liip\ImagineBundle\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface as DeprecatedSymfonyMimeTypeGuesserInterface;
 use Symfony\Component\Mime\MimeTypesInterface as SymfonyMimeTypeGuesserInterface;
 
@@ -26,6 +27,10 @@ class SimpleMimeTypeGuesser implements MimeTypeGuesserInterface
      */
     public function __construct($mimeTypeGuesser)
     {
+        if (!$mimeTypeGuesser instanceof SymfonyMimeTypeGuesserInterface && !$mimeTypeGuesser instanceof DeprecatedSymfonyMimeTypeGuesserInterface) {
+            throw new InvalidArgumentException('$mimeTypeGuesser must be an instance of Symfony\Component\Mime\MimeTypeGuesserInterface or Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface');
+        }
+
         if (interface_exists((SymfonyMimeTypeGuesserInterface::class) && $mimeTypeGuesser instanceof DeprecatedSymfonyMimeTypeGuesserInterface)) {
             @trigger_error(sprintf('Passing a %s to "%s()" is deprecated since Symfony 4.3, pass a "%s" instead.', DeprecatedSymfonyMimeTypeGuesserInterface::class, __METHOD__, SymfonyMimeTypeGuesserInterface::class), E_USER_DEPRECATED);
         }

--- a/Binary/SimpleMimeTypeGuesser.php
+++ b/Binary/SimpleMimeTypeGuesser.php
@@ -11,20 +11,25 @@
 
 namespace Liip\ImagineBundle\Binary;
 
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface as SymfonyMimeTypeGuesserInterface;
+use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface as DeprecatedSymfonyMimeTypeGuesserInterface;
+use Symfony\Component\Mime\MimeTypesInterface as SymfonyMimeTypeGuesserInterface;
 
 class SimpleMimeTypeGuesser implements MimeTypeGuesserInterface
 {
     /**
-     * @var \Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface
+     * @var DeprecatedSymfonyMimeTypeGuesserInterface|SymfonyMimeTypeGuesserInterface
      */
     protected $mimeTypeGuesser;
 
     /**
-     * @param SymfonyMimeTypeGuesserInterface $mimeTypeGuesser
+     * @param DeprecatedSymfonyMimeTypeGuesserInterface|SymfonyMimeTypeGuesserInterface $mimeTypeGuesser
      */
-    public function __construct(SymfonyMimeTypeGuesserInterface $mimeTypeGuesser)
+    public function __construct($mimeTypeGuesser)
     {
+        if (interface_exists((SymfonyMimeTypeGuesserInterface::class) && $mimeTypeGuesser instanceof DeprecatedSymfonyMimeTypeGuesserInterface)) {
+            @trigger_error(sprintf('Passing a %s to "%s()" is deprecated since Symfony 4.3, pass a "%s" instead.', DeprecatedSymfonyMimeTypeGuesserInterface::class, __METHOD__, SymfonyMimeTypeGuesserInterface::class), E_USER_DEPRECATED);
+        }
+
         $this->mimeTypeGuesser = $mimeTypeGuesser;
     }
 
@@ -40,7 +45,7 @@ class SimpleMimeTypeGuesser implements MimeTypeGuesserInterface
         try {
             file_put_contents($tmpFile, $binary);
 
-            $mimeType = $this->mimeTypeGuesser->guess($tmpFile);
+            $mimeType = interface_exists(SymfonyMimeTypeGuesserInterface::class) ? $this->mimeTypeGuesser->guessMimeType($tmpFile) : $this->mimeTypeGuesser->guess($tmpFile);
 
             unlink($tmpFile);
 

--- a/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
@@ -29,6 +29,13 @@ class FileSystemLoaderFactory extends AbstractLoaderFactory
         $locatorDefinition->replaceArgument(1, $config['allow_unresolvable_data_roots']);
 
         $definition = $this->getChildLoaderDefinition();
+
+        if ($container->hasDefinition('liip_imagine.mime_types')) {
+            $mimeTypes = $container->getDefinition('liip_imagine.mime_types');
+            $definition->replaceArgument(0, $mimeTypes);
+            $definition->replaceArgument(1, $mimeTypes);
+        }
+
         $definition->replaceArgument(2, $locatorDefinition);
 
         return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);

--- a/DependencyInjection/Factory/Loader/FlysystemLoaderFactory.php
+++ b/DependencyInjection/Factory/Loader/FlysystemLoaderFactory.php
@@ -23,6 +23,12 @@ class FlysystemLoaderFactory extends AbstractLoaderFactory
     public function create(ContainerBuilder $container, $loaderName, array $config)
     {
         $definition = $this->getChildLoaderDefinition();
+
+        if ($container->hasDefinition('liip_imagine.mime_types')) {
+            $mimeTypes = $container->getDefinition('liip_imagine.mime_types');
+            $definition->replaceArgument(0, $mimeTypes);
+        }
+
         $definition->replaceArgument(1, new Reference($config['filesystem_service']));
 
         return $this->setTaggedLoaderDefinition($loaderName, $definition, $container);

--- a/Imagine/Data/DataManager.php
+++ b/Imagine/Data/DataManager.php
@@ -14,6 +14,7 @@ namespace Liip\ImagineBundle\Imagine\Data;
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
 use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
+use Liip\ImagineBundle\Exception\InvalidArgumentException;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Liip\ImagineBundle\Model\Binary;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface as DeprecatedExtensionGuesserInterface;
@@ -65,6 +66,10 @@ class DataManager
         $defaultLoader = null,
         $globalDefaultImage = null
     ) {
+        if (!$extensionGuesser instanceof MimeTypesInterface && !$extensionGuesser instanceof DeprecatedExtensionGuesserInterface) {
+            throw new InvalidArgumentException('$extensionGuesser must be an instance of Symfony\Component\Mime\MimeTypesInterface or Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface');
+        }
+
         if (interface_exists(MimeTypesInterface::class) && $extensionGuesser instanceof DeprecatedExtensionGuesserInterface) {
             @trigger_error(sprintf('Passing a %s to "%s()" is deprecated since Symfony 4.3, pass a "%s" instead.', DeprecatedExtensionGuesserInterface::class, __METHOD__, MimeTypesInterface::class), E_USER_DEPRECATED);
         }

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -29,6 +29,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
+use Symfony\Component\Mime\MimeTypesInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 abstract class AbstractTest extends TestCase
@@ -207,7 +208,11 @@ abstract class AbstractTest extends TestCase
      */
     protected function createExtensionGuesserInterfaceMock()
     {
-        return $this->createObjectMock(ExtensionGuesserInterface::class);
+        if (!interface_exists(MimeTypesInterface::class)) {
+            return $this->createObjectMock(ExtensionGuesserInterface::class);
+        }
+
+        return $this->createObjectMock(MimeTypesInterface::class);
     }
 
     /**

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -19,6 +19,8 @@ use Liip\ImagineBundle\Model\FileBinary;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
+use Symfony\Component\Mime\MimeTypes;
+use Symfony\Component\Mime\MimeTypeGuesserInterface;
 
 /**
  * @covers \Liip\ImagineBundle\Binary\Loader\FileSystemLoader
@@ -194,6 +196,16 @@ class FileSystemLoaderTest extends TestCase
      */
     private function getFileSystemLoader(array $roots = [], LocatorInterface $locator = null)
     {
+        if (interface_exists(MimeTypeGuesserInterface::class)) {
+            $mimeTypes = MimeTypes::getDefault();
+
+            return new FileSystemLoader(
+                $mimeTypes,
+                $mimeTypes,
+                null !== $locator ? $locator : $this->getFileSystemLocator(\count($roots) ? $roots : $this->getDefaultDataRoots())
+            );
+        }
+
         return new FileSystemLoader(
             MimeTypeGuesser::getInstance(),
             ExtensionGuesser::getInstance(),

--- a/Tests/Binary/Loader/FileSystemLoaderTest.php
+++ b/Tests/Binary/Loader/FileSystemLoaderTest.php
@@ -34,6 +34,44 @@ class FileSystemLoaderTest extends TestCase
         $this->assertInstanceOf(FileSystemLoader::class, $loader);
     }
 
+    /**
+     * @dataProvider provideMultipleWrongArgumentsConstructorCases
+     *
+     * @param $expectedMessage
+     * @param $mimeGuesser
+     * @param $extensionGuesser
+     */
+    public function testThrowsIfConstructedWithWrongTypeArguments($expectedMessage, $mimeGuesser, $extensionGuesser)
+    {
+        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        new FileSystemLoader(
+            $mimeGuesser,
+            $extensionGuesser,
+            $this->getFileSystemLocator( $this->getDefaultDataRoots())
+        );
+    }
+
+    /**
+     * @return string[][]
+     */
+    public static function provideMultipleWrongArgumentsConstructorCases()
+    {
+        return [
+            [
+                '$mimeGuesser must be an instance of Symfony\Component\Mime\MimeTypeGuesserInterface or Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface',
+                'foo',
+                'bar'
+            ],
+            [
+                '$extensionGuesser must be an instance of Symfony\Component\Mime\MimeTypesInterface or Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface',
+                MimeTypeGuesser::getInstance(),
+                'bar'
+            ],
+        ];
+    }
+
     public function testImplementsLoaderInterface()
     {
         $this->assertInstanceOf(LoaderInterface::class, $this->getFileSystemLoader());

--- a/Tests/Binary/Loader/FlysystemLoaderTest.php
+++ b/Tests/Binary/Loader/FlysystemLoaderTest.php
@@ -17,6 +17,7 @@ use Liip\ImagineBundle\Binary\Loader\FlysystemLoader;
 use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
 use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
+use Symfony\Component\Mime\MimeTypes;
 
 /**
  * @requires PHP 5.4
@@ -43,7 +44,9 @@ class FlysystemLoaderTest extends AbstractTest
      */
     public function getFlysystemLoader()
     {
-        return new FlysystemLoader(ExtensionGuesser::getInstance(), $this->flyFilesystem);
+        $extensionGuesser = class_exists(MimeTypes::class) ? MimeTypes::getDefault() : ExtensionGuesser::getInstance();
+
+        return new FlysystemLoader($extensionGuesser, $this->flyFilesystem);
     }
 
     public function testShouldImplementLoaderInterface()

--- a/Tests/Binary/Loader/FlysystemLoaderTest.php
+++ b/Tests/Binary/Loader/FlysystemLoaderTest.php
@@ -54,6 +54,17 @@ class FlysystemLoaderTest extends AbstractTest
         $this->assertInstanceOf(LoaderInterface::class, $this->getFlysystemLoader());
     }
 
+    public function testThrowsIfConstructedWithWrongTypeArguments()
+    {
+        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$extensionGuesser must be an instance of Symfony\Component\Mime\MimeTypesInterface or Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface');
+
+        new FlysystemLoader(
+            'foo',
+            $this->flyFilesystem
+        );
+    }
+
     public function testReturnImageContentOnFind()
     {
         $loader = $this->getFlysystemLoader();

--- a/Tests/Binary/SimpleMimeTypeGuesserTest.php
+++ b/Tests/Binary/SimpleMimeTypeGuesserTest.php
@@ -30,6 +30,14 @@ class SimpleMimeTypeGuesserTest extends TestCase
         $this->assertInstanceOf(SimpleMimeTypeGuesser::class, $guesser);
     }
 
+    public function testThrowsIfConstructedWithWrongTypeArguments()
+    {
+        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$mimeTypeGuesser must be an instance of Symfony\Component\Mime\MimeTypeGuesserInterface or Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface');
+
+        new SimpleMimeTypeGuesser('foo');
+    }
+
     public function testImplementsMimeTypeGuesserInterface()
     {
         $this->assertInstanceOf(MimeTypeGuesserInterface::class, $this->getSimpleMimeTypeGuesser());

--- a/Tests/Binary/SimpleMimeTypeGuesserTest.php
+++ b/Tests/Binary/SimpleMimeTypeGuesserTest.php
@@ -15,6 +15,8 @@ use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
 use Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
+use Symfony\Component\Mime\MimeTypes;
+use Symfony\Component\Mime\MimeTypesInterface as SymfonyMimeTypeGuesserInterface;
 
 /**
  * @covers \Liip\ImagineBundle\Binary\SimpleMimeTypeGuesser<extended>
@@ -65,6 +67,10 @@ class SimpleMimeTypeGuesserTest extends TestCase
      */
     private function getSimpleMimeTypeGuesser()
     {
+        if (interface_exists(SymfonyMimeTypeGuesserInterface::class)) {
+            return new SimpleMimeTypeGuesser(MimeTypes::getDefault());
+        }
+
         return new SimpleMimeTypeGuesser(MimeTypeGuesser::getInstance());
     }
 }

--- a/Tests/Imagine/Data/DataManagerTest.php
+++ b/Tests/Imagine/Data/DataManagerTest.php
@@ -14,6 +14,7 @@ namespace Liip\ImagineBundle\Tests\Imagine\Data;
 use Liip\ImagineBundle\Imagine\Data\DataManager;
 use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Tests\AbstractTest;
+use Symfony\Component\Mime\MimeTypesInterface;
 
 /**
  * @covers \Liip\ImagineBundle\Imagine\Data\DataManager
@@ -296,11 +297,20 @@ class DataManagerTest extends AbstractTest
             ->willReturn($mimeType);
 
         $extensionGuesser = $this->createExtensionGuesserInterfaceMock();
-        $extensionGuesser
-            ->expects($this->once())
-            ->method('guess')
-            ->with($mimeType)
-            ->willReturn($expectedFormat);
+
+        if ($extensionGuesser instanceof MimeTypesInterface) {
+            $extensionGuesser
+                ->expects($this->once())
+                ->method('getExtensions')
+                ->with($mimeType)
+                ->willReturn([$expectedFormat]);
+        } else {
+            $extensionGuesser
+                ->expects($this->once())
+                ->method('guess')
+                ->with($mimeType)
+                ->willReturn($expectedFormat);
+        }
 
         $config = $this->createFilterConfigurationMock();
         $config

--- a/Tests/Imagine/Data/DataManagerTest.php
+++ b/Tests/Imagine/Data/DataManagerTest.php
@@ -11,6 +11,7 @@
 
 namespace Liip\ImagineBundle\Tests\Imagine\Data;
 
+use Liip\ImagineBundle\Binary\Loader\FlysystemLoader;
 use Liip\ImagineBundle\Imagine\Data\DataManager;
 use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Tests\AbstractTest;
@@ -21,6 +22,17 @@ use Symfony\Component\Mime\MimeTypesInterface;
  */
 class DataManagerTest extends AbstractTest
 {
+    public function testThrowsIfConstructedWithWrongTypeArguments()
+    {
+        $this->expectException(\Liip\ImagineBundle\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$extensionGuesser must be an instance of Symfony\Component\Mime\MimeTypesInterface or Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface');
+
+        $mimeTypeGuesser = $this->createMimeTypeGuesserInterfaceMock();
+        $config = $this->createFilterConfigurationMock();
+
+        new DataManager($mimeTypeGuesser, 'foo', $config, 'default');
+    }
+
     public function testUseDefaultLoaderUsedIfNoneSet()
     {
         $loader = $this->createBinaryLoaderInterfaceMock();

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,12 @@ application code or are otherwise particularly noteworthy. Reference our full
 [changelog](https://github.com/liip/LiipImagineBundle/blob/2.0/CHANGELOG.md) for a complete list of all changes for a
 given release.
 
+## [Unreleased](https://github.com/liip/LiipImagineBundle/tree/HEAD)
+- __[Deprecated]__ Constructing `FileSystemLoader`, `FlysystemLoader`, `SimpleMimeTypeGuesser` and `DataManager` with 
+`\Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface` and 
+`\Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface` have been deprecated for Symfony 4.3+ in 
+favor of the [new interfaces](https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.3.md#httpfoundation).
+
 ## [2.0.0](https://github.com/liip/LiipImagineBundle/blob/2.0/CHANGELOG.md#191)
 
 *Released on* 2018-04-06 *and assigned* [`2.0.0`](https://github.com/liip/LiipImagineBundle/releases/tag/2.0.0) *tag \([view verbose changelog](https://github.com/liip/LiipImagineBundle/compare/1.9.1...2.0.0)\).*


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Tests pass? | yes
| Fixed tickets | https://github.com/liip/LiipImagineBundle/issues/1200
| License | MIT
| Doc PR | <!--highly recommended for new features-->

An attempt to remove the deprecations related to mime type and extension guessers based on https://github.com/symfony/symfony/commit/74ca91deaa014a4e776671bfc523bd10077a52eb#diff-b7fc65c7d852312152e353f395fc70a8. Any feedback is more than welcome 🙂 

https://github.com/liip/LiipImagineBundle/issues/1166 can be closed as well.