### PR TITLE
Specify Twig package in the required dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,7 @@
         "doctrine/mongodb-odm": "required to use mongodb-backed doctrine components",
         "enqueue/enqueue-bundle": "^0.9 add if you like to process images in background",
         "league/flysystem": "required to use FlySystem data loader or cache resolver",
-        "monolog/monolog": "A psr/log compatible logger is required to enable logging",
-        "twig/twig": "required to use the provided Twig extension. Version 1.12 or greater needed"
+        "monolog/monolog": "A psr/log compatible logger is required to enable logging"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "symfony/options-resolver": "^3.4|^4.3|^5.0",
         "symfony/process": "^3.4|^4.3|^5.0",
         "symfony/templating": "^3.4|^4.3|^5.0",
-        "symfony/translation": "^3.4|^4.3|^5.0"
+        "symfony/translation": "^3.4|^4.3|^5.0",
+        "twig/twig": "^1.40|^2.9|^3.0"
     },
     "require-dev": {
         "ext-gd": "*",
@@ -45,8 +46,7 @@
         "symfony/form": "^3.4|^4.3|^5.0",
         "symfony/phpunit-bridge": "^4.3|^5.0",
         "symfony/validator": "^3.4|^4.3|^5.0",
-        "symfony/yaml": "^3.4|^4.3|^5.0",
-        "twig/twig": "^1.34|^2.4|^3.0"
+        "symfony/yaml": "^3.4|^4.3|^5.0"
     },
     "suggest": {
         "ext-exif": "required to read EXIF metadata from images",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2..x/master
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1272
| License | MIT

Add missing required version of `twig/twig` package.
Due to the use of `apply` tag, Twig package versions need to be added.

According to the Twig documentations here:
- https://twig.symfony.com/doc/1.x/tags/apply.html
- https://twig.symfony.com/doc/2.x/tags/apply.html
- https://twig.symfony.com/doc/3.x/tags/apply.html

Twig required versions are: **1.40**, **2.9** and **3.0**.