### PR TITLE
Eliminate root_dir usage

### DIFF
--- a/Imagine/Filter/Loader/PasteFilterLoader.php
+++ b/Imagine/Filter/Loader/PasteFilterLoader.php
@@ -25,12 +25,12 @@ class PasteFilterLoader implements LoaderInterface
     /**
      * @var string
      */
-    protected $rootPath;
+    protected $projectDir;
 
-    public function __construct(ImagineInterface $imagine, $rootPath)
+    public function __construct(ImagineInterface $imagine, $projectDir)
     {
         $this->imagine = $imagine;
-        $this->rootPath = $rootPath . '/app';
+        $this->projectDir = $projectDir;
     }
 
     /**
@@ -46,7 +46,17 @@ class PasteFilterLoader implements LoaderInterface
         $x = isset($options['start'][0]) ? $options['start'][0] : null;
         $y = isset($options['start'][1]) ? $options['start'][1] : null;
 
-        $destImage = $this->imagine->open($this->rootPath.'/'.$options['image']);
+        $file = $this->projectDir . '/' . $options['image'];
+
+        if (!file_exists($file) {
+            @trigger_error(
+                'The ' . $file . ' does not exists, change the path based on kernel.project_dir parameter',
+                E_USER_DEPRECATED
+            );
+            $file = $this->projectDir . '/app/' . $options['image'];
+        }
+
+        $destImage = $this->imagine->open($file);
 
         return $image->paste($destImage, new Point($x, $y));
     }

--- a/Imagine/Filter/Loader/PasteFilterLoader.php
+++ b/Imagine/Filter/Loader/PasteFilterLoader.php
@@ -48,7 +48,7 @@ class PasteFilterLoader implements LoaderInterface
 
         $file = $this->projectDir . '/' . $options['image'];
 
-        if (!file_exists($file) {
+        if (!file_exists($file)) {
             @trigger_error(
                 'The ' . $file . ' does not exists, change the path based on kernel.project_dir parameter',
                 E_USER_DEPRECATED

--- a/Imagine/Filter/Loader/PasteFilterLoader.php
+++ b/Imagine/Filter/Loader/PasteFilterLoader.php
@@ -30,7 +30,7 @@ class PasteFilterLoader implements LoaderInterface
     public function __construct(ImagineInterface $imagine, $rootPath)
     {
         $this->imagine = $imagine;
-        $this->rootPath = $rootPath;
+        $this->rootPath = $rootPath . '/app';
     }
 
     /**

--- a/Imagine/Filter/Loader/WatermarkFilterLoader.php
+++ b/Imagine/Filter/Loader/WatermarkFilterLoader.php
@@ -55,7 +55,7 @@ class WatermarkFilterLoader implements LoaderInterface
 
         $file = $this->projectDir . '/' . $options['image'];
 
-        if (!file_exists($file) {
+        if (!file_exists($file)) {
             @trigger_error(
                 'The ' . $file . ' does not exists, change the path based on kernel.project_dir parameter',
                 E_USER_DEPRECATED

--- a/Imagine/Filter/Loader/WatermarkFilterLoader.php
+++ b/Imagine/Filter/Loader/WatermarkFilterLoader.php
@@ -31,7 +31,7 @@ class WatermarkFilterLoader implements LoaderInterface
     public function __construct(ImagineInterface $imagine, $rootPath)
     {
         $this->imagine = $imagine;
-        $this->rootPath = $rootPath;
+        $this->rootPath = $rootPath . '/app';
     }
 
     /**

--- a/Imagine/Filter/Loader/WatermarkFilterLoader.php
+++ b/Imagine/Filter/Loader/WatermarkFilterLoader.php
@@ -26,12 +26,12 @@ class WatermarkFilterLoader implements LoaderInterface
     /**
      * @var string
      */
-    protected $rootPath;
+    protected $projectDir;
 
-    public function __construct(ImagineInterface $imagine, $rootPath)
+    public function __construct(ImagineInterface $imagine, $projectDir)
     {
         $this->imagine = $imagine;
-        $this->rootPath = $rootPath . '/app';
+        $this->projectDir = $projectDir;
     }
 
     /**
@@ -53,7 +53,17 @@ class WatermarkFilterLoader implements LoaderInterface
             $options['size'] = mb_substr($options['size'], 0, -1) / 100;
         }
 
-        $watermark = $this->imagine->open($this->rootPath.'/'.$options['image']);
+        $file = $this->projectDir . '/' . $options['image'];
+
+        if (!file_exists($file) {
+            @trigger_error(
+                'The ' . $file . ' does not exists, change the path based on kernel.project_dir parameter',
+                E_USER_DEPRECATED
+            );
+            $file = $this->projectDir . '/app/' . $options['image'];
+        }
+
+        $watermark = $this->imagine->open($file);
 
         $size = $image->getSize();
         $watermarkSize = $watermark->getSize();

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -212,13 +212,13 @@
         <service id="liip_imagine.filter.loader.paste" class="Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader">
             <tag name="liip_imagine.filter.loader" loader="paste" />
             <argument type="service" id="liip_imagine" />
-            <argument>%kernel.root_dir%</argument>
+            <argument>%kernel.project_dir%</argument>
         </service>
 
         <service id="liip_imagine.filter.loader.watermark" class="Liip\ImagineBundle\Imagine\Filter\Loader\WatermarkFilterLoader">
             <tag name="liip_imagine.filter.loader" loader="watermark" />
             <argument type="service" id="liip_imagine" />
-            <argument>%kernel.root_dir%</argument>
+            <argument>%kernel.project_dir%</argument>
         </service>
 
         <service id="liip_imagine.filter.loader.background" class="Liip\ImagineBundle\Imagine\Filter\Loader\BackgroundFilterLoader">

--- a/Resources/doc/filters/general.rst
+++ b/Resources/doc/filters/general.rst
@@ -184,7 +184,7 @@ Example configuration:
                     # use and setup the "watermark" filter
                     watermark:
 
-                        # path to the watermark file (prepended with "%kernel.root_dir%")
+                        # path to the watermark file (prepended with "%kernel.project_dir%")
                         image: Resources/data/watermark.png
 
                         # size of the water mark relative to the input image
@@ -199,7 +199,7 @@ Watermark Options
 
 :strong:`image:` ``string``
     Sets the location of the watermark image. The value of this option is prepended
-    with the resolved value of the ``%kernel.root_dir%`` parameter.
+    with the resolved value of the ``%kernel.project_dir%`` parameter.
 
 :strong:`size:` ``float``
     Sets the size of the watermark as a relative ration, relative to the original


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | symfony5
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | 
| License | MIT
| Doc PR | 

Replaced `root_dir` by `project_dir`. Not sure whether this is the correct way you want to do it, but seems working so far.