### PR TITLE
Generate WebP in liip:imagine:cache:resolve CLI command and async resolve cache messages

### DIFF
--- a/Async/ResolveCacheProcessor.php
+++ b/Async/ResolveCacheProcessor.php
@@ -57,10 +57,9 @@ final class ResolveCacheProcessor implements Processor, CommandSubscriberInterfa
             $filters = $message->getFilters() ?: array_keys($this->filterManager->getFilterConfiguration()->all());
             $path = $message->getPath();
             $results = [];
+
             foreach ($filters as $filter) {
-                if ($message->isForce()) {
-                    $this->filterService->bustCache($path, $filter);
-                }
+                $this->filterService->warmsUpCache($path, $filter, null, $message->isForce());
 
                 $results[$filter] = $this->filterService->getUrlOfFilteredImage($path, $filter);
             }

--- a/Async/ResolveCacheProcessor.php
+++ b/Async/ResolveCacheProcessor.php
@@ -59,7 +59,7 @@ final class ResolveCacheProcessor implements Processor, CommandSubscriberInterfa
             $results = [];
 
             foreach ($filters as $filter) {
-                $this->filterService->warmsUpCache($path, $filter, null, $message->isForce());
+                $this->filterService->warmUpCache($path, $filter, null, $message->isForce());
 
                 $results[$filter] = $this->filterService->getUrlOfFilteredImage($path, $filter);
             }

--- a/Command/ResolveCacheCommand.php
+++ b/Command/ResolveCacheCommand.php
@@ -146,9 +146,9 @@ EOF
                 } else {
                     $this->io->status('cached', 'white');
                 }
-            }
 
