### PR TITLE
Remplace deprecated assertFileNotExists calls

### DIFF
--- a/Tests/Functional/Command/AbstractCommandTestCase.php
+++ b/Tests/Functional/Command/AbstractCommandTestCase.php
@@ -42,7 +42,7 @@ class AbstractCommandTestCase extends AbstractSetupWebTestCase
     {
         foreach ($images as $i) {
             foreach ($filters as $f) {
-                $this->assertFileNotExists(sprintf('%s/%s/%s', $this->cacheRoot, $f, $i));
+                $this->assertFileDoesNotExist(sprintf('%s/%s/%s', $this->cacheRoot, $f, $i));
             }
         }
     }

--- a/Tests/Functional/Controller/ImagineControllerTest.php
+++ b/Tests/Functional/Controller/ImagineControllerTest.php
@@ -52,7 +52,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
     public function testShouldResolvePopulatingCacheFirst(): void
     {
         //guard
-        $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
+        $this->assertFileDoesNotExist($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
 
         $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/images/cats.jpeg');
 
@@ -73,7 +73,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
     public function testShouldResolvePopulatingCacheFirstWebP(): void
     {
         //guard
-        $this->assertFileNotExists($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
+        $this->assertFileDoesNotExist($this->cacheRoot.'/thumbnail_web_path/images/cats.jpeg');
 
         $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/images/cats.jpeg', [], [], [
             // Accept from Google Chrome 86
@@ -173,7 +173,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $url = 'http://localhost/media/cache/resolve/'.$expectedCachePath.'?'.http_build_query($params);
 
         //guard
-        $this->assertFileNotExists($this->cacheRoot.'/'.$expectedCachePath);
+        $this->assertFileDoesNotExist($this->cacheRoot.'/'.$expectedCachePath);
 
         $this->client->request('GET', $url);
 
@@ -211,7 +211,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
         $url = 'http://localhost/media/cache/resolve/'.$expectedCachePath.'?'.http_build_query($params);
 
         //guard
-        $this->assertFileNotExists($this->cacheRoot.'/'.$expectedCachePath);
+        $this->assertFileDoesNotExist($this->cacheRoot.'/'.$expectedCachePath);
 
         $this->client->request('GET', $url, [], [], [
             // Accept from Google Chrome 86


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets |
| License | MIT
| Doc PR |

Remove a few PHPUnit warnings.