### PR TITLE
GitHub actions phpstan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,12 @@
 * text=auto
 /.github/ export-ignore
+/.phpstan/ export-ignore
 /Tests/ export-ignore
 /.gitattributes export-ignore
 /.github_changelog_generator export-ignore
 /.php_cs.dist export-ignore
 /.scrutinizer.yml export-ignore
+/.styleci.yml export-ignore
+/.travis.yml export-ignore
+/.phpstan.neon.dist export-ignore
 /.phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,5 @@
 /.github_changelog_generator export-ignore
 /.php_cs.dist export-ignore
 /.scrutinizer.yml export-ignore
-/.styleci.yml export-ignore
-/.travis.yml export-ignore
 /.phpstan.neon.dist export-ignore
 /.phpunit.xml.dist export-ignore

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -3,6 +3,9 @@ name: PHPStan
 on:
   pull_request:
   push:
+    branches:
+      - 1.x
+      - 2.x
 
 jobs:
   phpstan:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,24 @@
+name: PHPStan
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: Update project dependencies
+        uses: ramsey/composer-install@v1
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyze

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /bin/
 /composer.lock
 /composer.phar
+/phpstan.neon
 /phpunit.xml
 /Tests/Functional/app/public/media/cache
 /Tests/Functional/app/web/media/cache

--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -1,6 +1,6 @@
 parameters:
     ignoreErrors:
-        - message: '#^Access to undefined constant Liip\\ImagineBundle\\Config\\Filter\\Type\\FilterAbstract::NAME\.$#'
+        - message: '#^Access to undefined constant static\(Liip\\ImagineBundle\\Config\\Filter\\Type\\FilterAbstract\)::NAME\.$#'
           paths:
               - ../Config/Filter/Type/FilterAbstract.php
         - message: '#^Unsafe usage of new static\(\)\.$#'

--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -1,0 +1,9 @@
+parameters:
+    ignoreErrors:
+        - message: '#^Access to undefined constant Liip\\ImagineBundle\\Config\\Filter\\Type\\FilterAbstract::NAME\.$#'
+          paths:
+              - ../Config/Filter/Type/FilterAbstract.php
+        - message: '#^Unsafe usage of new static\(\)\.$#'
+          paths:
+              - ../Async/CacheResolved.php
+              - ../Async/ResolveCache.php

--- a/.phpstan/stubs/AdapterInterface.stub
+++ b/.phpstan/stubs/AdapterInterface.stub
@@ -1,0 +1,118 @@
+<?php
+
+namespace League\Flysystem;
+
+interface AdapterInterface extends ReadInterface
+{
+    /**
+     * @const  VISIBILITY_PUBLIC  public visibility
+     */
+    const VISIBILITY_PUBLIC = 'public';
+
+    /**
+     * @const  VISIBILITY_PRIVATE  private visibility
+     */
+    const VISIBILITY_PRIVATE = 'private';
+
+    /**
+     * Write a new file.
+     *
+     * @param string $path
+     * @param string $contents
+     * @param Config $config   Config object
+     *
+     * @return array|false false on failure file meta data on success
+     */
+    public function write($path, $contents, Config $config);
+
+    /**
+     * Write a new file using a stream.
+     *
+     * @param string   $path
+     * @param resource $resource
+     * @param Config   $config   Config object
+     *
+     * @return array|false false on failure file meta data on success
+     */
+    public function writeStream($path, $resource, Config $config);
+
+    /**
+     * Update a file.
+     *
+     * @param string $path
+     * @param string $contents
+     * @param Config $config   Config object
+     *
+     * @return array|false false on failure file meta data on success
+     */
+    public function update($path, $contents, Config $config);
+
+    /**
+     * Update a file using a stream.
+     *
+     * @param string   $path
+     * @param resource $resource
+     * @param Config   $config   Config object
+     *
+     * @return array|false false on failure file meta data on success
+     */
+    public function updateStream($path, $resource, Config $config);
+
+    /**
+     * Rename a file.
+     *
+     * @param string $path
+     * @param string $newpath
+     *
+     * @return bool
+     */
+    public function rename($path, $newpath);
+
+    /**
+     * Copy a file.
+     *
+     * @param string $path
+     * @param string $newpath
+     *
+     * @return bool
+     */
+    public function copy($path, $newpath);
+
+    /**
+     * Delete a file.
+     *
+     * @param string $path
+     *
+     * @return bool
+     */
+    public function delete($path);
+
+    /**
+     * Delete a directory.
+     *
+     * @param string $dirname
+     *
+     * @return bool
+     */
+    public function deleteDir($dirname);
+
+    /**
+     * Create a directory.
+     *
+     * @param string $dirname directory name
+     * @param Config $config
+     *
+     * @return array|false
+     */
+    public function createDir($dirname, Config $config);
+
+    /**
+     * Set the visibility for a file.
+     *
+     * @param string $path
+     * @param string $visibility
+     *
+     * @return array|false file meta data
+     */
+    public function setVisibility($path, $visibility);
+}

