### PR TITLE
Pass catched exception to give more insight on the original problem

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -144,9 +144,9 @@ class ImagineController
                 return new RedirectResponse($this->dataManager->getDefaultImageUrl($filter));
             }
 
-            throw new NotFoundHttpException(sprintf('Source image for path "%s" could not be found', $path));
+            throw new NotFoundHttpException(sprintf('Source image for path "%s" could not be found', $path), $exception);
         } catch (NonExistingFilterException $exception) {
-            throw new NotFoundHttpException(sprintf('Requested non-existing filter "%s"', $filter));
+            throw new NotFoundHttpException(sprintf('Requested non-existing filter "%s"', $filter), $exception);
         } catch (RuntimeException $exception) {
             throw new \RuntimeException(vsprintf('Unable to create image for path "%s" and filter "%s". Message was "%s"', [
                 $hash ? sprintf('%s/%s', $hash, $path) : $path,


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | master
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

IMHO every caught exception should always be passed to any new exception thrown. 
Without this change, I would have never guessed that I was missing a PHP extension 😅