### PR TITLE
Revert "Only use actual path without any query parameters from the url"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ for a given releases. Unreleased, upcoming changes will be updated here periodic
 - Fix Symfony 4.2 Deprecation Warnings ([hjanuschka](https://github.com/hjanuschka))
 - Fix special characters encoding in URL path ([dbalabka](https://github.com/dbalabka))
 - Update imagine/imagine dependency to 1.1 ([maximgubar](https://github.com/maximgubar))
-- Only use actual path without any query parameters from the url ([maximgubar](https://github.com/maximgubar))
+- __\[BC BREAK\]__ Only use actual path ([parse_url's](https://www.php.net/manual/en/function.parse-url.php) PHP_URL_PATH) without any query parameters from the url ([maximgubar](https://github.com/maximgubar))
 - __\[Dependency Injection\]__ Add aliases for data and filter manager ([fpaterno](https://github.com/fpaterno))
 - Use Autorotate Filter from Imagine library ([franmomu](https://github.com/franmomu))
 - Fix Mime deprecations for Symfony 4 ([franmomu](https://github.com/franmomu))

--- a/Templating/FilterTrait.php
+++ b/Templating/FilterTrait.php
@@ -40,7 +40,7 @@ trait FilterTrait
      */
     public function filter($path, $filter, array $config = [], $resolver = null)
     {
-        return $this->cache->getBrowserPath(parse_url($path, PHP_URL_PATH), $filter, $config, $resolver);
+        return $this->cache->getBrowserPath($path, $filter, $config, $resolver);
     }
 
     /**


### PR DESCRIPTION
This reverts commit b77558c98e389bef3a642f4a03745b47925b90d4.
This commit broke backwards compatibility with code which wanted to use
more than just the path component of a URL (e.g. wanted to use full URLs
with a domain via `Liip\ImagineBundle\Binary\Loader\StreamLoader`). This was released on upgrade from 2.1.0 to 2.2.0 so if the project follows semver then I don't think this should have happened.

It's not clear from the commit history why a need was felt to strip query parameters, but if a particular user needs it then this should probably be done by them?

Sample project using this was [camdram/camdram](https://github.com/camdram/camdram/blob/56517df4efe2678817eba5c33da6e56d0390ee11/app/config/services.yml#L56).

| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes/no
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->