### PR TITLE
Fix service definitions for mime and extension guessers

### DIFF
--- a/DependencyInjection/Compiler/MaybeSetMimeServicesAsAliasesCompilerPass.php
+++ b/DependencyInjection/Compiler/MaybeSetMimeServicesAsAliasesCompilerPass.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Changes the `liip_imagine.mime_type_guesser` and `liip_imagine.extension_guesser` services to be aliases of the
+ * `mime_types` service provided by the FrameworkBundle when available.
+ *
+ * This compiler pass can be removed when dropping support for Symfony 4.2 and earlier.
+ *
+ * @internal
+ */
+final class MaybeSetMimeServicesAsAliasesCompilerPass extends AbstractCompilerPass
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->hasDefinition('mime_types')) {
+            $container->removeDefinition('liip_imagine.mime_type_guesser');
+            $container->removeDefinition('liip_imagine.extension_guesser');
+
+            $container->setAlias('liip_imagine.mime_type_guesser', 'mime_types');
+            $container->setAlias('liip_imagine.extension_guesser', 'mime_types');
+
+            $message = 'Replaced the "%s" and "%s" service definitions with aliases to "%s"';
+
+            $this->log($container, $message, 'liip_imagine.mime_type_guesser', 'liip_imagine.extension_guesser', 'mime_types');
+        }
+    }
+}

--- a/LiipImagineBundle.php
+++ b/LiipImagineBundle.php
@@ -16,6 +16,7 @@ use Liip\ImagineBundle\Async\Topics;
 use Liip\ImagineBundle\DependencyInjection\Compiler\DriverCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass;
+use Liip\ImagineBundle\DependencyInjection\Compiler\MaybeSetMimeServicesAsAliasesCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\MetadataReaderCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\NonFunctionalFilterExceptionPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\PostProcessorsCompilerPass;
@@ -47,6 +48,7 @@ class LiipImagineBundle extends Bundle
         $container->addCompilerPass(new PostProcessorsCompilerPass());
         $container->addCompilerPass(new ResolversCompilerPass());
         $container->addCompilerPass(new MetadataReaderCompilerPass());
+        $container->addCompilerPass(new MaybeSetMimeServicesAsAliasesCompilerPass());
 
         if (class_exists(AddTopicMetaPass::class)) {
             $container->addCompilerPass(AddTopicMetaPass::create()


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | Fixes #1287
| License | MIT
| Doc PR | N/A

In #1217 several deprecations from `symfony/http-foundation` for Symfony 4.3 were addressed, but the related service configurations weren't updated, leaving the `liip_imagine.mime_type_guesser` and `liip_imagine.extension_guesser` services in a broken state when `symfony/http-foundation:^5.0` is used.

This PR aims to fix the service definitions by conditionally changing those two services to be aliases of the `mime_types` service the FrameworkBundle provides if a version of the FrameworkBundle that offers that service is installed.  This should retain B/C for Symfony 4.2 and earlier by using the existing definition which uses the classes from `symfony/http-foundation` while offering forward compatibility by mapping the services to the replacement API for the deprecated classes.  When support for Symfony 4.2 and earlier are removed, this compiler pass can be removed and the two services converted into aliases unconditionally.