### PR TITLE
Run static code analysis on GitHub Actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 * text=auto
 /.travis/ export-ignore
 /.github/ export-ignore
+/.phpstan/ export-ignore
 /Tests/ export-ignore
 /.coveralls.yml export-ignore
 /.gitattributes export-ignore
@@ -9,4 +10,5 @@
 /.scrutinizer.yml export-ignore
 /.styleci.yml export-ignore
 /.travis.yml export-ignore
+/.phpstan.neon.dist export-ignore
 /.phpunit.xml.dist export-ignore

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,24 @@
+name: PHPStan
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: Update project dependencies
+        uses: ramsey/composer-install@v1
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyze

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /bin/
 /composer.lock
 /composer.phar
+/phpstan.neon
 /phpunit.xml
 /Tests/Functional/app/public/media/cache
 /Tests/Functional/app/web/media/cache

--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -1,0 +1,9 @@
+parameters:
+    ignoreErrors:
+        - message: '#^Access to undefined constant Liip\\ImagineBundle\\Config\\Filter\\Type\\FilterAbstract::NAME\.$#'
+          paths:
+              - ../Config/Filter/Type/FilterAbstract.php
+        - message: '#^Unsafe usage of new static\(\)\.$#'
+          paths:
+              - ../Async/CacheResolved.php
+              - ../Async/ResolveCache.php

--- a/.phpstan/stubs/Event.stub
+++ b/.phpstan/stubs/Event.stub
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+/**
+ * @deprecated since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead
+ */
+class Event
+{
+    private $propagationStopped = false;
+
+    /**
+     * @return bool Whether propagation was already stopped for this event
+     *
+     * @deprecated since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead
+     */
+    public function isPropagationStopped()
+    {
+        return $this->propagationStopped;
+    }
+
+    /**
+     * @deprecated since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead
+     */
+    public function stopPropagation()
+    {
+        $this->propagationStopped = true;
+    }
+}

--- a/.phpstan/stubs/ExtensionGuesserInterface.stub
+++ b/.phpstan/stubs/ExtensionGuesserInterface.stub
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\File\MimeType;
+
+use Symfony\Component\Mime\MimeTypesInterface;
+
+/**
+ * Guesses the file extension corresponding to a given mime type.
+ *
+ * @deprecated since Symfony 4.3, use {@link MimeTypesInterface} instead
+ */
+interface ExtensionGuesserInterface
+{
+    /**
+     * Makes a best guess for a file extension, given a mime type.
+     *
+     * @param string $mimeType The mime type
+     *
+     * @return string The guessed extension or NULL, if none could be guessed
+     */
+    public function guess($mimeType);
+}

--- a/.phpstan/stubs/MimeTypeGuesserInterface.stub
+++ b/.phpstan/stubs/MimeTypeGuesserInterface.stub
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\File\MimeType;
+
+use Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException;
+use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
+use Symfony\Component\Mime\MimeTypesInterface;
+
+/**
+ * Guesses the mime type of a file.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated since Symfony 4.3, use {@link MimeTypesInterface} instead
+ */
+interface MimeTypeGuesserInterface
+{
+    /**
+     * Guesses the mime type of the file with the given path.
+     *
+     * @param string $path The path to the file
+     *
+     * @return string|null The mime type or NULL, if none could be guessed
+     *
+     * @throws FileNotFoundException If the file does not exist
+     * @throws AccessDeniedException If the file could not be read
+     */
+    public function guess($path);
+}

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "doctrine/persistence": "^1.3",
         "enqueue/enqueue-bundle": "^0.9|^0.10",
         "league/flysystem": "^1.0",
+        "phpstan/phpstan": "^0.12.64",
         "psr/log": "^1.0",
         "symfony/browser-kit": "^3.4|^4.3|^5.0",
         "symfony/console": "^3.4|^4.3|^5.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,27 @@
+includes:
+    - .phpstan/baseline.neon
+parameters:
+    level: 1
+    paths:
+        - Async
+        - Binary
+        - Command
+        - Component
+        - Config
+        - Controller
+        - DependencyInjection
+        - Events
+        - Exception
+        - Factory
+        - Form
+        - Imagine
+        - Model
+        - Resources
+        - Service
+        - Templating
+        - Utility
+        - LiipImagineBundle.php
+    scanFiles:
+        - .phpstan/stubs/Event.stub
+        - .phpstan/stubs/ExtensionGuesserInterface.stub
+        - .phpstan/stubs/MimeTypeGuesserInterface.stub


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets |
| License | MIT
| Doc PR |
 
As discussed with @dbu, here is a PR to replace most of Scrutinizer work with static code analysis.

I choose PHPStan as I use it daily at work and it's the tool used by SonataAdminBundle which is my main source of inspiration for all my GitHub Actions PRs.