### PR TITLE
Depend on doctrine/persistence instead of doctrine/orm

### DIFF
--- a/Tests/Binary/Loader/AbstractDoctrineLoaderTest.php
+++ b/Tests/Binary/Loader/AbstractDoctrineLoaderTest.php
@@ -34,10 +34,6 @@ class AbstractDoctrineLoaderTest extends TestCase
 
     public function setUp(): void
     {
-        if (!interface_exists(ObjectManager::class)) {
-            $this->markTestSkipped('Requires the doctrine/orm package.');
-        }
-
         $this->om = $this
             ->getMockBuilder(ObjectManager::class)
             ->getMock();

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "amazonwebservices/aws-sdk-for-php": "^1.0",
         "aws/aws-sdk-php": "^2.4",
         "doctrine/cache": "^1.1",
-        "doctrine/orm": "^2.3",
+        "doctrine/persistence": "^1.3",
         "enqueue/enqueue-bundle": "^0.9|^0.10",
         "friendsofphp/php-cs-fixer": "^2.10",
         "league/flysystem": "^1.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets |
| License | MIT
| Doc PR |

This use the right `require-dev` dependency for `AbstractDoctrineLoader`.

This make PHPStan happy (#1336), remove some skipped tests and split off some work of #1305.