### PR TITLE
Remove urldecode path

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -15,7 +15,6 @@ use Imagine\Exception\RuntimeException;
 use Liip\ImagineBundle\Config\Controller\ControllerConfig;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Exception\Imagine\Filter\NonExistingFilterException;
-use Liip\ImagineBundle\Imagine\Cache\Helper\PathHelper;
 use Liip\ImagineBundle\Imagine\Cache\SignerInterface;
 use Liip\ImagineBundle\Imagine\Data\DataManager;
 use Liip\ImagineBundle\Service\FilterService;
@@ -82,7 +81,6 @@ class ImagineController
      */
     public function filterAction(Request $request, $path, $filter)
     {
-        $path = PathHelper::urlPathToFilePath($path);
         $resolver = $request->get('resolver');
 
         return $this->createRedirectResponse(function () use ($path, $filter, $resolver, $request) {
@@ -115,7 +113,6 @@ class ImagineController
     public function filterRuntimeAction(Request $request, $hash, $path, $filter)
     {
         $resolver = $request->get('resolver');
-        $path = PathHelper::urlPathToFilePath($path);
         $runtimeConfig = $request->query->get('filters', []);
 
         if (!\is_array($runtimeConfig)) {

--- a/Imagine/Cache/Helper/PathHelper.php
+++ b/Imagine/Cache/Helper/PathHelper.php
@@ -22,10 +22,4 @@ class PathHelper
     {
         return implode('/', array_map('rawurlencode', explode('/', $path)));
     }
-
-    public static function urlPathToFilePath(string $url): string
-    {
-        // used urldecode instead of rawurlencode for BC safety to support "+" in URL
-        return urldecode($url);
-    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | https://github.com/liip/LiipImagineBundle/issues/1143
| License | MIT
| Doc PR | <!--highly recommended for new features-->

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->

It is not required to `urldecode` since it is already decoded.
And this is causing issue when the filename contains `+` which is decoded as a space.