### PR TITLE
Fix missing port in url parsing

### DIFF
--- a/Imagine/Cache/Resolver/ProxyResolver.php
+++ b/Imagine/Cache/Resolver/ProxyResolver.php
@@ -89,7 +89,7 @@ class ProxyResolver implements ResolverInterface
         // BC
         if (is_numeric($randKey)) {
             $port = parse_url($url, PHP_URL_PORT);
-            $host = parse_url($url, PHP_URL_SCHEME) . '://' . parse_url($url, PHP_URL_HOST) . ($port ? ':' . $port : '');
+            $host = parse_url($url, PHP_URL_SCHEME).'://'.parse_url($url, PHP_URL_HOST).($port ? ':'.$port : '');
             $proxyHost = $this->hosts[$randKey];
 
             return str_replace($host, $proxyHost, $url);

--- a/Imagine/Cache/Resolver/ProxyResolver.php
+++ b/Imagine/Cache/Resolver/ProxyResolver.php
@@ -88,7 +88,8 @@ class ProxyResolver implements ResolverInterface
 
         // BC
         if (is_numeric($randKey)) {
-            $host = parse_url($url, PHP_URL_SCHEME).'://'.parse_url($url, PHP_URL_HOST);
+            $port = parse_url($url, PHP_URL_PORT);
+            $host = parse_url($url, PHP_URL_SCHEME) . '://' . parse_url($url, PHP_URL_HOST) . ($port ? ':' . $port : '');
             $proxyHost = $this->hosts[$randKey];
 
             return str_replace($host, $proxyHost, $url);


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes/no
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | not needed

This fix allows using development host like `https://127.0.0.1:8000/`. `ProxyResolver` helps to load images from production servers instead of keeping all them on the development environment.

A workaround is to use regexp keys in `$hosts`:
```php
new ProxyResolver(
      ...,
      ['regexp/^https?:\/\/[^\/]+(:[0-9]+)?/' => 'https://cdn.example.com']
)
```