### PR TITLE
Change registering the form theme to prepend the configuration

### DIFF
--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -20,12 +20,13 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
 use Symfony\Component\Mime\MimeTypes;
 
-class LiipImagineExtension extends Extension
+class LiipImagineExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * @var ResolverFactoryInterface[]
@@ -113,11 +114,6 @@ class LiipImagineExtension extends Extension
         $container->setParameter('liip_imagine.controller.filter_action', $config['controller']['filter_action']);
         $container->setParameter('liip_imagine.controller.filter_runtime_action', $config['controller']['filter_runtime_action']);
 
-        $container->setParameter('twig.form.resources', array_merge(
-            $container->hasParameter('twig.form.resources') ? $container->getParameter('twig.form.resources') : [],
-            ['@LiipImagine/Form/form_div_layout.html.twig']
-        ));
-
         if ($container->hasDefinition('liip_imagine.mime_types')) {
             $mimeTypes = $container->getDefinition('liip_imagine.mime_types');
             $container->getDefinition('liip_imagine.binary.mime_type_guesser')
@@ -133,6 +129,13 @@ class LiipImagineExtension extends Extension
         $webpOptions = $config['webp'];
         unset($webpOptions['generate']);
         $container->setParameter('liip_imagine.webp.options', $webpOptions);
+    }
+
+    public function prepend(ContainerBuilder $container): void
+    {
+        if ($container->hasExtension('twig')) {
+            $container->prependExtensionConfig('twig', ['form_themes' => ['@LiipImagine/Form/form_div_layout.html.twig']]);
+        }
     }
 
     private function createFilterSets(array $defaultFilterSets, array $filterSets): array


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | N/A
| License | MIT
| Doc PR | N/A

Per the [TwigBundle documentation](https://symfony.com/doc/current/form/form_themes.html#applying-themes-to-all-forms), the latest registered from themes have the highest priority.  Right now, this bundle is appending its form theme to the end of the list when the container is built, which effectively makes it the highest priority form theme and something that cannot be overridden.

By changing the container extension to prepend the form theme param to the TwigBundle config, we can get the form theme loaded in at a lower priority that will allow an app's own form theme(s) to override it if so desired.

`twig.form.resources` param before this change from the app I tested this change with:

```php
[
    'twig.form.resources' => [
        0 => 'form_div_layout.html.twig',
        1 => '@MisdPhoneNumber/Form/phone_number.html.twig',
        2 => 'form/app_form_layout.html.twig',
        3 => '@LiipImagine/Form/form_div_layout.html.twig',
    ],
]
```

After this change:


```php
[
    'twig.form.resources' => [
        0 => 'form_div_layout.html.twig',
        1 => '@MisdPhoneNumber/Form/phone_number.html.twig',
        2 => '@LiipImagine/Form/form_div_layout.html.twig',
        3 => 'form/app_form_layout.html.twig',
    ],
]
```