### PR TITLE
Fix RST documentation compilation errors introduced at various times in past

### DIFF
--- a/Resources/doc/cache-resolver/aws_s3.rst
+++ b/Resources/doc/cache-resolver/aws_s3.rst
@@ -136,8 +136,8 @@ You have to set up the services required:
             factory: [Aws\S3\S3Client, factory]
             arguments:
                 -
-                    credentials: { key: %amazon.s3.key%, secret: %amazon.s3.secret% }
-                    region: %amazon.s3.region%
+                    credentials: { key: "%amazon.s3.key%", secret: "%amazon.s3.secret%" }
+                    region: "%amazon.s3.region%"
                     version: "%amazon.s3.version%"
 
 

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -80,8 +80,8 @@ There are several configuration options available:
 * ``driver`` - one of the three drivers: ``gd``, ``imagick``, ``gmagick``.
   Default value: ``gd``
 * ``default_filter_set_settings`` - specify the default values that will be inherit for any set defined in
-``filter_sets``. These values will be overridden if they are specified in the each set. In case of ``filters`` and
-``post_processors``, the specified values will be merged with the default ones.
+  ``filter_sets``. These values will be overridden if they are specified in the each set. In case of ``filters`` and
+  ``post_processors``, the specified values will be merged with the default ones.
 * ``filter_sets`` - specify the filter sets that you want to define and use.
 
 Each filter set that you specify has the following options:

--- a/Resources/doc/post-processors/png-quant.rst
+++ b/Resources/doc/post-processors/png-quant.rst
@@ -51,7 +51,7 @@ Options
 :strong:`speed:` ``int``
     The speed/quality trade-off value to use. Valid values: ``1`` (slowest/best) through ``11`` (fastest/worst).
 
-:string:`dithering:` ``bool|float``
+:strong:`dithering:` ``bool|float``
     When set to ``false`` the Floyd-Steinberg dithering algorithm is completely disabled. Otherwise, when a ``float``,
     the dithering level is set.
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | `2.0`
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | o
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

This PR fixes three compilation errors that were introduced into the RST documentation at various points in the past, including:
- [`Resources/doc/configuration.rst#L83`](https://github.com/liip/LiipImagineBundle/blob/master/Resources/doc/configuration.rst#L83): __Bullet list ends without a blank line; unexpected unindent.__
- [`Resources/doc/post-processors/png-quant.rst#L56`](https://github.com/liip/LiipImagineBundle/blob/master/Resources/doc/post-processors/png-quant.rst#L56): __Unknown interpreted text role "string".__
- [`Resources/doc/cache-resolver/aws_s3.rst#L121`](https://github.com/liip/LiipImagineBundle/blob/master/Resources/doc/cache-resolver/aws_s3.rst#L121): __Could not lex literal_block as "yaml".__

As a result of the above fixed RST syntax issues, the documentation again compiled as expected without errors or warnings.
