### PR TITLE
Fix deprecation of PHPUnit 8

### DIFF
--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -87,6 +87,15 @@ abstract class AbstractTest extends TestCase
         ];
     }
 
+    public function expectExceptionMessageMatchesBC(string $regularExpression): void
+    {
+        if (method_exists($this, 'expectExceptionMessageMatches')) {
+            $this->expectExceptionMessageMatches($regularExpression);
+        } else {
+            $this->expectExceptionMessageRegExp($regularExpression);
+        }
+    }
+
     protected function createFilterConfiguration(): FilterConfiguration
     {
         $config = new FilterConfiguration();

--- a/Tests/Binary/Loader/ChainLoaderTest.php
+++ b/Tests/Binary/Loader/ChainLoaderTest.php
@@ -18,7 +18,7 @@ use Liip\ImagineBundle\Binary\Locator\FileSystemLocator;
 use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Model\FileBinary;
-use PHPUnit\Framework\TestCase;
+use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
@@ -27,7 +27,7 @@ use Symfony\Component\Mime\MimeTypes;
 /**
  * @covers \Liip\ImagineBundle\Binary\Loader\ChainLoader
  */
-class ChainLoaderTest extends TestCase
+class ChainLoaderTest extends AbstractTest
 {
     public function testImplementsLoaderInterface(): void
     {
@@ -94,7 +94,7 @@ class ChainLoaderTest extends TestCase
     public function testThrowsIfFileDoesNotExist(string $path): void
     {
         $this->expectException(NotLoadableException::class);
-        $this->expectExceptionMessageRegExp('{Source image not resolvable "[^"]+" using "FileSystemLoader=\[foo\]" 1 loaders}');
+        $this->expectExceptionMessageMatchesBC('{Source image not resolvable "[^"]+" using "FileSystemLoader=\[foo\]" 1 loaders}');
 
         $this->getChainLoader()->find($path);
     }
@@ -105,7 +105,7 @@ class ChainLoaderTest extends TestCase
     public function testThrowsIfFileDoesNotExistWithMultipleLoaders(string $path): void
     {
         $this->expectException(NotLoadableException::class);
-        $this->expectExceptionMessageRegExp('{Source image not resolvable "[^"]+" using "FileSystemLoader=\[foo\], FileSystemLoader=\[bar\]" 2 loaders \(internal exceptions: FileSystemLoader=\[.+\], FileSystemLoader=\[.+\]\)\.}');
+        $this->expectExceptionMessageMatchesBC('{Source image not resolvable "[^"]+" using "FileSystemLoader=\[foo\], FileSystemLoader=\[bar\]" 2 loaders \(internal exceptions: FileSystemLoader=\[.+\], FileSystemLoader=\[.+\]\)\.}');
 
         $this->getChainLoader([], [
             'foo' => $this->createFileSystemLoader(

--- a/Tests/Binary/Loader/FlysystemLoaderTest.php
+++ b/Tests/Binary/Loader/FlysystemLoaderTest.php
@@ -75,7 +75,7 @@ class FlysystemLoaderTest extends AbstractTest
     public function testThrowsIfInvalidPathGivenOnFind(): void
     {
         $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
-        $this->expectExceptionMessageRegExp('{Source image .+ not found}');
+        $this->expectExceptionMessageMatchesBC('{Source image .+ not found}');
 
         $loader = $this->getFlysystemLoader();
 

--- a/Tests/Binary/Loader/FlysystemV2LoaderTest.php
+++ b/Tests/Binary/Loader/FlysystemV2LoaderTest.php
@@ -59,7 +59,7 @@ class FlysystemV2LoaderTest extends AbstractTest
     public function testThrowsIfInvalidPathGivenOnFind(): void
     {
         $this->expectException(NotLoadableException::class);
-        $this->expectExceptionMessageRegExp('{Source image .+ not found}');
+        $this->expectExceptionMessageMatchesBC('{Source image .+ not found}');
 
         $loader = $this->getFlysystemLoader();
 

--- a/Tests/Binary/Loader/StreamLoaderTest.php
+++ b/Tests/Binary/Loader/StreamLoaderTest.php
@@ -22,7 +22,7 @@ class StreamLoaderTest extends AbstractTest
     public function testThrowsIfInvalidPathGivenOnFind(): void
     {
         $this->expectException(\Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException::class);
-        $this->expectExceptionMessageRegExp('{Source image file://.+ not found.}');
+        $this->expectExceptionMessageMatchesBC('{Source image file://.+ not found.}');
 
         $loader = new StreamLoader('file://');
         $loader->find($this->temporaryPath.'/invalid.jpeg');

--- a/Tests/Component/Console/Style/ImagineStyleTest.php
+++ b/Tests/Component/Console/Style/ImagineStyleTest.php
@@ -226,7 +226,7 @@ class ImagineStyleTest extends AbstractTest
     public function testInvalidFormatAndReplacements(string $format, array $replacements): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('{Invalid string format "[^"]+" or replacements "[^"]+".}');
+        $this->expectExceptionMessageMatchesBC('{Invalid string format "[^"]+" or replacements "[^"]+".}');
 
         $style = $this->createImagineStyle($output = $this->createBufferedOutput());
         $style->text($format, $replacements);

--- a/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/FlysystemLoaderFactoryTest.php
@@ -15,7 +15,7 @@ use League\Flysystem\FilesystemInterface;
 use League\Flysystem\FilesystemOperator;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface;
-use PHPUnit\Framework\TestCase;
+use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\FlysystemLoaderFactory<extended>
  */
-class FlysystemLoaderFactoryTest extends TestCase
+class FlysystemLoaderFactoryTest extends AbstractTest
 {
     protected function setUp(): void
     {
@@ -86,7 +86,7 @@ class FlysystemLoaderFactoryTest extends TestCase
     public function testThrowIfFileSystemServiceNotSetOnAddConfiguration(): void
     {
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
-        $this->expectExceptionMessageMatches('/^The child (node|config) "filesystem_service" (at path|under) "flysystem" must be configured\.$/');
+        $this->expectExceptionMessageMatchesBC('/^The child (node|config) "filesystem_service" (at path|under) "flysystem" must be configured\.$/');
 
         $treeBuilder = new TreeBuilder('flysystem');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')

--- a/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Loader/StreamLoaderFactoryTest.php
@@ -13,7 +13,7 @@ namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory\Loader;
 
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory;
-use PHPUnit\Framework\TestCase;
+use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Loader\StreamLoaderFactory<extended>
  */
-class StreamLoaderFactoryTest extends TestCase
+class StreamLoaderFactoryTest extends AbstractTest
 {
     public function testImplementsLoaderFactoryInterface(): void
     {
@@ -69,7 +69,7 @@ class StreamLoaderFactoryTest extends TestCase
     public function testThrowIfWrapperNotSetOnAddConfiguration(): void
     {
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
-        $this->expectExceptionMessageMatches('/^The child (node|config) "wrapper" (at path|under) "stream" must be configured\.$/');
+        $this->expectExceptionMessageMatchesBC('/^The child (node|config) "wrapper" (at path|under) "stream" must be configured\.$/');
 
         $treeBuilder = new TreeBuilder('stream');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -14,7 +14,7 @@ namespace Liip\ImagineBundle\Tests\DependencyInjection\Factory\Resolver;
 use Aws\S3\S3Client;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface;
-use PHPUnit\Framework\TestCase;
+use Liip\ImagineBundle\Tests\AbstractTest;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * @covers \Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory<extended>
  */
-class AwsS3ResolverFactoryTest extends TestCase
+class AwsS3ResolverFactoryTest extends AbstractTest
 {
     public function testImplementsResolverFactoryInterface(): void
     {
@@ -295,7 +295,7 @@ class AwsS3ResolverFactoryTest extends TestCase
     public function testThrowBucketNotSetOnAddConfiguration(): void
     {
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
-        $this->expectExceptionMessageMatches('/^The child (node|config) "bucket" (at path|under) "aws_s3" must be configured\.$/');
+        $this->expectExceptionMessageMatchesBC('/^The child (node|config) "bucket" (at path|under) "aws_s3" must be configured\.$/');
 
         $treeBuilder = new TreeBuilder('aws_s3');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
@@ -311,7 +311,7 @@ class AwsS3ResolverFactoryTest extends TestCase
     public function testThrowClientConfigNotSetOnAddConfiguration(): void
     {
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
-        $this->expectExceptionMessageMatches('/^The child (node|config) "client_config" (at path|under) "aws_s3" must be configured\.$/');
+        $this->expectExceptionMessageMatchesBC('/^The child (node|config) "client_config" (at path|under) "aws_s3" must be configured\.$/');
 
         $treeBuilder = new TreeBuilder('aws_s3');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
@@ -331,7 +331,7 @@ class AwsS3ResolverFactoryTest extends TestCase
     public function testThrowClientConfigNotArrayOnAddConfiguration(): void
     {
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
-        $this->expectExceptionMessageRegExp('{^Invalid type for path "aws_s3.client_config". Expected (\")?array(\")?, but got (\")?string(\")?$}');
+        $this->expectExceptionMessageMatchesBC('{^Invalid type for path "aws_s3.client_config". Expected (\")?array(\")?, but got (\")?string(\")?$}');
 
         $treeBuilder = new TreeBuilder('aws_s3');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode')

--- a/Tests/Imagine/Filter/Loader/ResampleFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/ResampleFilterLoaderTest.php
@@ -154,7 +154,7 @@ class ResampleFilterLoaderTest extends AbstractTest
     public function testThrowsOnInvalidTemporaryPathOption(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessageRegExp('{Unable to create temporary file in ".+" base path.}');
+        $this->expectExceptionMessageMatchesBC('{Unable to create temporary file in ".+" base path.}');
 
         $loader = $this->createResampleFilterLoaderInstance();
         $loader->load($this->getImageInterfaceMock(), [


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0 <!--choose version number-->
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->

Fix error

> expectExceptionMessageRegExp() is deprecated in PHPUnit 8 and will be removed in PHPUnit 9. Use expectExceptionMessageMatches() instead.