### PR TITLE
Deprecation warning in Symfony 5.1

### DIFF
--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -7,7 +7,7 @@
         <service id="liip_imagine.templating.filter_helper" class="Liip\ImagineBundle\Templating\Helper\FilterHelper">
             <tag name="templating.helper" alias="imagine" />
             <argument type="service" id="liip_imagine.cache.manager" />
-            <deprecated>The "%service_id%" service is deprecated since LiipImagineBundle 2.2 and will be removed in 3.0.</deprecated>
+            <deprecated package="liip/imagine-bundle" version="2.2">The "%service_id%" service is deprecated since LiipImagineBundle 2.2 and will be removed in 3.0.</deprecated>
         </service>
     </services>
 </container>


### PR DESCRIPTION
After upgrading to Symfony 5.1 I got the deprecation warning

`Since symfony/dependency-injection 5.1: Not setting the attribute "package" of the node "deprecated" is deprecated.`

| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Tests pass? | yes
| Fixed tickets | none
| License | MIT

