### PR TITLE
Fix typos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ suite against various PHP versions and checks that proper code style standards a
 ## Report Bug
 
 If you believe you have encountered a *behavioral bug*, *documentation error*, or *other
-issue*, first search for an [existing issue][issue-list], and if one does't already exist,
+issue*, first search for an [existing issue][issue-list], and if one doesn't already exist,
 then proceed to [create a new issue][issue-make]. If you have the available time and the
 required skill set, we appreciate those who offer fixes themselves via
 [pull requests][pr-list], as well.

--- a/Imagine/Filter/PostProcessor/MozJpegPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/MozJpegPostProcessor.php
@@ -16,7 +16,7 @@ use Liip\ImagineBundle\Model\Binary;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
 /**
- * mozjpeg post-processor, for noticably better jpeg compression.
+ * mozjpeg post-processor, for noticeably better jpeg compression.
  *
  * @see http://calendar.perfplanet.com/2014/mozjpeg-3-0/
  * @see https://mozjpeg.codelove.de/binaries.html

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -80,7 +80,7 @@ There are several configuration options available:
 * ``driver`` - one of the three drivers: ``gd``, ``imagick``, ``gmagick``.
   Default value: ``gd``
 * ``default_filter_set_settings`` - specify the default values that will be inherit for any set defined in
-``filter_sets``. These values will be overriden if they are specified in the each set. In case of ``filters`` and
+``filter_sets``. These values will be overridden if they are specified in the each set. In case of ``filters`` and
 ``post_processors``, the specified values will be merged with the default ones.
 * ``filter_sets`` - specify the filter sets that you want to define and use.
 


### PR DESCRIPTION
Hello,

This PR will fix : 

- 1 typo in `.github/CONTRIBUTING.md`
- 1 typo in `Imagine/Filter/PostProcessor/MozJpegPostProcessor.php`
- 1 typo in `Resources/doc/configuration.rst`



Cheers! :robot: