### PR TITLE
Undefined quality key. Fixes #1310

### DIFF
--- a/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
@@ -156,7 +156,7 @@ class JpegOptimPostProcessor extends AbstractPostProcessor
         }
 
         if ($quality = $options['quality'] ?? $this->quality) {
-            if (!\in_array($options['quality'], range(0, 100), true)) {
+            if (!\in_array($quality, range(0, 100), true)) {
                 throw new InvalidOptionException('the "quality" option must be an int between 0 and 100', $options);
             }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1310 <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

I met an issue when trying to use the `jpegoptim` post processor in one of our projects. The issue happens when there is a quality set in the processor constructor and no quality option is passed. It throws an error like:

![screenshot-grafe local-2021 04 23-12_05_56](https://user-images.githubusercontent.com/1119272/115856102-56fefd80-a42c-11eb-916c-e8cd37627258.png)

I've modified the tests so the issue is detected and then applied the fix. 

This issue was already reported by @ant46 in #1310 
