### PR TITLE
Add Twig filter for resolve path to cache

### DIFF
--- a/Resources/doc/basic-usage.rst
+++ b/Resources/doc/basic-usage.rst
@@ -114,6 +114,11 @@ when the first page request is served. The transformed image is then cached
 for subsequent requests. The final cached image path would be similar to
 ``/media/cache/my_thumb/relative/path/to/image.jpg``.
 
+.. tip::
+
+    You can :doc:`prepare the cache in advance <commands>` and use the ``imagine_filter_cache`` filter to always
+    return a link to the final cached image.
+
 .. note::
 
     Using the ``dev`` environment you might find that images are not properly

--- a/Templating/FilterExtension.php
+++ b/Templating/FilterExtension.php
@@ -25,6 +25,7 @@ class FilterExtension extends AbstractExtension
     {
         return [
             new TwigFilter('imagine_filter', [$this, 'filter']),
+            new TwigFilter('imagine_filter_cache', [$this, 'filterCache']),
         ];
     }
 }

--- a/Templating/FilterTrait.php
+++ b/Templating/FilterTrait.php
@@ -42,6 +42,24 @@ trait FilterTrait
     }
 
     /**
+     * Gets the cache path for the image and filter to apply.
+     */
+    public function filterCache(
+        string $path,
+        string $filter,
+        array $config = [],
+        ?string $resolver = null
+    ): string {
+        $path = parse_url($path, PHP_URL_PATH);
+
+        if (!empty($config)) {
+            $path = $this->cache->getRuntimePath($path, $config);
+        }
+
+        return $this->cache->resolve($path, $filter, $resolver);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getName()

--- a/Tests/Templating/AbstractFilterTest.php
+++ b/Tests/Templating/AbstractFilterTest.php
@@ -41,7 +41,56 @@ abstract class AbstractFilterTest extends AbstractTest
             ->with($expectedInputPath, $expectedFilter)
             ->willReturn($expectedCachePath);
 
-        $this->assertSame($expectedCachePath, $this->createTemplatingMock($manager)->filter($expectedInputPath, $expectedFilter));
+        $actualPath = $this->createTemplatingMock($manager)->filter($expectedInputPath, $expectedFilter);
+
+        $this->assertSame($expectedCachePath, $actualPath);
+    }
+
+    public function testInvokeFilterCacheMethod(): void
+    {
+        $expectedFilter = 'thumbnail';
+        $expectedInputPath = 'thePathToTheImage';
+        $expectedCachePath = 'thePathToTheCachedImage';
+
+        $manager = $this->createCacheManagerMock();
+        $manager
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($expectedInputPath, $expectedFilter)
+            ->willReturn($expectedCachePath);
+
+        $actualPath = $this->createTemplatingMock($manager)->filterCache($expectedInputPath, $expectedFilter);
+
+        $this->assertSame($expectedCachePath, $actualPath);
+    }
+
+    public function testInvokeFilterCacheMethodWithRuntimeConfig(): void
+    {
+        $expectedFilter = 'thumbnail';
+        $expectedInputPath = 'thePathToTheImage';
+        $expectedCachePath = 'thePathToTheCachedImage';
+        $expectedRuntimeConfig = [
+            'thumbnail' => [
+                'size' => [100, 100],
+            ],
+        ];
+        $expectedRuntimeConfigPath = 'thePathToTheImageWithRuntimeConfig';
+
+        $manager = $this->createCacheManagerMock();
+        $manager
+            ->expects($this->once())
+            ->method('getRuntimePath')
+            ->with($expectedInputPath, $expectedRuntimeConfig)
+            ->willReturn($expectedRuntimeConfigPath);
+        $manager
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($expectedRuntimeConfigPath, $expectedFilter)
+            ->willReturn($expectedCachePath);
+
+        $actualPath = $this->createTemplatingMock($manager)->filterCache($expectedInputPath, $expectedFilter, $expectedRuntimeConfig);
+
+        $this->assertSame($expectedCachePath, $actualPath);
     }
 
     /**

--- a/Tests/Templating/FilterExtensionTest.php
+++ b/Tests/Templating/FilterExtensionTest.php
@@ -23,7 +23,7 @@ class FilterExtensionTest extends AbstractFilterTest
 {
     public function testAddsFilterMethodToFiltersList(): void
     {
-        $this->assertCount(1, $this->createTemplatingMock()->getFilters());
+        $this->assertCount(2, $this->createTemplatingMock()->getFilters());
     }
 
     public function testInstanceOfTwigFilter(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1346<!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->

Add a `imagine_filter_cache` new Twig filter what always return URL to cached image, even if there is no cache. Proper use of this filter can improve performance.

If you always [warm up the cache](https://symfony.com/doc/current/bundles/LiipImagineBundle/resolve-cache-images-in-background.html), then you do not need to check the existence of the cached image every time when rendering templates. You can immediately use the link to the cached version of the image.

Also, you can avoid unnecessary controller calls if you use the local filesystem to store the image cache and use the same cache path as in the controller.

```
# /etc/nginx/nginx.conf
map $http_accept $webp_suffix {
    "~*webp"  ".webp";
}

server {
    # ...

    location ~ ^/media/cache {
        expires 365d;
        access_log off;
        add_header Cache-Control "public";
        try_files $uri$webp_suffix $uri /index.php$is_args$args;
    }

    # ...
}
```

```yaml
# config/packages/liip_imagine.yaml
liip_imagine:
    resolvers:
       profile_photos:
          web_path:
            web_root: "%kernel.root_dir%/../public"
            cache_prefix: "media/cache"
    webp:
        generate: true
```

```yaml
# config/routes/liip_imagine.yaml
liip_imagine_filter:
    path: /media/cache/{filter}/{path}
    defaults:
        _controller: '%liip_imagine.controller.filter_action%'
    methods:
        - GET
    requirements:
        filter: '[A-z0-9_-]*'
        path: .+

```
