### PR TITLE
lazy twig extension: handle asset versioning, added imagine_filter_cache, better test coverage

### DIFF
--- a/DependencyInjection/Compiler/AssetsVersionCompilerPass.php
+++ b/DependencyInjection/Compiler/AssetsVersionCompilerPass.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Inject the Symfony framework assets version parameter to the
+ * LiipImagineBundle twig extension if possible.
+ *
+ * We extract the version parameter from the StaticVersionStrategy service
+ * definition. If anything is not as expected, we log a warning and do nothing.
+ *
+ * The expectation is for the user to configure the assets version in liip
+ * imagine for custom setups.
+ *
+ * Anything other than StaticVersionStrategy needs to be implemented by the
+ * user in CacheResolveEvent event listeners.
+ */
+class AssetsVersionCompilerPass extends AbstractCompilerPass
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!class_exists(StaticVersionStrategy::class)
+            // this application has no asset version configured
+            || !$container->has('assets._version__default')
+            // we are not using the new LazyFilterRuntime
+            || !$container->hasDefinition('liip_imagine.templating.filter_runtime')
+        ) {
+            return;
+        }
+        $runtimeDefinition = $container->getDefinition('liip_imagine.templating.filter_runtime');
+        if (null !== $runtimeDefinition->getArgument(1)) {
+            // the asset version has been set explicitly
+            return;
+        }
+
+        $versionStrategyDefinition = $container->findDefinition('assets._version__default');
+        if (!is_a($versionStrategyDefinition->getClass(), StaticVersionStrategy::class, true)) {
+            $this->log($container, 'Symfony assets versioning strategy "'.$versionStrategyDefinition->getClass().'" not automatically supported. Configure liip_imagine.twig.assets_version if you have problems with assets versioning');
+
+            return;
+        }
+        $version = $versionStrategyDefinition->getArgument(0);
+        $format = $versionStrategyDefinition->getArgument(1);
+        $format = $container->resolveEnvPlaceholders($format);
+        if ($format && !$this->str_ends_with($format, '?%%s')) {
+            $this->log($container, 'Can not handle assets versioning with custom format "'.$format.'". asset twig function can likely not be used with the imagine_filter');
+
+            return;
+        }
+
+        $runtimeDefinition->setArgument(1, $version);
+    }
+
+    /**
+     * Can be replaced with the built-in method when dropping support for PHP < 8.0
+     */
+    private function str_ends_with(string $haystack, string $needle): bool
+    {
+        return mb_substr($haystack, -mb_strlen($needle)) === $needle;
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -195,19 +195,25 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end()
-            ->enumNode('twig_mode')
-                ->defaultValue('legacy')
-                ->info('Twig mode: none/lazy/legacy (default)')
-                ->values(['none', 'lazy', 'legacy'])
-                ->validate()
-                    ->ifTrue(function ($v) {
-                        return 'legacy' === $v;
-                    })
-                    ->then(function ($v) {
-                        @trigger_error('Twig "legacy" mode has been deprecated and will be removed in 3.0. Use "none" or "lazy".', E_USER_DEPRECATED);
+            ->arrayNode('twig')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->enumNode('mode')
+                        ->defaultValue('legacy')
+                        ->info('Twig mode: none/lazy/legacy (default)')
+                        ->values(['none', 'lazy', 'legacy'])
+                        ->validate()
+                            ->ifTrue(function ($v) {
+                                return 'legacy' === $v;
+                            })
+                            ->then(function ($v) {
+                                @trigger_error('Twig "legacy" mode has been deprecated and will be removed in 3.0. Use "none" or "lazy".', E_USER_DEPRECATED);
 
-                        return $v;
-                    })
+                                return $v;
+                            })
+                        ->end()
+                    ->end()
+                    ->scalarNode('assets_version')->defaultNull()->end()
                 ->end()
             ->end()
             ->booleanNode('enqueue')

--- a/LiipImagineBundle.php
+++ b/LiipImagineBundle.php
@@ -13,6 +13,7 @@ namespace Liip\ImagineBundle;
 
 use Enqueue\Bundle\DependencyInjection\Compiler\AddTopicMetaPass;
 use Liip\ImagineBundle\Async\Topics;
+use Liip\ImagineBundle\DependencyInjection\Compiler\AssetsVersionCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\DriverCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\FiltersCompilerPass;
 use Liip\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass;
@@ -29,6 +30,7 @@ use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\FlysystemResolverFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\WebPathResolverFactory;
 use Liip\ImagineBundle\DependencyInjection\LiipImagineExtension;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -42,6 +44,7 @@ class LiipImagineBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new NonFunctionalFilterExceptionPass());