-            $this->io->line(sprintf(' %s', $this->cacheManager->resolve($image, $filter)));
+                $this->io->line(sprintf(' %s', $this->cacheManager->resolve($filterPathContainer->getTarget(), $filter)));
+            }
         } catch (\Exception $e) {
             ++$this->failures;
 

--- a/Command/ResolveCacheCommand.php
+++ b/Command/ResolveCacheCommand.php
@@ -111,7 +111,7 @@ EOF
         $this->io->group($image, $filter, 'blue');
 
         try {
-            if ($this->filterService->warmsUpCache($image, $filter, null, $forced)) {
+            if ($this->filterService->warmUpCache($image, $filter, null, $forced)) {
                 $this->io->status('resolved', 'green');
             } else {
                 $this->io->status('cached', 'white');

--- a/Message/Handler/WarmupCacheHandler.php
+++ b/Message/Handler/WarmupCacheHandler.php
@@ -41,9 +41,7 @@ class WarmupCacheHandler implements MessageHandlerInterface
         $path = $message->getPath();
 
         foreach ($filters as $filter) {
-            if ($message->isForce()) {
-                $this->filterService->bustCache($path, $filter);
-            }
+            $this->filterService->warmUpCache($path, $filter, null, $message->isForce());
 
             $this->filterService->getUrlOfFilteredImage($path, $filter);
         }

--- a/Resources/config/commands.xml
+++ b/Resources/config/commands.xml
@@ -8,15 +8,14 @@
         <service id="liip_imagine.command.cache_remove" class="Liip\ImagineBundle\Command\RemoveCacheCommand">
             <argument type="service" id="liip_imagine.cache.manager" />
             <argument type="service" id="liip_imagine.filter.manager" />
+            <argument type="service" id="liip_imagine.service.filter" />
             <tag name="console.command" command="liip:imagine:cache:remove" alias="imagine:del" />
         </service>
 
         <service id="liip_imagine.command.cache_resolve" class="Liip\ImagineBundle\Command\ResolveCacheCommand">
-            <argument type="service" id="liip_imagine.data.manager" />
             <argument type="service" id="liip_imagine.cache.manager" />
             <argument type="service" id="liip_imagine.filter.manager" />
-            <argument>%liip_imagine.webp.generate%</argument>
-            <argument>%liip_imagine.webp.options%</argument>
+            <argument type="service" id="liip_imagine.service.filter" />
             <tag name="console.command" command="liip:imagine:cache:resolve" alias="imagine:get" />
         </service>
 

--- a/Resources/config/commands.xml
+++ b/Resources/config/commands.xml
@@ -15,6 +15,8 @@
             <argument type="service" id="liip_imagine.data.manager" />
             <argument type="service" id="liip_imagine.cache.manager" />
             <argument type="service" id="liip_imagine.filter.manager" />
+            <argument>%liip_imagine.webp.generate%</argument>
+            <argument>%liip_imagine.webp.options%</argument>
             <tag name="console.command" command="liip:imagine:cache:resolve" alias="imagine:get" />
         </service>
 

--- a/Service/FilterService.php
+++ b/Service/FilterService.php
@@ -47,7 +47,7 @@ class FilterService
     private $webpGenerate;
 
     /**
-     * @var array
+     * @var mixed[]
      */
     private $webpOptions;
 

--- a/Service/FilterService.php
+++ b/Service/FilterService.php
@@ -71,7 +71,7 @@ class FilterService
      * @param string $path
      * @param string $filter
      *
-     * @return bool Returns true if the cache is busted
+     * @return bool Returns true if we removed at least one cached image
      */
     public function bustCache($path, $filter)
     {

--- a/Service/FilterService.php
+++ b/Service/FilterService.php
@@ -93,7 +93,7 @@ class FilterService
      *
      * @return bool Returns true if the cache is warmed up
      */
-    public function warmsUpCache(
+    public function warmUpCache(
         string $path,
         string $filter,
         ?string $resolver = null,
@@ -102,7 +102,7 @@ class FilterService
         $warmedUp = false;
 
         foreach ($this->buildFilterPathContainers($path) as $filterPathContainer) {
-            if ($this->warmsUpCacheFilterPathContainer($filterPathContainer, $filter, $resolver, $forced)) {
+            if ($this->warmUpCacheFilterPathContainer($filterPathContainer, $filter, $resolver, $forced)) {
                 $warmedUp = true;
             }
         }
@@ -120,7 +120,7 @@ class FilterService
     public function getUrlOfFilteredImage($path, $filter, $resolver = null, bool $webpSupported = false)
     {
         foreach ($this->buildFilterPathContainers($path) as $filterPathContainer) {
-            $this->warmsUpCacheFilterPathContainer($filterPathContainer, $filter, $resolver);
+            $this->warmUpCacheFilterPathContainer($filterPathContainer, $filter, $resolver);
         }
 
         return $this->resolveFilterPathContainer(new FilterPathContainer($path), $filter, $resolver, $webpSupported);
@@ -146,7 +146,7 @@ class FilterService
         ];
 
         foreach ($this->buildFilterPathContainers($path, $runtimePath, $runtimeOptions) as $filterPathContainer) {
-            $this->warmsUpCacheFilterPathContainer($filterPathContainer, $filter, $resolver);
+            $this->warmUpCacheFilterPathContainer($filterPathContainer, $filter, $resolver);
         }
 
         return $this->resolveFilterPathContainer(
@@ -194,7 +194,7 @@ class FilterService
      *
      * @return bool Returns true if the cache is warmed up
      */
-    private function warmsUpCacheFilterPathContainer(
+    private function warmUpCacheFilterPathContainer(
         FilterPathContainer $filterPathContainer,
         string $filter,
         ?string $resolver = null,

--- a/Tests/Async/ResolveCacheProcessorTest.php
+++ b/Tests/Async/ResolveCacheProcessorTest.php
@@ -294,6 +294,7 @@ class ResolveCacheProcessorTest extends AbstractTest
 
     public function testShouldBurstCacheWhenResolvingForced(): void
     {
+        $force = true;
         $filterName = 'fooFilter';
         $imagePath = 'theImagePath';
 
@@ -308,8 +309,8 @@ class ResolveCacheProcessorTest extends AbstractTest
         $filterServiceMock = $this->createFilterServiceMock();
         $filterServiceMock
             ->expects($this->once())
-            ->method('bustCache')
-            ->with($imagePath, $filterName);
+            ->method('warmsUpCache')
+            ->with($imagePath, $filterName, null, $force);
 
         $processor = new ResolveCacheProcessor(
             $filterManagerMock,
@@ -318,7 +319,7 @@ class ResolveCacheProcessorTest extends AbstractTest
         );
 
         $message = new NullMessage();
-        $message->setBody(json_encode(['path' => $imagePath, 'force' => true]));
+        $message->setBody(json_encode(['path' => $imagePath, 'force' => $force]));
 
         $result = $processor->process($message, new NullContext());
 

--- a/Tests/Async/ResolveCacheProcessorTest.php
+++ b/Tests/Async/ResolveCacheProcessorTest.php
@@ -309,7 +309,7 @@ class ResolveCacheProcessorTest extends AbstractTest
         $filterServiceMock = $this->createFilterServiceMock();
         $filterServiceMock
             ->expects($this->once())
-            ->method('warmsUpCache')
+            ->method('warmUpCache')
             ->with($imagePath, $filterName, null, $force);
 
         $processor = new ResolveCacheProcessor(

--- a/Tests/Service/FilterPathContainerTest.php
+++ b/Tests/Service/FilterPathContainerTest.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+namespace Liip\ImagineBundle\Tests\Service;
+
+use Liip\ImagineBundle\Service\FilterPathContainer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Liip\ImagineBundle\Service\FilterPathContainer
+ */
+final class FilterPathContainerTest extends TestCase
+{
+    public function testWithEmptyTarget(): void
+    {
+        $source = 'cats.jpeg';
+        $options = [];
+
+        $container = new FilterPathContainer($source);
+
+        $this->assertSame($source, $container->getSource());
+        $this->assertSame($source, $container->getTarget());
+        $this->assertSame($options, $container->getOptions());
+    }
+
+    public function testCustomTarget(): void
+    {
+        $source = 'cats.jpeg';
+        $target = 'cats.jpeg.webp';
+        $options = [
+            'format' => 'webp',
+        ];
+
+        $container = new FilterPathContainer($source, $target, $options);
+
+        $this->assertSame($source, $container->getSource());
+        $this->assertSame($target, $container->getTarget());
+        $this->assertSame($options, $container->getOptions());
+    }
+
+    public function provideWebpOptions(): \Traversable
+    {
+        yield 'empty options' => [
+            [],
+            [],
+            [
+                'format' => 'webp',
+            ],
+        ];
+
+        yield 'custom webp options' => [
+            [],
+            [
+                'quality' => 100,
+            ],
+            [
+                'format' => 'webp',
+                'quality' => 100,
+            ],
+        ];
+
+        yield 'overwrite base options' => [
+            [
+                'format' => 'jpeg',
+                'quality' => 80,
+                'jpeg_quality' => 80,
+                'post_processors' => [
+                    'jpegoptim' => [
+                        'strip_all' => true,
+                        'max' => 80,
+                        'progressive' => true,
+                    ],
+                ],
+            ],
+            [
+                'quality' => 100,
+                'post_processors' => [
+                    'my_custom_webp_post_processor' => [],
+                ],
+            ],
+            [
+                'format' => 'webp',
+                'quality' => 100,
+                'post_processors' => [
+                    'my_custom_webp_post_processor' => [],
+                ],
+                'jpeg_quality' => 80,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideWebpOptions
+     */
+    public function testCreateWebp(array $baseOptions, array $webpOptions, array $expectedOptions): void
+    {
+        $source = 'cats.jpeg';
+        $target = 'cats.jpeg.webp';
+
+        $container = (new FilterPathContainer($source, '', $baseOptions))->createWebp($webpOptions);
+
+        $this->assertSame($source, $container->getSource());
+        $this->assertSame($target, $container->getTarget());
+        $this->assertSame($expectedOptions, $container->getOptions());
+    }
+}

--- a/Tests/Service/FilterPathContainerTest.php
+++ b/Tests/Service/FilterPathContainerTest.php
@@ -1,5 +1,13 @@
 <?php
-declare(strict_types=1);
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
 
 namespace Liip\ImagineBundle\Tests\Service;
 
@@ -13,7 +21,7 @@ final class FilterPathContainerTest extends TestCase
 {
     public function testWithEmptyTarget(): void
     {
-        $source = 'cats.jpeg';
+        $source = 'images/cats.jpeg';
         $options = [];
 
         $container = new FilterPathContainer($source);
@@ -25,8 +33,8 @@ final class FilterPathContainerTest extends TestCase
 
     public function testCustomTarget(): void
     {
-        $source = 'cats.jpeg';
-        $target = 'cats.jpeg.webp';
+        $source = 'images/cats.jpeg';
+        $target = 'images/cats.jpeg.webp';
         $options = [
             'format' => 'webp',
         ];
@@ -94,8 +102,8 @@ final class FilterPathContainerTest extends TestCase
      */
     public function testCreateWebp(array $baseOptions, array $webpOptions, array $expectedOptions): void
     {
-        $source = 'cats.jpeg';
-        $target = 'cats.jpeg.webp';
+        $source = 'images/cats.jpeg';
+        $target = 'images/cats.jpeg.webp';
 
         $container = (new FilterPathContainer($source, '', $baseOptions))->createWebp($webpOptions);
 

--- a/Tests/Service/FilterServiceTest.php
+++ b/Tests/Service/FilterServiceTest.php
@@ -1,0 +1,764 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Service;
+
+use Liip\ImagineBundle\Binary\BinaryInterface;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Liip\ImagineBundle\Imagine\Data\DataManager;
+use Liip\ImagineBundle\Imagine\Filter\FilterManager;
+use Liip\ImagineBundle\Service\FilterService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers \Liip\ImagineBundle\Service\FilterService
+ */
+final class FilterServiceTest extends TestCase
+{
+    private const SOURCE_IMAGE = '/images/cats.jpeg';
+    private const WEBP_IMAGE = '/images/cats.jpeg.webp';
+    private const RUNTIME_IMAGE = '/filter_hash/images/cats.jpeg';
+    private const RUNTIME_WEBP_IMAGE = '/filter_hash/images/cats.jpeg.webp';
+    private const FILTER = 'thumbnail_web_path';
+    private const RUNTIME_FILTERS = [
+        'thumbnail' => [
+            'size' => [50, 50],
+        ],
+    ];
+    private const WEBP_OPTIONS = [
+        'quality' => 100,
+        'post_processors' => [
+            'my_custom_webp_post_processor' => [],
+        ],
+    ];
+
+    /**
+     * @var MockObject|DataManager
+     */
+    private $dataManager;
+
+    /**
+     * @var MockObject|FilterManager
+     */
+    private $filterManager;
+
+    /**
+     * @var MockObject|CacheManager
+     */
+    private $cacheManager;
+
+    /**
+     * @var MockObject|LoggerInterface
+     */
+    private $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dataManager = $this
+            ->getMockBuilder(DataManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->filterManager = $this
+            ->getMockBuilder(FilterManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->cacheManager = $this
+            ->getMockBuilder(CacheManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->logger = $this
+            ->getMockBuilder(LoggerInterface::class)
+            ->getMock();
+    }
+
+    public function provideWebpGeneration(): \Traversable
+    {
+        yield 'WebP generation enabled' => [true];
+
+        yield 'WebP generation disabled' => [false];
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testBustCache(bool $webpGenerate): void
+    {
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::SOURCE_IMAGE],
+                [self::WEBP_IMAGE]
+            )
+            ->willReturn(true);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('remove')
+            ->withConsecutive(
+                [self::SOURCE_IMAGE, self::FILTER],
+                [self::WEBP_IMAGE, self::FILTER]
+            );
+
+        $this->assertTrue($service->bustCache(self::SOURCE_IMAGE, self::FILTER));
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testNothingBustCache(bool $webpGenerate): void
+    {
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::SOURCE_IMAGE],
+                [self::WEBP_IMAGE]
+            )
+            ->willReturn(false);
+        $this->cacheManager
+            ->expects($this->never())
+            ->method('remove');
+
+        $this->assertFalse($service->bustCache(self::SOURCE_IMAGE, self::FILTER));
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testWarmsUpCache(bool $webpGenerate): void
+    {
+        $resolver = null;
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::SOURCE_IMAGE, self::FILTER, $resolver],
+                [self::WEBP_IMAGE, self::FILTER, $resolver]
+            )
+            ->willReturn(true);
+        $this->cacheManager
+            ->expects($this->never())
+            ->method('store');
+
+        $this->dataManager
+            ->expects($this->never())
+            ->method('find');
+
+        $this->filterManager
+            ->expects($this->never())
+            ->method('applyFilter');
+
+        $this->assertFalse($service->warmsUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver));
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testWarmsUpCacheForced(bool $webpGenerate): void
+    {
+        $resolver = null;
+        $binary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+        $filteredBinary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->never())
+            ->method('isStored');
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('store')
+            ->withConsecutive(
+                [$filteredBinary, self::SOURCE_IMAGE, self::FILTER, $resolver],
+                [$filteredBinary, self::WEBP_IMAGE, self::FILTER, $resolver]
+            );
+
+        $this->dataManager
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->with(self::FILTER, self::SOURCE_IMAGE)
+            ->willReturn($binary);
+
+        $this->filterManager
+            ->expects($this->atLeastOnce())
+            ->method('applyFilter')
+            ->withConsecutive(
+                [$binary, self::FILTER, []],
+                [$binary, self::FILTER, [
+                    'format' => 'webp',
+                ] + self::WEBP_OPTIONS]
+            )
+            ->willReturn($binary);
+
+        $this->assertTrue($service->warmsUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver, true));
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testWarmsUpCacheNotStored(bool $webpGenerate): void
+    {
+        $resolver = null;
+        $binary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+        $filteredBinary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::SOURCE_IMAGE, self::FILTER, $resolver],
+                [self::WEBP_IMAGE, self::FILTER, $resolver]
+            )
+            ->willReturn(false);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('store')
+            ->withConsecutive(
+                [$filteredBinary, self::SOURCE_IMAGE, self::FILTER, $resolver],
+                [$filteredBinary, self::WEBP_IMAGE, self::FILTER, $resolver]
+            );
+
+        $this->dataManager
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->with(self::FILTER, self::SOURCE_IMAGE)
+            ->willReturn($binary);
+
+        $this->filterManager
+            ->expects($this->atLeastOnce())
+            ->method('applyFilter')
+            ->withConsecutive(
+                [$binary, self::FILTER, []],
+                [$binary, self::FILTER, [
+                    'format' => 'webp',
+                ] + self::WEBP_OPTIONS]
+            )
+            ->willReturn($binary);
+
+        $this->assertTrue($service->warmsUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver));
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testWarmsUpCacheNotStoredForced(bool $webpGenerate): void
+    {
+        $resolver = null;
+        $binary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+        $filteredBinary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->never())
+            ->method('isStored');
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('store')
+            ->withConsecutive(
+                [$filteredBinary, self::SOURCE_IMAGE, self::FILTER, $resolver],
+                [$filteredBinary, self::WEBP_IMAGE, self::FILTER, $resolver]
+            );
+
+        $this->dataManager
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->with(self::FILTER, self::SOURCE_IMAGE)
+            ->willReturn($binary);
+
+        $this->filterManager
+            ->expects($this->atLeastOnce())
+            ->method('applyFilter')
+            ->withConsecutive(
+                [$binary, self::FILTER, []],
+                [$binary, self::FILTER, [
+                        'format' => 'webp',
+                    ] + self::WEBP_OPTIONS]
+            )
+            ->willReturn($binary);
+
+        $this->assertTrue($service->warmsUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver, true));
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testGetUrlOfFilteredImage(bool $webpGenerate): void
+    {
+        $resolver = null;
+        $url = 'https://example.com/cache'.self::SOURCE_IMAGE;
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::SOURCE_IMAGE, self::FILTER, $resolver],
+                [self::WEBP_IMAGE, self::FILTER, $resolver]
+            )
+            ->willReturn(true);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('resolve')
+            ->with(self::SOURCE_IMAGE, self::FILTER, $resolver)
+            ->willReturn($url);
+        $this->cacheManager
+            ->expects($this->never())
+            ->method('store');
+
+        $this->dataManager
+            ->expects($this->never())
+            ->method('find');
+
+        $this->filterManager
+            ->expects($this->never())
+            ->method('applyFilter');
+
+        $this->assertSame($url, $service->getUrlOfFilteredImage(self::SOURCE_IMAGE, self::FILTER, $resolver));
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testGetUrlOfFilteredImageWebpSupported(bool $webpGenerate): void
+    {
+        $resolver = null;
+        $url = 'https://example.com/cache'.self::WEBP_IMAGE;
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::SOURCE_IMAGE, self::FILTER, $resolver],
+                [self::WEBP_IMAGE, self::FILTER, $resolver]
+            )
+            ->willReturn(true);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('resolve')
+            ->with(self::WEBP_IMAGE, self::FILTER, $resolver)
+            ->willReturn($url);
+
+        $this->cacheManager
+            ->expects($this->never())
+            ->method('store');
+
+        $this->dataManager
+            ->expects($this->never())
+            ->method('find');
+
+        $this->filterManager
+            ->expects($this->never())
+            ->method('applyFilter');
+
+        $this->assertSame($url, $service->getUrlOfFilteredImage(self::SOURCE_IMAGE, self::FILTER, $resolver, true));
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testGetUrlOfFilteredImageNotStored(bool $webpGenerate): void
+    {
+        $resolver = null;
+        $url = 'https://example.com/cache'.self::SOURCE_IMAGE;
+        $binary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+        $filteredBinary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::SOURCE_IMAGE, self::FILTER, $resolver],
+                [self::WEBP_IMAGE, self::FILTER, $resolver]
+            )
+            ->willReturn(false);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('store')
+            ->withConsecutive(
+                [$filteredBinary, self::SOURCE_IMAGE, self::FILTER, $resolver],
+                [$filteredBinary, self::WEBP_IMAGE, self::FILTER, $resolver]
+            );
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('resolve')
+            ->with(self::SOURCE_IMAGE, self::FILTER, $resolver)
+            ->willReturn($url);
+
+        $this->dataManager
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->with(self::FILTER, self::SOURCE_IMAGE)
+            ->willReturn($binary);
+
+        $this->filterManager
+            ->expects($this->atLeastOnce())
+            ->method('applyFilter')
+            ->withConsecutive(
+                [$binary, self::FILTER, []],
+                [$binary, self::FILTER, [
+                    'format' => 'webp',
+                ] + self::WEBP_OPTIONS]
+            )
+            ->willReturn($binary);
+
+        $this->assertSame($url, $service->getUrlOfFilteredImage(self::SOURCE_IMAGE, self::FILTER, $resolver));
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testGetUrlOfFilteredImageNotStoredWebpSupported(bool $webpGenerate): void
+    {
+        $resolver = null;
+        $url = 'https://example.com/cache'.self::WEBP_IMAGE;
+        $binary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+        $filteredBinary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::SOURCE_IMAGE, self::FILTER, $resolver],
+                [self::WEBP_IMAGE, self::FILTER, $resolver]
+            )
+            ->willReturn(false);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('store')
+            ->withConsecutive(
+                [$filteredBinary, self::SOURCE_IMAGE, self::FILTER, $resolver],
+                [$filteredBinary, self::WEBP_IMAGE, self::FILTER, $resolver]
+            );
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('resolve')
+            ->with(self::WEBP_IMAGE, self::FILTER, $resolver)
+            ->willReturn($url);
+
+        $this->dataManager
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->with(self::FILTER, self::SOURCE_IMAGE)
+            ->willReturn($binary);
+
+        $this->filterManager
+            ->expects($this->atLeastOnce())
+            ->method('applyFilter')
+            ->withConsecutive(
+                [$binary, self::FILTER, []],
+                [$binary, self::FILTER, [
+                    'format' => 'webp',
+                ] + self::WEBP_OPTIONS]
+            )
+            ->willReturn($binary);
+
+        $this->assertSame($url, $service->getUrlOfFilteredImage(self::SOURCE_IMAGE, self::FILTER, $resolver, true));
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testGetUrlOfFilteredWithRuntimeFiltersImage(bool $webpGenerate): void
+    {
+        $resolver = null;
+        $url = 'https://example.com/cache'.self::RUNTIME_IMAGE;
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::RUNTIME_IMAGE, self::FILTER, $resolver],
+                [self::RUNTIME_WEBP_IMAGE, self::FILTER, $resolver]
+            )
+            ->willReturn(true);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('resolve')
+            ->with(self::RUNTIME_IMAGE, self::FILTER, $resolver)
+            ->willReturn($url);
+        $this->cacheManager
+            ->expects($this->never())
+            ->method('store');
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('getRuntimePath')
+            ->with(self::SOURCE_IMAGE, self::RUNTIME_FILTERS)
+            ->willReturn(self::RUNTIME_IMAGE);
+
+        $this->dataManager
+            ->expects($this->never())
+            ->method('find');
+
+        $this->filterManager
+            ->expects($this->never())
+            ->method('applyFilter');
+
+        $result = $service->getUrlOfFilteredImageWithRuntimeFilters(
+            self::SOURCE_IMAGE,
+            self::FILTER,
+            self::RUNTIME_FILTERS,
+            $resolver
+        );
+
+        $this->assertSame($url, $result);
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testGetUrlOfFilteredImageWithRuntimeFiltersWebpSupported(bool $webpGenerate): void
+    {
+        $resolver = null;
+        $url = 'https://example.com/cache'.self::RUNTIME_WEBP_IMAGE;
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::RUNTIME_IMAGE, self::FILTER, $resolver],
+                [self::RUNTIME_WEBP_IMAGE, self::FILTER, $resolver]
+            )
+            ->willReturn(true);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('resolve')
+            ->with(self::RUNTIME_WEBP_IMAGE, self::FILTER, $resolver)
+            ->willReturn($url);
+        $this->cacheManager
+            ->expects($this->never())
+            ->method('store');
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('getRuntimePath')
+            ->with(self::SOURCE_IMAGE, self::RUNTIME_FILTERS)
+            ->willReturn(self::RUNTIME_IMAGE);
+
+        $this->dataManager
+            ->expects($this->never())
+            ->method('find');
+
+        $this->filterManager
+            ->expects($this->never())
+            ->method('applyFilter');
+
+        $result = $service->getUrlOfFilteredImageWithRuntimeFilters(
+            self::SOURCE_IMAGE,
+            self::FILTER,
+            self::RUNTIME_FILTERS,
+            $resolver,
+            true
+        );
+
+        $this->assertSame($url, $result);
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testGetUrlOfFilteredImageWithRuntimeFiltersNotStored(bool $webpGenerate): void
+    {
+        $resolver = null;
+        $url = 'https://example.com/cache'.self::RUNTIME_IMAGE;
+        $runtimeOptions = [
+            'filters' => self::RUNTIME_FILTERS,
+        ];
+        $binary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+        $filteredBinary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::RUNTIME_IMAGE, self::FILTER, $resolver],
+                [self::RUNTIME_WEBP_IMAGE, self::FILTER, $resolver]
+            )
+            ->willReturn(false);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('store')
+            ->withConsecutive(
+                [$filteredBinary, self::RUNTIME_IMAGE, self::FILTER, $resolver],
+                [$filteredBinary, self::RUNTIME_WEBP_IMAGE, self::FILTER, $resolver]
+            );
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('resolve')
+            ->with(self::RUNTIME_IMAGE, self::FILTER, $resolver)
+            ->willReturn($url);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('getRuntimePath')
+            ->with(self::SOURCE_IMAGE, self::RUNTIME_FILTERS)
+            ->willReturn(self::RUNTIME_IMAGE);
+
+        $this->dataManager
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->with(self::FILTER, self::SOURCE_IMAGE)
+            ->willReturn($binary);
+
+        $this->filterManager
+            ->expects($this->atLeastOnce())
+            ->method('applyFilter')
+            ->withConsecutive(
+                [$binary, self::FILTER, $runtimeOptions],
+                [$binary, self::FILTER, [
+                    'format' => 'webp',
+                ] + self::WEBP_OPTIONS + $runtimeOptions]
+            )
+            ->willReturn($binary);
+
+        $result = $service->getUrlOfFilteredImageWithRuntimeFilters(
+            self::SOURCE_IMAGE,
+            self::FILTER,
+            self::RUNTIME_FILTERS,
+            $resolver
+        );
+
+        $this->assertSame($url, $result);
+    }
+
+    /**
+     * @dataProvider provideWebpGeneration
+     */
+    public function testGetUrlOfFilteredImageWithRuntimeFiltersNotStoredWebpSupported(bool $webpGenerate): void
+    {
+        $resolver = null;
+        $url = 'https://example.com/cache'.self::RUNTIME_WEBP_IMAGE;
+        $runtimeOptions = [
+            'filters' => self::RUNTIME_FILTERS,
+        ];
+        $binary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+        $filteredBinary = $this
+            ->getMockBuilder(BinaryInterface::class)
+            ->getMock();
+
+        $service = $this->createFilterService($webpGenerate);
+
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('isStored')
+            ->withConsecutive(
+                [self::RUNTIME_IMAGE, self::FILTER, $resolver],
+                [self::RUNTIME_WEBP_IMAGE, self::FILTER, $resolver]
+            )
+            ->willReturn(false);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('store')
+            ->withConsecutive(
+                [$filteredBinary, self::RUNTIME_IMAGE, self::FILTER, $resolver],
+                [$filteredBinary, self::RUNTIME_WEBP_IMAGE, self::FILTER, $resolver]
+            );
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('resolve')
+            ->with(self::RUNTIME_WEBP_IMAGE, self::FILTER, $resolver)
+            ->willReturn($url);
+        $this->cacheManager
+            ->expects($this->atLeastOnce())
+            ->method('getRuntimePath')
+            ->with(self::SOURCE_IMAGE, self::RUNTIME_FILTERS)
+            ->willReturn(self::RUNTIME_IMAGE);
+
+        $this->dataManager
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->with(self::FILTER, self::SOURCE_IMAGE)
+            ->willReturn($binary);
+
+        $this->filterManager
+            ->expects($this->atLeastOnce())
+            ->method('applyFilter')
+            ->withConsecutive(
+                [$binary, self::FILTER, $runtimeOptions],
+                [$binary, self::FILTER, [
+                        'format' => 'webp',
+                    ] + self::WEBP_OPTIONS + $runtimeOptions]
+            )
+            ->willReturn($binary);
+
+        $result = $service->getUrlOfFilteredImageWithRuntimeFilters(
+            self::SOURCE_IMAGE,
+            self::FILTER,
+            self::RUNTIME_FILTERS,
+            $resolver,
+            true
+        );
+
+        $this->assertSame($url, $result);
+    }
+
+    private function createFilterService(bool $webpGenerate): FilterService
+    {
+        return new FilterService(
+            $this->dataManager,
+            $this->filterManager,
+            $this->cacheManager,
+            $webpGenerate,
+            self::WEBP_OPTIONS,
+            $this->logger
+        );
+    }
+}

--- a/Tests/Service/FilterServiceTest.php
+++ b/Tests/Service/FilterServiceTest.php
@@ -168,7 +168,7 @@ final class FilterServiceTest extends TestCase
             ->expects($this->never())
             ->method('applyFilter');
 
-        $this->assertFalse($service->warmsUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver));
+        $this->assertFalse($service->warmUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver));
     }
 
     /**
@@ -214,7 +214,7 @@ final class FilterServiceTest extends TestCase
             )
             ->willReturn($binary);
 
-        $this->assertTrue($service->warmsUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver, true));
+        $this->assertTrue($service->warmUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver, true));
     }
 
     /**
@@ -265,7 +265,7 @@ final class FilterServiceTest extends TestCase
             )
             ->willReturn($binary);
 
-        $this->assertTrue($service->warmsUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver));
+        $this->assertTrue($service->warmUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver));
     }
 
     /**
@@ -311,7 +311,7 @@ final class FilterServiceTest extends TestCase
             )
             ->willReturn($binary);
 
-        $this->assertTrue($service->warmsUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver, true));
+        $this->assertTrue($service->warmUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver, true));
     }
 
     /**
@@ -356,7 +356,7 @@ final class FilterServiceTest extends TestCase
                 $exception->getMessage()
             ));
 
-        $service->warmsUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver, true);
+        $service->warmUpCache(self::SOURCE_IMAGE, self::FILTER, $resolver, true);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1319
| License | MIT
| Doc PR | <!--highly recommended for new features-->

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->

The `liip:imagine:cache:resolve` CLI command warms up the cache for the specified image sources with all or specified filters applied, and prints the list of cache files. I forgot that this command should also create a image in WebP format if [WebP generation](https://symfony.com/doc/2.x/bundles/LiipImagineBundle/basic-usage.html#webp-image-format) is enabled.


* Add new mthod `FilterService::warmsUpCache()`;
* The mthod `FilterService::bustCache()` now return result of busting;
* The `liip:imagine:cache:resolve` command now warms up image in WebP format too;
* The `liip:imagine:cache:remove` command now remove image in WebP format too;
* The `ResolveCacheProcessor` wat async warms up cache now warmed up image in WebP format too;
* Add unit tests for `FilterPathContainer`;
* Add unit tests for `FilterService`.