### PR TITLE
Replace assertContains with assertStringContainsString

### DIFF
--- a/Tests/Imagine/Filter/PostProcessor/PngquantPostProcessorTest.php
+++ b/Tests/Imagine/Filter/PostProcessor/PngquantPostProcessorTest.php
@@ -148,8 +148,8 @@ class PngquantPostProcessorTest extends AbstractPostProcessorTestCase
         $process = $this->getPostProcessorInstance();
         $result = $process->process(new FileBinary($file, 'image/png', 'png'), $options);
 
-        $this->assertContains($expected, $result->getContent());
-        $this->assertContains($content, $result->getContent());
+        $this->assertStringContainsString($expected, $result->getContent());
+        $this->assertStringContainsString($content, $result->getContent());
 
         @unlink($file);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | 
| License | MIT
| Doc PR |

Since #1315, tests are run with PHPUnit 8.3 which deprecates `assertContains` when using strings.

This PR handle this deprecation to remove some warnings in the CI.