### PR TITLE
Fix markTestSkipped calls

### DIFF
--- a/Tests/Async/CacheResolvedTest.php
+++ b/Tests/Async/CacheResolvedTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CacheResolvedTest extends TestCase
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (!class_exists(EnqueueBundle::class)) {
             self::markTestSkipped('The tests are run without enqueue integration. Skip them');

--- a/Tests/Async/ResolveCacheProcessorTest.php
+++ b/Tests/Async/ResolveCacheProcessorTest.php
@@ -35,11 +35,13 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class ResolveCacheProcessorTest extends AbstractTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (!class_exists(EnqueueBundle::class)) {
             self::markTestSkipped('The tests are run without enqueue integration. Skip them');
         }
+
+        parent::setUp();
     }
 
     public function testShouldImplementProcessorInterface(): void

--- a/Tests/Async/ResolveCacheTest.php
+++ b/Tests/Async/ResolveCacheTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ResolveCacheTest extends TestCase
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (!class_exists(EnqueueBundle::class)) {
             self::markTestSkipped('The tests are run without enqueue integration. Skip them');


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets |
| License | MIT
| Doc PR |

Before when tests has to be skipped, the reason was `Test skipped because of an error in hook method`. Now the real reason is displayed (`The tests are run without enqueue integration. Skip them`).
