### PR TITLE
[Flysystem Resolver] Allowing "noPredefinedVisibility" for the visibility config parameter

### DIFF
--- a/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
@@ -65,7 +65,7 @@ class FlysystemResolverFactory extends AbstractResolverFactory
                     ->cannotBeEmpty()
                 ->end()
                 ->enumNode('visibility')
-                    ->values(['public', 'private', 'noPredefinedVisibility'])
+                    ->values(['public', 'private', null])
                     ->defaultValue('public')
                 ->end()
             ->end();

--- a/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
@@ -65,7 +65,7 @@ class FlysystemResolverFactory extends AbstractResolverFactory
                     ->cannotBeEmpty()
                 ->end()
                 ->enumNode('visibility')
-                    ->values(['public', 'private'])
+                    ->values(['public', 'private', 'noPredefinedVisibility'])
                     ->defaultValue('public')
                 ->end()
             ->end();

--- a/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
@@ -65,7 +65,7 @@ class FlysystemResolverFactory extends AbstractResolverFactory
                     ->cannotBeEmpty()
                 ->end()
                 ->enumNode('visibility')
-                    ->values(['public', 'private', null])
+                    ->values(['public', 'private', 'noPredefinedVisibility'])
                     ->defaultValue('public')
                 ->end()
             ->end();


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | 
| License | MIT

GCP storage buckets now suggest not to use ACL but bucket-wide permissions when possible. Unfortunately trying to upload a file to a bucket using a uniform bucket-level access throws an error:
`Cannot insert legacy ACL for an object when uniform bucket-level access is enabled`

This PR allows usage of the `noPredefinedVisibility` value for the "visibility" resolver configuration parameter.

@see
* https://github.com/thephpleague/flysystem/pull/1357
* https://github.com/thephpleague/flysystem/issues/1356