### PR TITLE
Fix unsafe usages of new static().

### DIFF
--- a/Async/CacheResolved.php
+++ b/Async/CacheResolved.php
@@ -77,6 +77,6 @@ class CacheResolved implements \JsonSerializable
             throw new LogicException('The message uris must not be empty array.');
         }
 
-        return new static($data['path'], $data['uris']);
+        return new self($data['path'], $data['uris']);
     }
 }

--- a/Async/ResolveCache.php
+++ b/Async/ResolveCache.php
@@ -92,6 +92,6 @@ class ResolveCache implements \JsonSerializable
             throw new LogicException('The message filters could be either null or array.');
         }
 
-        return new static($data['path'], $data['filters'], $data['force']);
+        return new self($data['path'], $data['filters'], $data['force']);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | ?
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets |
| License | MIT
| Doc PR |

PHPStan (#1336) complains about those two `new static` calls.

I'd like to have your opinion to know if it is a BC break or not.