--- a/.phpstan/stubs/Event.stub
+++ b/.phpstan/stubs/Event.stub
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+/**
+ * @deprecated since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead
+ */
+class Event
+{
+    private $propagationStopped = false;
+
+    /**
+     * @return bool Whether propagation was already stopped for this event
+     *
+     * @deprecated since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead
+     */
+    public function isPropagationStopped()
+    {
+        return $this->propagationStopped;
+    }
+
+    /**
+     * @deprecated since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead
+     */
+    public function stopPropagation()
+    {
+        $this->propagationStopped = true;
+    }
+}

--- a/.phpstan/stubs/ExtensionGuesserInterface.stub
+++ b/.phpstan/stubs/ExtensionGuesserInterface.stub
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\File\MimeType;
+
+use Symfony\Component\Mime\MimeTypesInterface;
+
+/**
+ * Guesses the file extension corresponding to a given mime type.
+ *
+ * @deprecated since Symfony 4.3, use {@link MimeTypesInterface} instead
+ */
+interface ExtensionGuesserInterface
+{
+    /**
+     * Makes a best guess for a file extension, given a mime type.
+     *
+     * @param string $mimeType The mime type
+     *
+     * @return string The guessed extension or NULL, if none could be guessed
+     */
+    public function guess($mimeType);
+}

