### PR TITLE
Add FormatExtensionResolver

### DIFF
--- a/Imagine/Cache/Resolver/FormatExtensionResolver.php
+++ b/Imagine/Cache/Resolver/FormatExtensionResolver.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Imagine\Cache\Resolver;
+
+use Liip\ImagineBundle\Binary\BinaryInterface;
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+
+class FormatExtensionResolver implements ResolverInterface
+{
+    /**
+     * @var ResolverInterface
+     */
+    private $resolver;
+
+    /**
+     * @var FilterConfiguration
+     */
+    private $filterConfig;
+
+    public function __construct(ResolverInterface $resolver, FilterConfiguration $filterConfig)
+    {
+        $this->resolver = $resolver;
+        $this->filterConfig = $filterConfig;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve($path, $filter)
+    {
+        $path = $this->replaceExtension($path, $filter);
+
+        return $this->resolver->resolve($path, $filter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function store(BinaryInterface $binary, $targetPath, $filter)
+    {
+        $targetPath = $this->replaceExtension($targetPath, $filter);
+
+        return $this->resolver->store($binary, $targetPath, $filter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStored($path, $filter)
+    {
+        $path = $this->replaceExtension($path, $filter);
+
+        return $this->resolver->isStored($path, $filter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove(array $paths, array $filters)
+    {
+        $newPaths = [];
+        foreach ($paths as $path) {
+            foreach ($filters as $filter) {
+                $newPath = $this->replaceExtension($path, $filter);
+                if (!\in_array($newPath, $newPaths, true)) {
+                    $newPaths[] = $newPath;
+                }
+            }
+        }
+
+        return $this->resolver->remove($newPaths, $filters);
+    }
+
+    private function replaceExtension(string $path, string $filter): string
+    {
+        $config = $this->filterConfig->get($filter);
+        if (!$config['format']) {
+            return $path;
+        }
+
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        $path = ($extension ? mb_substr($path, 0, -mb_strlen($extension)) : $path.'.').$config['format'];
+
+        return $path;
+    }
+}

--- a/Resources/doc/cache-resolver/format_extension.rst
+++ b/Resources/doc/cache-resolver/format_extension.rst
@@ -1,0 +1,65 @@
+
+.. _cache-resolver-format-extension:
+
+FormatExtensionResolver
+=======================
+
+The ``FormatExtensionResolver`` cannot be used by itself. Instead, it is a "decorator" for
+another resolver. It adds the ability to set the correct file extension when a filter converted the image format.
+
+Configuration
+-------------
+
+To use this cache resolver, you must first define the cache resolver it will decorate.
+In this example, we will use the :ref:`Web Path Resolver <cache-resolver-web-path>`.
+
+Next, we need to define a service for this cache resolver and inject the web path cache resolver service to decorate.
+
+.. code-block:: yaml
+
+    # app/config/services.yml
+
+    services:
+        acme.imagine.cache.format_extension:
+            class: Liip\ImagineBundle\Imagine\Cache\Resolver\FormatExtensionResolver
+            arguments:
+                - "@acme.imagine.cache.resolver.web_path"
+                - "@liip_imagine.filter.configuration"
+            tags:
+                - { name: "liip_imagine.cache.resolver", resolver: "format_extension" }
+
+
+With this configuration, the format extension resolver will rewrite the extension to match the filter format.
+For example, you have the source image ``image.png`` and you apply filter with format ``jpg`` you will get jpeg-image ``image.jpg``.
+
+Usage
+-----
+
+After configuring ``FormatExtensionResolver``, you can set it as the default cache resolver
+for ``LiipImagineBundle`` using the following configuration.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        cache: format_extension
+
+
+Usage on a Specific Filter
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Alternatively, you can set ``FormatExtensionResolver`` as the cache resolver for a specific
+filter set using the following configuration.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        filter_sets:
+            cache: ~
+            my_thumb:
+                cache: format_extension
+                filters:
+                    # the filter list

--- a/Tests/Imagine/Cache/Resolver/FormatExtensionResolverTest.php
+++ b/Tests/Imagine/Cache/Resolver/FormatExtensionResolverTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Imagine\Cache\Resolver;
+
+use Liip\ImagineBundle\Imagine\Cache\Resolver\FormatExtensionResolver;
+use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+use Liip\ImagineBundle\Model\Binary;
+use Liip\ImagineBundle\Tests\AbstractTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Cache\Resolver\FormatExtensionResolver
+ */
+class FormatExtensionResolverTest extends AbstractTest
+{
+    /**
+     * @var MockObject|ResolverInterface
+     */
+    private $primaryResolver;
+
+    /**
+     * @var FormatExtensionResolver
+     */
+    private $resolver;
+
+    protected function setUp(): void
+    {
+        $this->primaryResolver = $this->createObjectMock(ResolverInterface::class);
+        $filterConfiguration = new FilterConfiguration([
+            'thumbnail' => [
+                'format' => 'webp',
+            ],
+            'thumbnail_jpeg' => [
+                'format' => 'jpeg',
+            ],
+        ]);
+        $this->resolver = new FormatExtensionResolver($this->primaryResolver, $filterConfiguration);
+    }
+
+    public function providePaths(): array
+    {
+        return [
+            ['foo/bar.png', 'foo/bar.webp'],
+            ['foo/bar', 'foo/bar.webp'],
+            ['foo.png', 'foo.webp'],
+            ['foo', 'foo.webp'],
+            ['foo.bar/baz.png', 'foo.bar/baz.webp'],
+            ['foo.bar/baz', 'foo.bar/baz.webp'],
+        ];
+    }
+
+    /**
+     * @dataProvider providePaths
+     */
+    public function testResolve(string $path, string $expectedPath): void
+    {
+        $filter = 'thumbnail';
+
+        $this->primaryResolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($expectedPath, $filter);
+
+        $this->resolver->resolve($path, $filter);
+    }
+
+    /**
+     * @dataProvider providePaths
+     */
+    public function testStore(string $path, string $expectedPath): void
+    {
+        $filter = 'thumbnail';
+        $binary = new Binary('aContent', 'image/webp', 'webp');
+
+        $this->primaryResolver
+            ->expects($this->once())
+            ->method('store')
+            ->with($binary, $expectedPath, $filter);
+
+        $this->resolver->store($binary, $path, $filter);
+    }
+
+    /**
+     * @dataProvider providePaths
+     */
+    public function testIsStored(string $path, string $expectedPath): void
+    {
+        $filter = 'thumbnail';
+
+        $this->primaryResolver
+            ->expects($this->once())
+            ->method('isStored')
+            ->with($expectedPath, $filter);
+
+        $this->resolver->isStored($path, $filter);
+    }
+
+    public function testRemove(): void
+    {
+        $filters = ['thumbnail', 'thumbnail_jpeg'];
+        $paths = [
+            'foo/bar.png',
+            'foo/bar',
+            'foo.png',
+            'foo',
+            'foo.bar/baz.png',
+            'foo.bar/baz',
+        ];
+        $expectedPaths = [
+            'foo/bar.webp',
+            'foo/bar.jpeg',
+            'foo.webp',
+            'foo.jpeg',
+            'foo.bar/baz.webp',
+            'foo.bar/baz.jpeg',
+        ];
+
+        $this->primaryResolver
+            ->expects($this->once())
+            ->method('remove')
+            ->with($expectedPaths, $filters);
+
+        $this->resolver->remove($paths, $filters);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 (was branched from master)
| Bug fix? | yes
| New feature? | yes
| BC breaks? |no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | https://github.com/liip/LiipImagineBundle/issues/1198
| License | MIT
| Doc PR | <!--highly recommended for new features-->

I've added a new resolver to resolve issue with file extension when filter changes image format, see related issues.
Just add it as decorator to your primary resolver and images will be stored with proper extensions:
```yaml
services:
    acme.imagine.cache.resolver.format_extension:
        class: Liip\ImagineBundle\Imagine\Cache\Resolver\FormatExtensionResolver
        arguments:
            - "@liip_imagine.cache.resolver.default"
            - "@liip_imagine.filter.configuration"
        tags:
            - { name: "liip_imagine.cache.resolver", resolver: "format_extension" }
```