### PR TITLE
Create Lazy-Loaded Twig Extension

### DIFF
--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -184,6 +184,10 @@
 
         <service id="liip_imagine.templating.filter_extension" class="Liip\ImagineBundle\Templating\FilterExtension" public="false">
             <tag name="twig.extension" />
+        </service>
+
+        <service id="liip_imagine.templating.filter_runtime" class="Liip\ImagineBundle\Templating\FilterRuntime" public="false">
+            <tag name="twig.runtime" />
             <argument type="service" id="liip_imagine.cache.manager" />
         </service>
 

--- a/Templating/FilterRuntime.php
+++ b/Templating/FilterRuntime.php
@@ -11,18 +11,9 @@
 
 namespace Liip\ImagineBundle\Templating;
 
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
+use Twig\Extension\RuntimeExtensionInterface;
 
-class FilterExtension extends AbstractExtension
+class FilterRuntime implements RuntimeExtensionInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getFilters()
-    {
-        return [
-            new TwigFilter('imagine_filter', [FilterRuntime::class, 'filter']),
-        ];
-    }
+    use FilterTrait;
 }

--- a/Tests/Templating/AbstractFilterTest.php
+++ b/Tests/Templating/AbstractFilterTest.php
@@ -12,7 +12,7 @@
 namespace Liip\ImagineBundle\Tests\Templating;
 
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
-use Liip\ImagineBundle\Templating\FilterExtension;
+use Liip\ImagineBundle\Templating\FilterRuntime;
 use Liip\ImagineBundle\Templating\Helper\FilterHelper;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
@@ -45,7 +45,7 @@ abstract class AbstractFilterTest extends AbstractTest
     }
 
     /**
-     * @return FilterExtension|FilterHelper
+     * @return FilterRuntime|FilterHelper
      */
     abstract protected function createTemplatingMock(CacheManager $manager = null);
 }

--- a/Tests/Templating/FilterExtensionTest.php
+++ b/Tests/Templating/FilterExtensionTest.php
@@ -11,33 +11,27 @@
 
 namespace Liip\ImagineBundle\Tests\Templating;
 
-use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Templating\FilterExtension;
+use Liip\ImagineBundle\Tests\AbstractTest;
 use Twig\Extension\AbstractExtension;
 
 /**
- * @covers \Liip\ImagineBundle\Templating\FilterTrait
  * @covers \Liip\ImagineBundle\Templating\FilterExtension
  */
-class FilterExtensionTest extends AbstractFilterTest
+class FilterExtensionTest extends AbstractTest
 {
     public function testAddsFilterMethodToFiltersList(): void
     {
         $this->assertCount(1, $this->createTemplatingMock()->getFilters());
     }
 
-    public function testInstanceOfTwigFilter(): void
-    {
-        $this->assertInstanceOf(AbstractExtension::class, $this->createTemplatingMock());
-    }
-
-    protected function createTemplatingMock(CacheManager $manager = null): FilterExtension
+    protected function createTemplatingMock(): FilterExtension
     {
         if (!class_exists(AbstractExtension::class)) {
             $this->markTestSkipped('Requires the twig/twig package.');
         }
 
-        $mock = new FilterExtension($manager ?: $this->createCacheManagerMock());
+        $mock = new FilterExtension();
 
         $this->assertInstanceOf(FilterExtension::class, $mock);
 

--- a/Tests/Templating/FilterRuntimeTest.php
+++ b/Tests/Templating/FilterRuntimeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Templating;
+
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Liip\ImagineBundle\Templating\FilterRuntime;
+use Twig\Extension\RuntimeExtensionInterface;
+
+/**
+ * @covers \Liip\ImagineBundle\Templating\FilterTrait
+ * @covers \Liip\ImagineBundle\Templating\FilterRuntime
+ */
+class FilterRuntimeTest extends AbstractFilterTest
+{
+    public function testInstanceOfTwigFilter(): void
+    {
+        $this->assertInstanceOf(RuntimeExtensionInterface::class, $this->createTemplatingMock());
+    }
+
+    protected function createTemplatingMock(CacheManager $manager = null): FilterRuntime
+    {
+        if (!class_exists(RuntimeExtensionInterface::class)) {
+            $this->markTestSkipped('Requires the twig/twig package.');
+        }
+
+        $mock = new FilterRuntime($manager ?: $this->createCacheManagerMock());
+
+        $this->assertInstanceOf(FilterRuntime::class, $mock);
+
+        return $mock;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "symfony/phpunit-bridge": "^4.3|^5.0",
         "symfony/validator": "^3.4|^4.3|^5.0",
         "symfony/yaml": "^3.4|^4.3|^5.0",
-        "twig/twig": "^1.34|^2.4|^3.0"
+        "twig/twig": "^1.35|^2.4.4|^3.0"
     },
     "suggest": {
         "ext-exif": "required to read EXIF metadata from images",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1261
| License | MIT
| Doc PR | 

Hi!

Twig supports [Lazy-Loaded Extensions](https://symfony.com/doc/current/templating/twig_extension.html#creating-lazy-loaded-twig-extensions) since `1.35.0` and `2.4.4`.

However, I don't really know how we can be sure that Twig is indeed `>= 1.35.0` or `>= 2.4.4`.

I updated `composer.json` `require-dev` for `twig/twig` to `^1.35|^2.4.4|^3.0`.

Tests have been updated too.

(Also, @mbabker provided details and Blackfire comparison in #1261)