### PR TITLE
expose reference type further up following PR 1224

### DIFF
--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -100,22 +100,23 @@ class CacheManager
      * @param string $filter
      * @param array  $runtimeConfig
      * @param string $resolver
+     * @param int    $referenceType
      *
      * @return string
      */
-    public function getBrowserPath($path, $filter, array $runtimeConfig = [], $resolver = null)
+    public function getBrowserPath($path, $filter, array $runtimeConfig = [], $resolver = null, $referenceType = UrlGeneratorInterface::ABSOLUTE_URL)
     {
         if (!empty($runtimeConfig)) {
             $rcPath = $this->getRuntimePath($path, $runtimeConfig);
 
             return $this->isStored($rcPath, $filter, $resolver) ?
                 $this->resolve($rcPath, $filter, $resolver) :
-                $this->generateUrl($path, $filter, $runtimeConfig, $resolver);
+                $this->generateUrl($path, $filter, $runtimeConfig, $resolver, $referenceType);
         }
 
         return $this->isStored($path, $filter, $resolver) ?
             $this->resolve($path, $filter, $resolver) :
-            $this->generateUrl($path, $filter, [], $resolver);
+            $this->generateUrl($path, $filter, [], $resolver, $referenceType);
     }
 
     /**

--- a/Templating/FilterTrait.php
+++ b/Templating/FilterTrait.php
@@ -12,6 +12,7 @@
 namespace Liip\ImagineBundle\Templating;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 trait FilterTrait
 {
@@ -35,12 +36,13 @@ trait FilterTrait
      * @param string      $filter
      * @param array       $config
      * @param string|null $resolver
+     * @param int         $referenceType
      *
      * @return string
      */
-    public function filter($path, $filter, array $config = [], $resolver = null)
+    public function filter($path, $filter, array $config = [], $resolver = null, $referenceType = UrlGeneratorInterface::ABSOLUTE_URL)
     {
-        return $this->cache->getBrowserPath(parse_url($path, PHP_URL_PATH), $filter, $config, $resolver);
+        return $this->cache->getBrowserPath(parse_url($path, PHP_URL_PATH), $filter, $config, $resolver, $referenceType);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| License | MIT

Following PR #1224 it would be also helpful for us to be able to set the reference type for the generated resolve url when using the filter and the getBrowserPath method of CacheManager