### PR TITLE
Bugfix: Don't resolve to webp in the controller if webp generation is disabled

### DIFF
--- a/Service/FilterService.php
+++ b/Service/FilterService.php
@@ -182,7 +182,7 @@ class FilterService
     ): string {
         $path = $filterPathContainer->getTarget();
 
-        if ($webpSupported) {
+        if ($this->webpGenerate && $webpSupported) {
             $path = $filterPathContainer->createWebp($this->webpOptions)->getTarget();
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.0
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #1408
| License | MIT
| Doc PR | -

Continuation of #1408, cleaning up the tests.