+        $container->addCompilerPass(new AssetsVersionCompilerPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new DriverCompilerPass());
         $container->addCompilerPass(new LoadersCompilerPass());
         $container->addCompilerPass(new FiltersCompilerPass());

--- a/Resources/config/imagine_twig_mode_lazy.xml
+++ b/Resources/config/imagine_twig_mode_lazy.xml
@@ -13,6 +13,7 @@
         <service id="liip_imagine.templating.filter_runtime" class="Liip\ImagineBundle\Templating\LazyFilterRuntime" public="false">
             <tag name="twig.runtime" />
             <argument type="service" id="liip_imagine.cache.manager" />
+            <argument>null</argument>
         </service>
 
     </services>

--- a/Resources/doc/asset-versioning.rst
+++ b/Resources/doc/asset-versioning.rst
@@ -1,0 +1,50 @@
+
+
+Asset Versioning
+================
+
+You can configure Symfony to append an `asset version`_ to the asset URLs. This
+is used to bust the cache after changes if you make clients cache assets for a
+long time.
+
+If you use the Twig ``asset`` function to resolve an image file name relative
+to the public web folder and then put the result into ``imagine_filter``, the
+query string would normally be considered part of the file name, making it so
+that the file can not be found.
+
+Since LiipImagineBundle version 2.7, we integrate with the configuration
+setting for ``framework.assets.version``. It strips the version from the file
+name and appends it to the resulting image URL so that the file is found and
+cache busting is used.
+
+Cache Busting
+~~~~~~~~~~~~~
+
+If you allow clients to cache your images, it can make sense to use asset
+versioning to bust the cache of your images. This can help for example after
+you changed the settings of a filter set.
+
+If you use ``framework.assets.version``, change the asset version in that case.
+If you do not use Symfony asset versioning, set the
+``liip_imagine.twig.assets_version`` parameter. Note that you still need to
+clear/refresh the cached images to have them updated, the asset version is only
+relevant for HTTP caches but not for the LiipImagineBundle cache.
+
+This approach works well for changed filter sets, but not for changes to
+individual images. For those, the best approach is to have a versioning in the
+file name or using the ``CacheResolveEvent`` to change the URL of the image.
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+If the version query is not handled correctly, check the logs during container
+building. If you use a custom asset versioning, you can configure the
+``liip_imagine.twig.assets_version`` parameter with the version string to look
+for.
+
+To completely disable asset version handling by LiipImagineBundle, you can set
+``liip_imagine.twig.assets_version`` to ``false``. But be aware that if you
+configured Symfony to append an asset version, you now won't be able to use the
+``asset`` Twig function with the ``imagine_filter``.
+
+.. _`asset version`: https://symfony.com/doc/current/reference/configuration/framework.html#reference-framework-assets-version

--- a/Resources/doc/basic-usage.rst
+++ b/Resources/doc/basic-usage.rst
@@ -116,10 +116,17 @@ for subsequent requests. The final cached image path would be similar to
 
 .. tip::
 
