### PR TITLE
Add doc for disabling auth on filter controllers

### DIFF
--- a/Resources/doc/basic-usage.rst
+++ b/Resources/doc/basic-usage.rst
@@ -264,6 +264,25 @@ If browser supports WebP, the request ``https://localhost/media/cache/resolve/th
 will be redirected to ``https://localhost/media/cache/thumbnail_web_path/images/cats.jpeg.webp``
 otherwise to ``https://localhost/media/cache/thumbnail_web_path/images/cats.jpeg``
 
+Optimize Firewall Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For most applications, requests to the filter controllers (the
+``/media/cache/resolve`` path) do not require Symfony to load the authenticated
+user data from the session. To optimize performance, you can disable the
+authentication system by defining a firewall for these controllers using the
+following code snippet:
+
+.. code-block:: yaml
+
+    # app/config/security.yml
+
+    security:
+        firewalls:
+            image_resolver:
+                pattern: ^/media/cache/resolve
+                security: false
+
 .. note::
 
     Using an unsecured connection (non HTTPS) on your site can cause problems with


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | N/A
| License | MIT
| Doc PR | This PR 😃 

Ref: https://twitter.com/mbabker/status/1405962888792231939?s=21

App performance can be improved for the `/media/cache/resolve/*` routes by disabling Symfony's authentication system.  Generally, there isn't much of a need to load the authenticated user data here, and for image-heavy applications (like the one that inspired this change) this can free up resources greatly (historically, the `liip_imagine_filter` controller in our application accounts for 55-60% of the total transaction time for our web frontend, after deployment this dropped down to 40-45%).

(RST isn't really a strong-suit for me, so I'm hoping I've got the format here generally right)