### PR TITLE
Fix RemoveCacheCommand with empty path

### DIFF
--- a/Command/RemoveCacheCommand.php
+++ b/Command/RemoveCacheCommand.php
@@ -37,7 +37,7 @@ class RemoveCacheCommand extends Command
     {
         $this
             ->setDescription('Remove cache entries for given paths and filters.')
-            ->addArgument('path', InputArgument::REQUIRED | InputArgument::IS_ARRAY,
+            ->addArgument('paths', InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
                 'Image file path(s) to run resolution on.')
             ->addOption('filter', 'f', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Filter(s) to use for image remove; if none explicitly passed, use all filters.')
@@ -77,9 +77,13 @@ EOF
 
         [$images, $filters] = $this->resolveInputFiltersAndPaths($input);
 
-        foreach ($images as $i) {
-            foreach ($filters as $f) {
-                $this->runCacheImageRemove($i, $f);
+        if (empty($images)) {
+            $this->cacheManager->remove(null, $filters);
+        } else {
+            foreach ($images as $i) {
+                foreach ($filters as $f) {
+                    $this->runCacheImageRemove($i, $f);
+                }
             }
         }
 

--- a/Command/ResolveCacheCommand.php
+++ b/Command/ResolveCacheCommand.php
@@ -44,7 +44,7 @@ class ResolveCacheCommand extends Command
     {
         $this
             ->setDescription('Warms up the cache for the specified image sources with all or specified filters applied, and prints the list of cache files.')
-            ->addArgument('path', InputArgument::REQUIRED | InputArgument::IS_ARRAY,
+            ->addArgument('paths', InputArgument::REQUIRED | InputArgument::IS_ARRAY,
                 'Image file path(s) for which to generate the cached images.')
             ->addOption('filter', 'f', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Filter(s) to use for image resolution; if none explicitly passed, use all filters.')

--- a/Tests/Functional/Command/ResolveCacheCommandTest.php
+++ b/Tests/Functional/Command/ResolveCacheCommandTest.php
@@ -221,7 +221,7 @@ class ResolveCacheCommandTest extends AbstractCommandTestCase
      */
     private function executeResolveCacheCommand(array $paths, array $filters = [], array $additionalOptions = [], int &$return = null): string
     {
-        $options = array_merge(['path' => $paths], $additionalOptions);
+        $options = array_merge(['paths' => $paths], $additionalOptions);
 
         if (0 < \count($filters)) {
             $options['--filter'] = $filters;


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | https://github.com/liip/LiipImagineBundle/issues/1236
| License | MIT
| Doc PR | <!--highly recommended for new features-->

In https://github.com/liip/LiipImagineBundle/pull/1222 the `path` for `RemoveCacheCommand` was made mandatory, so there is no way to remove all images and filters as before. 

As paths can be multiple I changed it back to `paths`. ~I don't like very much the solution because if you execute the command you would get:~

```
 - [OKAY] Completed 0 removals (0 images, 7 filters)
```
~which is a little bit weird, so~ any suggestion is more than welcome.

Now it says:
```
 -
 - [OKAY] Completed 7 removals (7 filters)
 -
```