### PR TITLE
test to check the twig filter behaviour

### DIFF
--- a/Tests/Templating/AbstractFilterTest.php
+++ b/Tests/Templating/AbstractFilterTest.php
@@ -28,22 +28,32 @@ abstract class AbstractFilterTest extends AbstractTest
         $this->assertSame('liip_imagine', $this->createTemplatingMock()->getName());
     }
 
-    public function testInvokeFilterMethod(): void
+    public function provideImageNames(): iterable
+    {
+        yield 'regular' => ['image' => 'cats.jpeg', 'urlimage' => 'cats.jpeg'];
+        yield 'whitespace' => ['image' => 'white cat.jpeg', 'urlimage' => 'white%20cat.jpeg'];
+        yield 'plus' => ['image' => 'cat+plus.jpeg', 'urlimage' => 'cat%2Bplus.jpeg'];
+        yield 'questionmark' => ['image' => 'cat?question.jpeg', 'urlimage' => 'cat%3Fquestion.jpeg'];
+        yield 'hash' => ['image' => 'cat#hash.jpeg', 'urlimage' => 'cat%23hash.jpeg'];
+    }
+
+    /**
+     * @dataProvider provideImageNames
+     */
+    public function testInvokeFilterMethod($image, $urlimage): void
     {
         $expectedFilter = 'thumbnail';
-        $expectedInputPath = 'thePathToTheImage';
-        $expectedCachePath = 'thePathToTheCachedImage';
 
         $manager = $this->createCacheManagerMock();
         $manager
             ->expects($this->once())
             ->method('getBrowserPath')
-            ->with($expectedInputPath, $expectedFilter)
-            ->willReturn($expectedCachePath);
+            ->with($image, $expectedFilter)
+            ->willReturn($urlimage);
 
-        $actualPath = $this->createTemplatingMock($manager)->filter($expectedInputPath, $expectedFilter);
+        $actualPath = $this->createTemplatingMock($manager)->filter($image, $expectedFilter);
 
-        $this->assertSame($expectedCachePath, $actualPath);
+        $this->assertSame($urlimage, $actualPath);
     }
 
     public function testInvokeFilterCacheMethod(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | ?
| Deprecations? | no
| Tests pass? | no
| Fixed tickets | 
| License | MIT
| Doc PR | 

trying out what happens with the twig filter and various file names.

see also #1291 and #1240 - note that the `parse_url` only acts when creating the url to the image, not when receiving the request. so the security issue i mention in #1291 and #1240 is actually not solved by `parse_url` at all. it would need to be handled either in the controller, or in the cache manager or loaders.

the original reason to add the `parse_url` given in #1116 was that e.g. the symfony `asset` function can add a version query string to the filename, if asset versioning is enabled. see also #903

it looks to me like we need a solution for the asset function (and potentially other things) but that does not break on some filenames.

if we fix the query string thing of assets (#903) we can also address #168