### PR TITLE
Remove non-functional allow_upscale reference

### DIFF
--- a/Resources/doc/filters/sizing.rst
+++ b/Resources/doc/filters/sizing.rst
@@ -53,11 +53,6 @@ Thumbnail Options
     Sets the generated thumbnail size as an integer array containing the dimensions
     as width and height values.
 
-:strong:`allow_upscale:` ``bool``
-    Toggles allowing image up-scaling when the image is smaller than the desired
-    thumbnail size.
-
-
 .. _filter-fixed:
 
 Fixed size


### PR DESCRIPTION
Reference to allow_upscale has been removed from the main doc file (filters.rst), see https://github.com/jeffclemens/LiipImagineBundle/commit/0eb167bc3fbbd23b020ae3b4f29efa47059396ea

But this option is still present in the "Sizing filters" page.

| Branch? | as the commit above. I don't know if allow_upscale has been functional at one time
| Bug fix? | Documentation fix
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | not needed
| Fixed tickets | "As stated in liip#560, allow_upscale is no longer functional"