-    You can prepare the cache in advance with either :doc:`the <commands>` or the
-    :doc:`message queue <resolve-cache-images-in-background>`. When you do that,
-    you can use the ``imagine_filter_cache`` filter to always return a link to
-    the final cached image.
+    You can prepare the cache in advance with either the :doc:`commands <commands>`
+    or the :doc:`message queue <resolve-cache-images-in-background>`. When you
+    do that, you can use the ``imagine_filter_cache`` filter to always return a
+    link to the final cached image.
+
+.. note::
+
+    When you use the ``asset`` function to resolve image paths and have asset
+    versioning configured, the ``imagine_filter`` tries to handle the version
+    query string. See :doc:`asset versioning <asset-versioning>` for more
+    information.
 
 .. note::
 
@@ -134,7 +141,6 @@ for subsequent requests. The final cached image path would be similar to
 
         web_profiler:
             intercept_redirects: false
-
 
 Runtime Options
 ---------------

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -25,7 +25,8 @@ The default configuration for the bundle looks like this:
         cache:                default
         data_loader:          default
         default_image:        null
-        twig_mode:            legacy
+        twig:
+            mode:             legacy
         default_filter_set_settings:
             quality:              100
             jpeg_quality:         ~
@@ -77,10 +78,13 @@ There are several configuration options available:
   the standard web_path resolver is used)
 * ``data_loader`` - name of a custom data loader. Default value: ``filesystem``
   (which means the standard filesystem loader is used).
-* ``twig_mode`` - Twig filter integration. ``none`` disables the twig filters, ``lazy`` enables
+* ``twig.mode`` - Twig filter integration. ``none`` disables the twig filters, ``lazy`` enables
   Twig using the Twig runtime for lazy loading. The default value is ``legacy`` and enables the
   old Twig integration that is loaded on each request. Version 3 will drop ``legacy`` and default
   to ``lazy``.
+  The twig filter automatically picks up the ``framework.assets.version`` configuration. You can
+  overwrite the version with the ``twig.assets_version`` option. See :doc:`asset-versioning` for
+  more information.
 * ``controller``
     * ``filter_action`` - name of the controller action to use in the route loader.
       Default value: ``liip_imagine.controller:filterAction``

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -43,6 +43,7 @@ usage to the architecture of bundle.
     data-loaders
     cache-resolvers
     cache-manager
+    asset-versioning
     commands
 
 .. toctree::

--- a/Templating/LazyFilterExtension.php
+++ b/Templating/LazyFilterExtension.php
@@ -23,6 +23,7 @@ final class LazyFilterExtension extends AbstractExtension
     {
         return [
             new TwigFilter('imagine_filter', [LazyFilterRuntime::class, 'filter']),
+            new TwigFilter('imagine_filter_cache', [LazyFilterRuntime::class, 'filterCache']),
         ];
     }
 

--- a/Tests/Templating/LazyFilterExtensionTest.php
+++ b/Tests/Templating/LazyFilterExtensionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Templating;
+
+use Liip\ImagineBundle\Templating\LazyFilterExtension;
+use Liip\ImagineBundle\Tests\AbstractTest;
+
+/**
+ * @covers \Liip\ImagineBundle\Templating\LazyFilterExtension
+ */
+class LazyFilterExtensionTest extends AbstractTest
+{
+    /**
+     * @var LazyFilterExtension
+     */
+    private $extension;
+
+    protected function setUp(): void
+    {
+        $this->extension = new LazyFilterExtension();
+    }
+
+    public function testAddsFilterMethodToFiltersList(): void
+    {
+        $this->assertCount(2, $this->extension->getFilters());
+    }
+}

