### PR TITLE
Fix documentation for Custom Data loaders xml config 

### DIFF
--- a/Resources/doc/data-loaders.rst
+++ b/Resources/doc/data-loaders.rst
@@ -98,7 +98,7 @@ To register ``AppBundle\Imagine\Binary\Loader\MyCustomDataLoader`` with the name
         <!-- app/config/services.xml -->
 
         <service id="imagine.data.loader.my_custom" class="AppBundle\Imagine\Binary\Loader\MyCustomDataLoader">
-            <tag name="liip_imagine.data.loader" loader="my_custom_data_loader" />
+            <tag name="liip_imagine.binary.loader" loader="my_custom_data_loader" />
             <argument type="service" id="liip_imagine" />
             <argument type="parameter" id="liip_imagine.formats" />
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 1.0 
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | none
| License | MIT
| Doc PR | <!--highly recommended for new features-->

This is just a small edit to the Custom data loaders documentation,
the xml config for the custom data loader service still had the 0.x syntax.