### PR TITLE
Fix deprecated usage of Symfony\Component\EventDispatcher\Event class

### DIFF
--- a/Events/CacheResolveEvent.php
+++ b/Events/CacheResolveEvent.php
@@ -12,8 +12,22 @@
 namespace Liip\ImagineBundle\Events;
 
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
-class CacheResolveEvent extends Event
+if (is_subclass_of(EventDispatcherInterface::class, ContractsEventDispatcherInterface::class)) {
+    abstract class BCEvent extends ContractsEvent
+    {
+    }
+}
+else {
+    abstract class BCEvent extends Event
+    {
+    }
+}
+
+class CacheResolveEvent extends BCEvent
 {
     /**
      * Resource path.


### PR DESCRIPTION
This fix usage of `Symfony\Component\EventDispatcher\Event` which was deprecated in Symfony 4.3.