--- a/.phpstan/stubs/FilesystemInterface.stub
+++ b/.phpstan/stubs/FilesystemInterface.stub
@@ -1,0 +1,284 @@
+<?php
+
+namespace League\Flysystem;
+
+use InvalidArgumentException;
+
+interface FilesystemInterface
+{
+    /**
+     * Check whether a file exists.
+     *
+     * @param string $path
+     *
+     * @return bool
+     */
+    public function has($path);
+
+    /**
+     * Read a file.
+     *
+     * @param string $path The path to the file.
+     *
+     * @throws FileNotFoundException
+     *
+     * @return string|false The file contents or false on failure.
+     */
+    public function read($path);
+
+    /**
+     * Retrieves a read-stream for a path.
+     *
+     * @param string $path The path to the file.
+     *
+     * @throws FileNotFoundException
+     *
+     * @return resource|false The path resource or false on failure.
+     */
+    public function readStream($path);
+
+    /**
+     * List contents of a directory.
+     *
+     * @param string $directory The directory to list.
+     * @param bool   $recursive Whether to list recursively.
+     *
+     * @return array A list of file metadata.
+     */
+    public function listContents($directory = '', $recursive = false);
+
+    /**
+     * Get a file's metadata.
+     *
+     * @param string $path The path to the file.
+     *
+     * @throws FileNotFoundException
+     *
+     * @return array|false The file metadata or false on failure.
+     */
+    public function getMetadata($path);
+
+    /**
+     * Get a file's size.
+     *
+     * @param string $path The path to the file.
+     *
+     * @throws FileNotFoundException
+     *
+     * @return int|false The file size or false on failure.
+     */
+    public function getSize($path);
+
+    /**
+     * Get a file's mime-type.
+     *
+     * @param string $path The path to the file.
+     *
+     * @throws FileNotFoundException
+     *
+     * @return string|false The file mime-type or false on failure.
+     */
+    public function getMimetype($path);
+
+    /**
+     * Get a file's timestamp.
+     *
+     * @param string $path The path to the file.
+     *
+     * @throws FileNotFoundException
+     *
+     * @return int|false The timestamp or false on failure.
+     */
+    public function getTimestamp($path);
+
+    /**
+     * Get a file's visibility.
+     *
+     * @param string $path The path to the file.
+     *
+     * @throws FileNotFoundException
+     *
+     * @return string|false The visibility (public|private) or false on failure.
+     */
+    public function getVisibility($path);
+
+    /**
+     * Write a new file.
+     *
+     * @param string $path     The path of the new file.
+     * @param string $contents The file contents.
+     * @param array  $config   An optional configuration array.
+     *
+     * @throws FileExistsException
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function write($path, $contents, array $config = []);
+
+    /**
+     * Write a new file using a stream.
+     *
+     * @param string   $path     The path of the new file.
+     * @param resource $resource The file handle.
+     * @param array    $config   An optional configuration array.
+     *
+     * @throws InvalidArgumentException If $resource is not a file handle.
+     * @throws FileExistsException
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function writeStream($path, $resource, array $config = []);
+
+    /**
+     * Update an existing file.
+     *
+     * @param string $path     The path of the existing file.
+     * @param string $contents The file contents.
+     * @param array  $config   An optional configuration array.
+     *
+     * @throws FileNotFoundException
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function update($path, $contents, array $config = []);
+
+    /**
+     * Update an existing file using a stream.
+     *
+     * @param string   $path     The path of the existing file.
+     * @param resource $resource The file handle.
+     * @param array    $config   An optional configuration array.
+     *
+     * @throws InvalidArgumentException If $resource is not a file handle.
+     * @throws FileNotFoundException
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function updateStream($path, $resource, array $config = []);
+
+    /**
+     * Rename a file.
+     *
+     * @param string $path    Path to the existing file.
+     * @param string $newpath The new path of the file.
+     *
+     * @throws FileExistsException   Thrown if $newpath exists.
+     * @throws FileNotFoundException Thrown if $path does not exist.
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function rename($path, $newpath);
+
+    /**
+     * Copy a file.
+     *
+     * @param string $path    Path to the existing file.
+     * @param string $newpath The new path of the file.
+     *
+     * @throws FileExistsException   Thrown if $newpath exists.
+     * @throws FileNotFoundException Thrown if $path does not exist.
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function copy($path, $newpath);
+
+    /**
+     * Delete a file.
+     *
+     * @param string $path
+     *
+     * @throws FileNotFoundException
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function delete($path);
+
+    /**
+     * Delete a directory.
+     *
+     * @param string $dirname
+     *
+     * @throws RootViolationException Thrown if $dirname is empty.
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function deleteDir($dirname);
+
+    /**
+     * Create a directory.
+     *
+     * @param string $dirname The name of the new directory.
+     * @param array  $config  An optional configuration array.
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function createDir($dirname, array $config = []);
+
+    /**
+     * Set the visibility for a file.
+     *
+     * @param string $path       The path to the file.
+     * @param string $visibility One of 'public' or 'private'.
+     *
+     * @throws FileNotFoundException
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function setVisibility($path, $visibility);
+
+    /**
+     * Create a file or update if exists.
+     *
+     * @param string $path     The path to the file.
+     * @param string $contents The file contents.
+     * @param array  $config   An optional configuration array.
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function put($path, $contents, array $config = []);
+
+    /**
+     * Create a file or update if exists.
+     *
+     * @param string   $path     The path to the file.
+     * @param resource $resource The file handle.
+     * @param array    $config   An optional configuration array.
+     *
+     * @throws InvalidArgumentException Thrown if $resource is not a resource.
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function putStream($path, $resource, array $config = []);
+
+    /**
+     * Read and delete a file.
+     *
+     * @param string $path The path to the file.
+     *
+     * @throws FileNotFoundException
+     *
+     * @return string|false The file contents, or false on failure.
+     */
+    public function readAndDelete($path);
+
+    /**
+     * Get a file/directory handler.
+     *
+     * @deprecated
+     *
+     * @param string  $path    The path to the file.
+     * @param Handler $handler An optional existing handler to populate.
+     *
+     * @return Handler Either a file or directory handler.
+     */
+    public function get($path, Handler $handler = null);
+
+    /**
+     * Register a plugin.
+     *
+     * @param PluginInterface $plugin The plugin to register.
+     *
+     * @return $this
+     */
+    public function addPlugin(PluginInterface $plugin);
+}

