### PR TITLE
Correct comment of unsecured connection

### DIFF
--- a/Resources/doc/basic-usage.rst
+++ b/Resources/doc/basic-usage.rst
@@ -266,7 +266,7 @@ otherwise to ``https://localhost/media/cache/thumbnail_web_path/images/cats.jpeg
 
 .. note::
 
-    Using an unsecured connection (HTTPS) on your site can cause problems with
+    Using an unsecured connection (non HTTPS) on your site can cause problems with
     caching the resolved paths for users, which can lead to the fact that users
     whose browser does not support WebP will serve a picture in WebP format.
     You can fix this problem by changing the redirect code from 301 *(Moved


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->


Fix problem discussed in https://github.com/liip/LiipImagineBundle/pull/1334#discussion_r551227757

```diff
-- unsecured connection (HTTPS)
++ unsecured connection (non HTTPS)
```
<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->