--- a/Tests/Templating/LazyFilterRuntimeTest.php
+++ b/Tests/Templating/LazyFilterRuntimeTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Templating;
+
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Liip\ImagineBundle\Templating\LazyFilterRuntime;
+use Liip\ImagineBundle\Tests\AbstractTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * @covers \Liip\ImagineBundle\Templating\LazyFilterRuntime
+ */
+class LazyFilterRuntimeTest extends AbstractTest
+{
+    /**
+     * @var LazyFilterRuntime
+     */
+    private $runtime;
+    /**
+     * @var CacheManager&MockObject
+     */
+    private $manager;
+
+    protected function setUp(): void
+    {
+        $this->manager = $this->createCacheManagerMock();
+        $this->runtime = new LazyFilterRuntime($this->manager);
+    }
+
+    public function provideImageNames(): iterable
+    {
+        yield 'regular' => ['image' => 'cats.jpeg', 'urlimage' => 'cats.jpeg'];
+        yield 'whitespace' => ['image' => 'white cat.jpeg', 'urlimage' => 'white%20cat.jpeg'];
+        yield 'plus' => ['image' => 'cat+plus.jpeg', 'urlimage' => 'cat%2Bplus.jpeg'];
+        yield 'questionmark' => ['image' => 'cat?question.jpeg', 'urlimage' => 'cat%3Fquestion.jpeg'];
+        yield 'hash' => ['image' => 'cat#hash.jpeg', 'urlimage' => 'cat%23hash.jpeg'];
+    }
+
+    /**
+     * @dataProvider provideImageNames
+     */
+    public function testInvokeFilterMethod($image, $urlimage): void
+    {
+        $expectedFilter = 'thumbnail';
+
+        $this->manager
+            ->expects($this->once())
+            ->method('getBrowserPath')
+            ->with($image, $expectedFilter)
+            ->willReturn($urlimage)
+        ;
+
+        $actualPath = $this->runtime->filter($image, $expectedFilter);
+
+        $this->assertSame($urlimage, $actualPath);
+    }
+
+    public function testInvokeFilterCacheMethod(): void
+    {
+        $expectedFilter = 'thumbnail';
+        $expectedInputPath = 'thePathToTheImage';
+        $expectedCachePath = 'thePathToTheCachedImage';
+
+        $this->manager
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($expectedInputPath, $expectedFilter)
+            ->willReturn($expectedCachePath);
+
+        $actualPath = $this->runtime->filterCache($expectedInputPath, $expectedFilter);
+
+        $this->assertSame($expectedCachePath, $actualPath);
+    }
+
+    public function testInvokeFilterCacheMethodWithRuntimeConfig(): void
+    {
+        $expectedFilter = 'thumbnail';
+        $expectedInputPath = 'thePathToTheImage';
+        $expectedCachePath = 'thePathToTheCachedImage';
+        $expectedRuntimeConfig = [
+            'thumbnail' => [
+                'size' => [100, 100],
+            ],
+        ];
+        $expectedRuntimeConfigPath = 'thePathToTheImageWithRuntimeConfig';
+
+        $this->manager
+            ->expects($this->once())
+            ->method('getRuntimePath')
+            ->with($expectedInputPath, $expectedRuntimeConfig)
+            ->willReturn($expectedRuntimeConfigPath)
+        ;
+        $this->manager
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($expectedRuntimeConfigPath, $expectedFilter)
+            ->willReturn($expectedCachePath)
+        ;
+
+        $actualPath = $this->runtime->filterCache($expectedInputPath, $expectedFilter, $expectedRuntimeConfig);
+
+        $this->assertSame($expectedCachePath, $actualPath);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require": {
         "php": "^7.1|^8.0",
+        "ext-mbstring": "*",
         "imagine/imagine": "^1.2.4",
         "symfony/filesystem": "^3.4|^4.3|^5.0",
         "symfony/finder": "^3.4|^4.3|^5.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | -
| Fixed tickets | fix #1392, #1291, #1240, #1172
| License | MIT
| Doc PR | :heavy_check_mark: 

While looking over things, i came up with a different approach that is less invasive than `parse_url` and as a bonus actually nicely handles asset versioning. this accidentally even provides a simplistic solution for #168 (with just one global version, which could be helpful when changing filter sets)