--- a/.phpstan/stubs/MimeTypeGuesserInterface.stub
+++ b/.phpstan/stubs/MimeTypeGuesserInterface.stub
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\File\MimeType;
+
+use Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException;
+use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
+use Symfony\Component\Mime\MimeTypesInterface;
+
+/**
+ * Guesses the mime type of a file.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated since Symfony 4.3, use {@link MimeTypesInterface} instead
+ */
+interface MimeTypeGuesserInterface
+{
+    /**
+     * Guesses the mime type of the file with the given path.
+     *
+     * @param string $path The path to the file
+     *
+     * @return string|null The mime type or NULL, if none could be guessed
+     *
+     * @throws FileNotFoundException If the file does not exist
+     * @throws AccessDeniedException If the file could not be read
+     */
+    public function guess($path);
+}

--- a/.phpstan/stubs/ReadInterface.stub
+++ b/.phpstan/stubs/ReadInterface.stub
@@ -1,0 +1,88 @@
+<?php
+
+namespace League\Flysystem;
+
+interface ReadInterface
+{
+    /**
+     * Check whether a file exists.
+     *
+     * @param string $path
+     *
+     * @return array|bool|null
+     */
+    public function has($path);
+
+    /**
+     * Read a file.
+     *
+     * @param string $path
+     *
+     * @return array|false
+     */
+    public function read($path);
+
+    /**
+     * Read a file as a stream.
+     *
+     * @param string $path
+     *
+     * @return array|false
+     */
+    public function readStream($path);
+
+    /**
+     * List contents of a directory.
+     *
+     * @param string $directory
+     * @param bool   $recursive
+     *
+     * @return array
+     */
+    public function listContents($directory = '', $recursive = false);
+
+    /**
+     * Get all the meta data of a file or directory.
+     *
+     * @param string $path
+     *
+     * @return array|false
+     */
+    public function getMetadata($path);
+
+    /**
+     * Get the size of a file.
+     *
+     * @param string $path
+     *
+     * @return array|false
+     */
+    public function getSize($path);
+
+    /**
+     * Get the mimetype of a file.
+     *
+     * @param string $path
+     *
+     * @return array|false
+     */
+    public function getMimetype($path);
+
+    /**
+     * Get the last modified time of a file as a timestamp.
+     *
+     * @param string $path
+     *
+     * @return array|false
+     */
+    public function getTimestamp($path);
+
+    /**
+     * Get the visibility of a file.
+     *
+     * @param string $path
+     *
+     * @return array|false
+     */
+    public function getVisibility($path);
+}

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "doctrine/persistence": "^1.3|^2.0",
         "enqueue/enqueue-bundle": "^0.9|^0.10",
         "league/flysystem": "^1.0|^2.0",
+        "phpstan/phpstan": "^0.12.64",
         "psr/log": "^1.0",
         "symfony/browser-kit": "^3.4|^4.3|^5.0",
         "symfony/console": "^3.4|^4.3|^5.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,27 @@
+includes:
+    - .phpstan/baseline.neon
+parameters:
+    level: 1
+    paths:
+        - Async
+        - Binary
+        - Command
+        - Component
+        - Config
+        - Controller
+        - DependencyInjection
+        - Events
+        - Exception
+        - Factory
+        - Form
+        - Imagine
+        - Model
+        - Resources
+        - Service
+        - Templating
+        - Utility
+        - LiipImagineBundle.php
+    scanFiles:
+        - .phpstan/stubs/Event.stub
+        - .phpstan/stubs/ExtensionGuesserInterface.stub
+        - .phpstan/stubs/MimeTypeGuesserInterface.stub

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,6 +22,9 @@ parameters:
         - Utility
         - LiipImagineBundle.php
     scanFiles:
+        - .phpstan/stubs/AdapterInterface.stub
         - .phpstan/stubs/Event.stub
         - .phpstan/stubs/ExtensionGuesserInterface.stub
+        - .phpstan/stubs/FilesystemInterface.stub
         - .phpstan/stubs/MimeTypeGuesserInterface.stub
+        - .phpstan/stubs/ReadInterface.stub


### PR DESCRIPTION
Rebased #1336 and solved conflicts

| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | fix #1336
| License | MIT
| Doc PR |
 
As discussed with @dbu, here is a PR to replace most of Scrutinizer work with static code analysis.

I choose PHPStan as I use it daily at work and it's the tool used by SonataAdminBundle which is my main source of inspiration for all my GitHub Actions PRs.