### PR TITLE
Extend WatermarkFilter with multiple option

### DIFF
--- a/Imagine/Filter/Loader/WatermarkFilterLoader.php
+++ b/Imagine/Filter/Loader/WatermarkFilterLoader.php
@@ -70,6 +70,21 @@ class WatermarkFilterLoader implements LoaderInterface
             $watermarkSize = $watermark->getSize();
         }
 
+        if ('multiple' === $options['position']) {
+            // we loop over the coordinates of the image to apply the watermark as much as possible
+            $pasteX = 0;
+            while ($pasteX < $size->getWidth()) {
+                $pasteY = 0;
+                while ($pasteY < $size->getHeight()) {
+                    $image->paste($watermark, new Point($pasteX, $pasteY));
+                    $pasteY += $watermarkSize->getHeight();
+                }
+                $pasteX += $watermarkSize->getWidth();
+            }
+
+            return $image;
+        }
+
         switch ($options['position']) {
             case 'topleft':
                 $x = 0;

--- a/Resources/doc/filters/general.rst
+++ b/Resources/doc/filters/general.rst
@@ -207,8 +207,10 @@ Watermark Options
 
 :strong:`position:` ``string``
     Sets the position of the watermark on the input image. Valid values: ``topleft``,
-    ``top``, ``topright``, ``left``, ``center``, ``right``, ``bottomleft``, ``bottom``, and
-    ``bottomright``.
+    ``top``, ``topright``, ``left``, ``center``, ``right``, ``bottomleft``, ``bottom``,
+    ``bottomright`` and ``multiple``.
+
+    When using ``multiple``, the watermark is pasted onto the image as often as possible.
 
 .. caution::
 


### PR DESCRIPTION
Signed-off-by: Timothy Zemp <timothy.zemp@gmail.com>

| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1007 
| License | MIT
| Doc PR | no

Extends the watermark functionally to allow multiple watermarks of the same type. It tries to paste the watermark onto the image as often as possible.

I'm not sure if "position" is the right way to address this problem, but i can be solved within few lines of code. It can also uses the "size" attribute -> 0.25% -> 4 watermarks per width.

Maybe some validation is required to prevent sizes > 1.0, as this is not validated yet.

Feedback appreciated :-)