### PR TITLE
Not resolve WebP in CacheManager

### DIFF
--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -55,22 +55,30 @@ class CacheManager
     protected $defaultResolver;
 
     /**
+     * @var bool
+     */
+    private $webpGenerate;
+
+    /**
      * Constructs the cache manager to handle Resolvers based on the provided FilterConfiguration.
      *
      * @param string $defaultResolver
+     * @param bool   $webpGenerate
      */
     public function __construct(
         FilterConfiguration $filterConfig,
         RouterInterface $router,
         SignerInterface $signer,
         EventDispatcherInterface $dispatcher,
-        $defaultResolver = null
+        $defaultResolver = null,
+        $webpGenerate = false
     ) {
         $this->filterConfig = $filterConfig;
         $this->router = $router;
         $this->signer = $signer;
         $this->dispatcher = $dispatcher;
         $this->defaultResolver = $defaultResolver ?: 'default';
+        $this->webpGenerate = $webpGenerate;
     }
 
     /**
@@ -103,12 +111,12 @@ class CacheManager
         if (!empty($runtimeConfig)) {
             $rcPath = $this->getRuntimePath($path, $runtimeConfig);
 
-            return $this->isStored($rcPath, $filter, $resolver) ?
+            return !$this->webpGenerate && $this->isStored($rcPath, $filter, $resolver) ?
                 $this->resolve($rcPath, $filter, $resolver) :
                 $this->generateUrl($path, $filter, $runtimeConfig, $resolver, $referenceType);
         }
 
-        return $this->isStored($path, $filter, $resolver) ?
+        return !$this->webpGenerate && $this->isStored($path, $filter, $resolver) ?
             $this->resolve($path, $filter, $resolver) :
             $this->generateUrl($path, $filter, [], $resolver, $referenceType);
     }

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -126,6 +126,7 @@
             <argument type="service" id="liip_imagine.cache.signer" />
             <argument type="service" id="event_dispatcher" />
             <argument>%liip_imagine.cache.resolver.default%</argument>
+            <argument>%liip_imagine.webp.generate%</argument>
         </service>
 
         <service id="liip_imagine.filter.configuration" class="Liip\ImagineBundle\Imagine\Filter\FilterConfiguration">

--- a/Tests/Imagine/Cache/CacheManagerTest.php
+++ b/Tests/Imagine/Cache/CacheManagerTest.php
@@ -133,6 +133,42 @@ class CacheManagerTest extends AbstractTest
         $this->assertSame('http://a/path/to/an/image.png', $actualBrowserPath);
     }
 
+    public function testDefaultResolverUsedIfNoneSetOnGetBrowserPathWithWebPGenerate(): void
+    {
+        $resolver = $this->createCacheResolverInterfaceMock();
+        $resolver
+            ->expects($this->never())
+            ->method('isStored');
+        $resolver
+            ->expects($this->never())
+            ->method('resolve');
+
+        $config = $this->createFilterConfigurationMock();
+        $config
+            ->expects($this->never())
+            ->method('get');
+
+        $router = $this->createRouterInterfaceMock();
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->willReturn('/media/cache/thumbnail/cats.jpeg');
+
+        $cacheManager = new CacheManager(
+            $config,
+            $router,
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock(),
+            null,
+            true
+        );
+        $cacheManager->addResolver('default', $resolver);
+
+        $actualBrowserPath = $cacheManager->getBrowserPath('cats.jpeg', 'thumbnail');
+
+        $this->assertSame('/media/cache/thumbnail/cats.jpeg', $actualBrowserPath);
+    }
+
     public function testFilterActionUrlGeneratedAndReturnIfResolverReturnNullOnGetBrowserPath(): void
     {
         $resolver = $this->createCacheResolverInterfaceMock();
@@ -215,6 +251,48 @@ class CacheManagerTest extends AbstractTest
             $router,
             new Signer('secret'),
             $this->createEventDispatcherInterfaceMock()
+        );
+        $cacheManager->addResolver('default', $resolver);
+
+        $actualBrowserPath = $cacheManager->getBrowserPath('cats.jpeg', 'thumbnail', $runtimeConfig);
+
+        $this->assertSame('/media/cache/thumbnail/rc/VhOzTGRB/cats.jpeg', $actualBrowserPath);
+    }
+
+    public function testFilterActionUrlGeneratedAndReturnIfResolverReturnNullOnGetBrowserPathWithRuntimeConfigWithWebPGenerate(): void
+    {
+        $runtimeConfig = [
+            'thumbnail' => [
+                'size' => [100, 100],
+            ],
+        ];
+
+        $resolver = $this->createCacheResolverInterfaceMock();
+        $resolver
+            ->expects($this->never())
+            ->method('isStored');
+        $resolver
+            ->expects($this->never())
+            ->method('resolve');
+
+        $config = $this->createFilterConfigurationMock();
+        $config
+            ->expects($this->never())
+            ->method('get');
+
+        $router = $this->createRouterInterfaceMock();
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->willReturn('/media/cache/thumbnail/rc/VhOzTGRB/cats.jpeg');
+
+        $cacheManager = new CacheManager(
+            $config,
+            $router,
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock(),
+            null,
+            true
         );
         $cacheManager->addResolver('default', $resolver);
 

--- a/Tests/Imagine/Cache/CacheManagerTest.php
+++ b/Tests/Imagine/Cache/CacheManagerTest.php
@@ -31,7 +31,12 @@ class CacheManagerTest extends AbstractTest
 {
     public function testAddCacheManagerAwareResolver(): void
     {
-        $cacheManager = new CacheManager($this->createFilterConfigurationMock(), $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $this->createFilterConfigurationMock(),
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
 
         $resolver = $this->createCacheManagerAwareResolverMock();
         $resolver
@@ -58,14 +63,23 @@ class CacheManagerTest extends AbstractTest
                 'cache' => null,
             ]);
 
-        $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $config,
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
         $cacheManager->getBrowserPath('cats.jpeg', 'thumbnail');
     }
 
     public function testGetRuntimePath(): void
     {
-        $config = $this->createFilterConfigurationMock();
-        $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $this->createFilterConfigurationMock(),
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
 
         $rcPath = $cacheManager->getRuntimePath('image.jpg', [
             'thumbnail' => [
@@ -106,7 +120,12 @@ class CacheManagerTest extends AbstractTest
             ->expects($this->never())
             ->method('generate');
 
-        $cacheManager = new CacheManager($config, $router, new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $config,
+            $router,
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
         $cacheManager->addResolver('default', $resolver);
 
         $actualBrowserPath = $cacheManager->getBrowserPath('cats.jpeg', 'thumbnail');
@@ -143,7 +162,12 @@ class CacheManagerTest extends AbstractTest
             ->method('generate')
             ->willReturn('/media/cache/thumbnail/cats.jpeg');
 
-        $cacheManager = new CacheManager($config, $router, new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $config,
+            $router,
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
         $cacheManager->addResolver('default', $resolver);
 
         $actualBrowserPath = $cacheManager->getBrowserPath('cats.jpeg', 'thumbnail');
@@ -186,7 +210,12 @@ class CacheManagerTest extends AbstractTest
             ->method('generate')
             ->willReturn('/media/cache/thumbnail/rc/VhOzTGRB/cats.jpeg');
 
-        $cacheManager = new CacheManager($config, $router, new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $config,
+            $router,
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
         $cacheManager->addResolver('default', $resolver);
 
         $actualBrowserPath = $cacheManager->getBrowserPath('cats.jpeg', 'thumbnail', $runtimeConfig);
@@ -329,7 +358,12 @@ class CacheManagerTest extends AbstractTest
                 ];
             });
 
-        $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $config,
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
         $cacheManager->addResolver($expectedFilter, $resolver);
         $cacheManager->remove($expectedPath, $expectedFilter);
     }
@@ -362,7 +396,12 @@ class CacheManagerTest extends AbstractTest
                 ];
             });
 
-        $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $config,
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
         $cacheManager->addResolver($expectedFilterOne, $resolverOne);
         $cacheManager->addResolver($expectedFilterTwo, $resolverTwo);
         $cacheManager->remove($expectedPath, [$expectedFilterOne, $expectedFilterTwo]);
@@ -393,7 +432,12 @@ class CacheManagerTest extends AbstractTest
                 ];
             });
 
-        $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $config,
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
         $cacheManager->addResolver($expectedFilter, $resolver);
         $cacheManager->remove([$expectedPathOne, $expectedPathTwo], $expectedFilter);
     }
@@ -427,7 +471,12 @@ class CacheManagerTest extends AbstractTest
                 ];
             });
 
-        $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $config,
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
         $cacheManager->addResolver($expectedFilterOne, $resolverOne);
         $cacheManager->addResolver($expectedFilterTwo, $resolverTwo);
         $cacheManager->remove(
@@ -470,7 +519,12 @@ class CacheManagerTest extends AbstractTest
                 $expectedFilterTwo => [],
             ]);
 
-        $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $config,
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
         $cacheManager->addResolver($expectedFilterOne, $resolverOne);
         $cacheManager->addResolver($expectedFilterTwo, $resolverTwo);
         $cacheManager->remove();
@@ -511,7 +565,12 @@ class CacheManagerTest extends AbstractTest
                 $expectedFilterTwo => [],
             ]);
 
-        $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $config,
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
         $cacheManager->addResolver($expectedFilterOne, $resolverOne);
         $cacheManager->addResolver($expectedFilterTwo, $resolverTwo);
         $cacheManager->remove($expectedPath);
@@ -538,7 +597,12 @@ class CacheManagerTest extends AbstractTest
                 ];
             });
 
-        $cacheManager = new CacheManager($config, $this->createRouterInterfaceMock(), new Signer('secret'), $this->createEventDispatcherInterfaceMock());
+        $cacheManager = new CacheManager(
+            $config,
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock()
+        );
         $cacheManager->addResolver($expectedFilterOne, $resolver);
         $cacheManager->addResolver($expectedFilterTwo, $resolver);
         $cacheManager->remove(null, [$expectedFilterOne, $expectedFilterTwo]);


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Fix problem described in #1319

> Given the following code:
> 
> ```twig
> <img src="{{ asset('DSC_3644.JPG') | imagine_filter('thumbnail') }}" alt="DSC_3644.JPG" />
> ```
> 
> When there is no cache, the src value is https://localhost:8000/media/cache/resolve/thumbnail/DSC_3644.JPG which is handled by the ImagineController and redirect to https://localhost:8000/media/cache/thumbnail/DSC_3644.JPG.webp
> 
> When the cache is warmed, the src value is https://127.0.0.1:8000/media/cache/thumbnail/DSC_3644.JPG which is not handled by the ImagineController and returns the JPEG version of the image.

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->