### PR TITLE
Don't use cs2pr to report PHP-CS-Fixer suggestions

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           php-version: 7.4
           coverage: none
-          tools: cs2pr, php-cs-fixer
+          tools: php-cs-fixer
 
       - name: Run PHP-CS-Fixer
-        run: php-cs-fixer fix --dry-run --format checkstyle | cs2pr
+        run: php-cs-fixer fix --dry-run --diff --diff-format udiff


### PR DESCRIPTION

| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes/no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | N/A
| License | MIT
| Doc PR | N/A

PHP-CS-Fixer doesn't support line numbers in checkstyle output format.

Developer would have to read action output to know what's wrong with PHP-CS-Fixer.