### PR TITLE
Suggest symfony/templating instead of requiring deprecated component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "symfony/mime": "^4.3|^5.0",
         "symfony/options-resolver": "^3.4|^4.3|^5.0",
         "symfony/process": "^3.4|^4.3|^5.0",
-        "symfony/templating": "^3.4|^4.3|^5.0",
         "twig/twig": "^1.44|^2.9|^3.0"
     },
     "require-dev": {
@@ -43,6 +42,7 @@
         "symfony/dependency-injection": "^3.4|^4.3|^5.0",
         "symfony/form": "^3.4|^4.3|^5.0",
         "symfony/phpunit-bridge": "^5.2",
+        "symfony/templating": "^3.4|^4.3|^5.0",
         "symfony/validator": "^3.4|^4.3|^5.0",
         "symfony/yaml": "^3.4|^4.3|^5.0"
     },
@@ -58,7 +58,8 @@
         "doctrine/mongodb-odm": "required to use mongodb-backed doctrine components",
         "enqueue/enqueue-bundle": "^0.9 add if you like to process images in background",
         "league/flysystem": "required to use FlySystem data loader or cache resolver",
-        "monolog/monolog": "A psr/log compatible logger is required to enable logging"
+        "monolog/monolog": "A psr/log compatible logger is required to enable logging",
+        "symfony/templating": "required to use deprecated Templating component instead of Twig"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

Since Symfony Templating component is deprecated and proposed to use Twig insead, so I think the right place for `symfony/templating` in `composer.json` is `suggest` section but not `require` section.