### PR TITLE
Fixing bug where apply tag was used but allowed non-supported Twig versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "symfony/phpunit-bridge": "^4.3",
         "symfony/validator": "^3.4|^4.2",
         "symfony/yaml": "^3.4|^4.2",
-        "twig/twig": "^1.34|^2.4"
+        "twig/twig": "^1.40|^2.9"
     },
     "suggest": {
         "ext-exif": "required to read EXIF metadata from images",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | none
| License | MIT
| Doc PR | not needed!

Hi!

In #1176, we started using the `apply` tag. But that was not available until Twig 1.40 (reference https://twig.symfony.com/doc/1.x/tags/apply.html) and Twig 2.9 (reference https://twig.symfony.com/doc/2.x/tags/apply.html).

The Twig range needs to be updated to reflect this.

Thanks!

