### PR TITLE
Update UPGRADE.md with a bc break notice

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,10 +7,15 @@ application code or are otherwise particularly noteworthy. Reference our full
 given release.
 
 ## [Unreleased](https://github.com/liip/LiipImagineBundle/tree/HEAD)
+
+## [2.2.0](https://github.com/liip/LiipImagineBundle/blob/2.2.0/CHANGELOG.md#unreleased)
+
+*Released on* 2019-04-10 *and assigned* [`2.2.0`](https://github.com/liip/LiipImagineBundle/releases/tag/2.2.0) *tag \([view verbose changelog](https://github.com/liip/LiipImagineBundle/compare/2.0.0...2.2.0)\).*
 - __[Deprecated]__ Constructing `FileSystemLoader`, `FlysystemLoader`, `SimpleMimeTypeGuesser` and `DataManager` with 
 `\Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface` and 
 `\Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface` have been deprecated for Symfony 4.3+ in 
 favor of the [new interfaces](https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.3.md#httpfoundation).
+- __[Utility]__ __[BC BREAK]__ The `SymfonyFramework` class marked as `internal` has been declared as final.
 
 ## [2.0.0](https://github.com/liip/LiipImagineBundle/blob/2.0/CHANGELOG.md#191)
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

As @robfrawley [pointed out](https://github.com/liip/LiipImagineBundle/commit/db8c3471c3f49add8a4bab03f230264d1bf41bdd#r35379488), when I passed the php-cs-fixer, an internal class was changed to `final`, this could be a bc break, this PR is about updating the `UPGRADE.md` file, noticing that.