### PR TITLE
$ should not be there

### DIFF
--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -12,7 +12,7 @@ and add it as a dependency to your project:
 
 .. code-block:: bash
 
-    $ composer require liip/imagine-bundle
+    composer require liip/imagine-bundle
 
 This command requires that `Composer`_ is installed globally, as explained in
 the `installation documentation`_ for Composer.


### PR DESCRIPTION
none of symfony examples contain `$` at the start, also copy link copies command with `$` which is not what most of us want

| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| License | MIT
| Doc PR | yes