### PR TITLE
Fix skipped functional tests with Symfony 5.x

### DIFF
--- a/Tests/Functional/AbstractSetupWebTestCase.php
+++ b/Tests/Functional/AbstractSetupWebTestCase.php
@@ -45,7 +45,7 @@ class AbstractSetupWebTestCase extends AbstractWebTestCase
 
         $this->client = $this->createClient();
         $this->client->catchExceptions(false);
-        $this->webRoot = sprintf('%s/public', self::$kernel->getContainer()->getParameter('kernel.root_dir'));
+        $this->webRoot = sprintf('%s/public', self::$kernel->getContainer()->getParameter('kernel.project_dir'));
         $this->cacheRoot = $this->webRoot.'/media/cache';
         $this->filesystem = new Filesystem();
         $this->filesystem->remove($this->cacheRoot);

--- a/Tests/Functional/AbstractWebTestCase.php
+++ b/Tests/Functional/AbstractWebTestCase.php
@@ -18,18 +18,6 @@ use Symfony\Component\BrowserKit\Client;
 abstract class AbstractWebTestCase extends WebTestCase
 {
     /**
-     * {@inheritdoc}
-     */
-    public static function createClient(array $options = [], array $server = [])
-    {
-        if (!class_exists(Client::class)) {
-            self::markTestSkipped('Requires the symfony/browser-kit package.');
-        }
-
-        return parent::createClient($options, $server);
-    }
-
-    /**
      * @return string
      */
     public static function getKernelClass()

--- a/Tests/Functional/AbstractWebTestCase.php
+++ b/Tests/Functional/AbstractWebTestCase.php
@@ -32,6 +32,10 @@ abstract class AbstractWebTestCase extends WebTestCase
      */
     protected function getService(string $name)
     {
+        if (property_exists($this, 'container')) {
+            return static::$container->get($name);
+        }
+
         return static::$kernel->getContainer()->get($name);
     }
 
@@ -40,6 +44,10 @@ abstract class AbstractWebTestCase extends WebTestCase
      */
     protected function getParameter(string $name)
     {
+        if (property_exists($this, 'container')) {
+            return static::$container->getParameter($name);
+        }
+
         return static::$kernel->getContainer()->getParameter($name);
     }
 

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -47,6 +47,11 @@ class AppKernel extends Kernel
         return sys_get_temp_dir().'/liip_imagine_test/cache/logs';
     }
 
+    public function getProjectDir()
+    {
+        return __DIR__;
+    }
+
     /**
      * @throws \Exception
      */

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -17,7 +17,7 @@ framework:
         storage_id: session.storage.mock_file
 
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/config/routing.yml"
 
 liip_imagine:
 
@@ -29,15 +29,15 @@ liip_imagine:
 
         default:
             filesystem:
-                data_root: "%kernel.root_dir%/public"
+                data_root: "%kernel.project_dir%/public"
 
         foo:
             filesystem:
-                data_root: "%kernel.root_dir%/../../Fixtures/FileSystemLocator/root-01"
+                data_root: "%kernel.project_dir%/../../Fixtures/FileSystemLocator/root-01"
 
         bar:
             filesystem:
-                data_root: "%kernel.root_dir%/../../Fixtures/FileSystemLocator/root-02"
+                data_root: "%kernel.project_dir%/../../Fixtures/FileSystemLocator/root-02"
 
         baz:
             chain:
@@ -73,7 +73,7 @@ liip_imagine:
 
         default:
             web_path:
-                web_root:     "%kernel.root_dir%/public"
+                web_root:     "%kernel.project_dir%/public"
                 cache_prefix: media/cache
 
     filter_sets:


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets |
| License | MIT
| Doc PR |

All functional teste where skipped in Symfony 5.x because of broken `symfony/browser-kit` detection.

I removed the detection as `symfony/browser-kit` is in require-dev and fixed broken tests.