### PR TITLE
[Doc] Simplified the "strong" role

### DIFF
--- a/Resources/doc/filters/general.rst
+++ b/Resources/doc/filters/general.rst
@@ -49,19 +49,19 @@ Example configuration:
 Background Options
 ~~~~~~~~~~~~~~~~~~
 
-:strong:`color:` ``string``
+**color:** ``string``
     Sets the background color HEX value. The default color is white (``#fff``).
 
-:strong:`size:` ``int[]``
+**size:** ``int[]``
     Sets the generated background size as an integer array containing the dimensions
     as width and height values.
 
-:strong:`position:` ``string``
+**position:** ``string``
     Sets the position of the input image on the newly created background image. Valid
     values: ``topleft``, ``top``, ``topright``, ``left``, ``center``, ``right``, ``bottomleft``,
     ``bottom``, and ``bottomright``.
 
-:strong:`transparency:` ``integer``
+**transparency:** ``integer``
     Sets the background alpha value. The value should be within a range of 0 - 100.
 
 
@@ -125,7 +125,7 @@ Example configuration:
 Interlace Options
 ~~~~~~~~~~~~~~~~~
 
-:strong:`mode:` ``string``
+**mode:** ``string``
     Sets the interlace mode to encode the file with. Valid values: ``none``, ``line``,
     ``plane``, and ``partition``.
 
@@ -197,15 +197,15 @@ Example configuration:
 Watermark Options
 ~~~~~~~~~~~~~~~~~
 
-:strong:`image:` ``string``
+**image:** ``string``
     Sets the location of the watermark image. The value of this option is prepended
     with the resolved value of the ``%kernel.project_dir%`` parameter.
 
-:strong:`size:` ``float``
+**size:** ``float``
     Sets the size of the watermark as a relative ration, relative to the original
     input image.
 
-:strong:`position:` ``string``
+**position:** ``string``
     Sets the position of the watermark on the input image. Valid values: ``topleft``,
     ``top``, ``topright``, ``left``, ``center``, ``right``, ``bottomleft``, ``bottom``,
     ``bottomright`` and ``multiple``.

--- a/Resources/doc/filters/orientation.rst
+++ b/Resources/doc/filters/orientation.rst
@@ -69,7 +69,7 @@ Example configuration:
 Rotate Options
 ~~~~~~~~~~~~~~
 
-:strong:`degree:` ``float``
+**degree:** ``float``
     Sets the "rotation angle" that defines the degree to rotate the image. Must be a
     positive number.
 
@@ -106,7 +106,7 @@ Example configuration:
 Flip Options
 ~~~~~~~~~~~~
 
-:strong:`axis:` ``string``
+**axis:** ``string``
     Sets the "flip axis" that defines the axis on which to flip the image. Valid values:
     ``x``, ``horizontal``, ``y``, ``vertical``.
 

--- a/Resources/doc/filters/sizing.rst
+++ b/Resources/doc/filters/sizing.rst
@@ -45,11 +45,11 @@ Example configuration:
 Thumbnail Options
 ~~~~~~~~~~~~~~~~~
 
-:strong:`mode:` ``string``
+**mode:** ``string``
     Sets the desired resize method: ``'outbound'`` crops the image as required, while
     ``'inset'`` performs a non-cropping relative resize.
 
-:strong:`size:` ``int[]``
+**size:** ``int[]``
     Sets the generated thumbnail size as an integer array containing the dimensions
     as width and height values.
 
@@ -87,11 +87,11 @@ Example configuration:
 Fixed Options
 ~~~~~~~~~~~~~
 
-:strong:`width:` ``int``
+**width:** ``int``
     Sets the "desired width" which initiates a proportional scale operation that up- or
     down-scales until the image width matches this value.
 
-:strong:`height:` ``int``
+**height:** ``int``
     Sets the "desired height" which initiates a proportional scale operation that up- or
     down-scales until the image height matches this value.
 
@@ -131,11 +131,11 @@ Example configuration:
 Crop Options
 ~~~~~~~~~~~~
 
-:strong:`size:` ``int[]``
+**size:** ``int[]``
     Sets the crop size as an integer array containing the dimensions as width and
     height values.
 
-:strong:`start:` ``int[]``
+**start:** ``int[]``
     Sets the top, left-post anchor coordinates where the crop operation starts.
 
 
@@ -207,19 +207,19 @@ Example configuration:
 Relative Resize Options
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-:strong:`heighten:` ``float``
+**heighten:** ``float``
     Sets the "desired height" which initiates a proportional scale operation that up- or
     down-scales until the image height matches this value.
 
-:strong:`widen:` ``float``
+**widen:** ``float``
     Sets the "desired width" which initiates a proportional scale operation that up- or
     down-scales until the image width matches this value.
 
-:strong:`increase:` ``float``
+**increase:** ``float``
     Sets the "desired additional size" which initiates a scale operation computed by
     adding this value to all image sides.
 
-:strong:`scale:` ``float``
+**scale:** ``float``
     Sets the "ratio multiple" which initiates a proportional scale operation computed
     by multiplying all image sides by this value.
 
@@ -286,11 +286,11 @@ Example configuration:
 Scale Options
 ~~~~~~~~~~~~~
 
-:strong:`dim:` ``int[]``
+**dim:** ``int[]``
     Sets the "desired dimensions" as an array containing a width and height integer, from
     which a relative resize is performed within these constraints.
 
-:strong:`to:` ``float``
+**to:** ``float``
     Sets the "ratio multiple" which initiates a proportional scale operation computed
     by multiplying all image sides by this value.
 
@@ -337,11 +337,11 @@ Example configuration:
 Down Scale Options
 ~~~~~~~~~~~~~~~~~~
 
-:strong:`max:` ``int[]``
+**max:** ``int[]``
     Sets the "desired max dimensions" as an array containing a width and height integer, from
     which a down-scale is performed to meet the passed constraints.
 
-:strong:`by:` ``float``
+**by:** ``float``
     Sets the "ratio multiple" which initiates a proportional scale operation computed
     by multiplying all image sides by this value.
 
@@ -388,11 +388,11 @@ Example configuration:
 Up Scale Options
 ~~~~~~~~~~~~~~~~
 
-:strong:`min:` ``int[]``
+**min:** ``int[]``
     Sets the "desired min dimensions" as an array containing a width and height integer, from
     which an up-scale is performed to meet the passed constraints.
 
-:strong:`by:` ``float``
+**by:** ``float``
     Sets the "ratio multiple" which initiates a proportional scale operation computed
     by multiplying all image sides by this value.
 

--- a/Resources/doc/post-processors/jpeg-moz.rst
+++ b/Resources/doc/post-processors/jpeg-moz.rst
@@ -40,12 +40,12 @@ This configuration sets a maximum quality factor of 70 for the resulting image b
 Options
 -------
 
-:strong:`quality:` ``int``
+**quality:** ``int``
     Sets the image quality factor.
 
 
 Parameters
 ----------
 
-:strong:`liip_imagine.mozjpeg.binary:` ``string``
+**liip_imagine.mozjpeg.binary:** ``string``
     Sets the location of the ``cjpeg`` executable. Default is ``/opt/mozjpeg/bin/cjpeg``.

--- a/Resources/doc/post-processors/jpeg-optim.rst
+++ b/Resources/doc/post-processors/jpeg-optim.rst
@@ -42,32 +42,32 @@ a maximum quality factor of 70 for the resulting image binary.
 Options
 -------
 
-:strong:`strip_all:` ``bool``
+**strip_all:** ``bool``
     Removes all comments, EXIF markers, and other image metadata.
 
-:strong:`max:` ``int``
+**max:** ``int``
     Sets the maximum image quality factor.
 
-:strong:`progressive:` ``bool``
+**progressive:** ``bool``
     Ensures the image uses progressive encoding.
 
 
 Parameters
 ----------
 
-:strong:`liip_imagine.jpegoptim.stripAll:` ``bool``
+**liip_imagine.jpegoptim.stripAll:** ``bool``
     Removes all comments, EXIF markers, and other metadata from the image binary.
 
-:strong:`liip_imagine.jpegoptim.max:` ``int``
+**liip_imagine.jpegoptim.max:** ``int``
     Assigns the maximum quality factor for the image binary.
 
-:strong:`liip_imagine.jpegoptim.progressive:` ``bool``
+**liip_imagine.jpegoptim.progressive:** ``bool``
     Ensures that progressive encoding is enabled for the image binary.
 
-:strong:`liip_imagine.jpegoptim.binary:` ``string``
+**liip_imagine.jpegoptim.binary:** ``string``
     Sets the location of the ``jpegoptim`` executable. Default is ``/usr/bin/jpegoptim``.
 
-:strong:`liip_imagine.jpegoptim.tempDir:` ``string``
+**liip_imagine.jpegoptim.tempDir:** ``string``
     Sets the directory to store temporary files.
 
 

--- a/Resources/doc/post-processors/png-opti.rst
+++ b/Resources/doc/post-processors/png-opti.rst
@@ -42,51 +42,51 @@ for the resulting image binary.
 Options
 -------
 
-:strong:`level:` ``int``
+**level:** ``int``
     Sets the image optimization level. Valid values are integers between ``0`` and ``7``.
 
-:strong:`snip:` ``bool``
+**snip:** ``bool``
     When multi-images are encountered (for example, an animated image), this causes one of the images to be kept and drops
     the other ones. Depending on the input format, this may be either the first or the most relevant (e.g. the largest) image.
 
-:strong:`strip:` ``bool|string``
+**strip:** ``bool|string``
     When set to ``true``, all extra image headers, such as its comments, EXIF markers, and other metadata, will be removed.
     Equivalently, the string value ``all`` also removes all extra metadata.
 
-:strong:`preserve_attributes:` ``bool``
+**preserve_attributes:** ``bool``
     Preserve file attributes (time stamps, file access rights, etc.) where applicable/possible.
 
-:strong:`interlace_type:` ``int``
+**interlace_type:** ``int``
     Sets the interlace type used for the output file. When set to ``0``, the output image will be non-interlaced. When
     set to ``1``, the output image will be interlaced using the Adam7 method. When not set, the output will have the
     same interlace type as the original input.
 
-:strong:`no_bit_depth_reductions:` ``bool``
+**no_bit_depth_reductions:** ``bool``
     Disables any bit depth reduction optimizations.
 
-:strong:`no_color_type_reductions:` ``bool``
+**no_color_type_reductions:** ``bool``
     Disables any color type reduction optimizations.
 
-:strong:`no_palette_reductions:` ``bool``
+**no_palette_reductions:** ``bool``
     Disables any color palette reduction optimizations.
 
-:strong:`no_reductions:` ``bool``
+**no_reductions:** ``bool``
     Disables any lossless reduction optimizations, enabling ``no_bit_depth_reductions``, ``no_color_type_reductions``,
     and ``no_palette_reductions``.
 
 Parameters
 ----------
 
-:strong:`liip_imagine.optipng.stripAll:` ``bool``
+**liip_imagine.optipng.stripAll:** ``bool``
     Removes all comments, EXIF markers, and other metadata from the image binary.
 
-:strong:`liip_imagine.optipng.level:` ``int``
+**liip_imagine.optipng.level:** ``int``
     Sets the image optimization factor. Default is ``7``.
 
-:strong:`liip_imagine.optipng.binary:` ``string``
+**liip_imagine.optipng.binary:** ``string``
     Sets the location of the ``optipng`` executable. Default is ``/usr/bin/optipng``.
 
-:strong:`liip_imagine.optipng.tempDir:` ``string``
+**liip_imagine.optipng.tempDir:** ``string``
     Sets the directory to store temporary files.
 
 

--- a/Resources/doc/post-processors/png-quant.rst
+++ b/Resources/doc/post-processors/png-quant.rst
@@ -41,22 +41,22 @@ This configuration sets a quality factor range of 75 to 85 for the resulting ima
 Options
 -------
 
-:strong:`quality:` ``int|int[]``
+**quality:** ``int|int[]``
     When set to an ``int`` this sets the maximum image quality level. When set to an ``int[]`` (such as ``[60,80]``) the
     first array ``int`` is used to define the lowest acceptable quality level and the second to define the maximum quality
     level (in this mode, the executable will use the least amount of colors required to meet or exceed the maximum quality,
     but if the conversion results in a quality below the minimum quality the converted file will be discarded and the
     original one used instead).
 
-:strong:`speed:` ``int``
+**speed:** ``int``
     The speed/quality trade-off value to use. Valid values: ``1`` (slowest/best) through ``11`` (fastest/worst).
 
-:strong:`dithering:` ``bool|float``
+**dithering:** ``bool|float``
     When set to ``false`` the Floyd-Steinberg dithering algorithm is completely disabled. Otherwise, when a ``float``,
     the dithering level is set.
 
 Parameters
 ----------
 
-:strong:`liip_imagine.pngquant.binary:` ``string``
+**liip_imagine.pngquant.binary:** ``string``
     Sets the location of the ``pnquant`` executable. Default is ``/usr/bin/pngquant``.


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | -
| License | MIT
| Doc PR | -

Hi! We're going to introduce some changes in the RST parser of symfony.com and the `:strong:` role is not going to be supported. That's why we suggest you to replace it by the other common way of adding strong emphasis (see https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#strong-emphasis).