### PR TITLE
validation for configuration to have readable error instead of fatal php error

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,11 +13,13 @@ namespace Liip\ImagineBundle\DependencyInjection;
 
 use Liip\ImagineBundle\Config\Controller\ControllerConfig;
 use Liip\ImagineBundle\Controller\ImagineController;
+use Liip\ImagineBundle\DependencyInjection\Factory\FactoryInterface;
 use Liip\ImagineBundle\DependencyInjection\Factory\Loader\LoaderFactoryInterface;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class Configuration implements ConfigurationInterface
 {
@@ -263,18 +265,35 @@ class Configuration implements ConfigurationInterface
 
     private function addResolversSections(ArrayNodeDefinition $resolversPrototypeNode)
     {
-        $this->addConfigurationSections($this->resolversFactories, $resolversPrototypeNode);
+        $this->addConfigurationSections($this->resolversFactories, $resolversPrototypeNode, 'resolver');
     }
 
     private function addLoadersSections(ArrayNodeDefinition $resolversPrototypeNode)
     {
-        $this->addConfigurationSections($this->loadersFactories, $resolversPrototypeNode);
+        $this->addConfigurationSections($this->loadersFactories, $resolversPrototypeNode, 'loader');
     }
 
-    private function addConfigurationSections(array $factories, ArrayNodeDefinition $definition)
+    /**
+     * @param FactoryInterface[] $factories
+     */
+    private function addConfigurationSections(array $factories, ArrayNodeDefinition $definition, $type)
     {
         foreach ($factories as $f) {
             $f->addConfiguration($definition->children()->arrayNode($f->getName()));
         }
+
+        $definition->end()
+            ->validate()
+            ->ifTrue(function ($array) use ($type) {
+                foreach ($array as $name => $element) {
+                    if (!$element) {
+                        throw new InvalidConfigurationException(ucfirst($type).' "'.$name.'" must have a factory configured');
+                    }
+                }
+
+                return false;
+            })
+            ->thenInvalid('Each '.$type.' must have a factory configured')
+            ->end();
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| License | MIT
| Doc | -

previously, if you create an empty resolvers / loaders section with no factories, you would get an `undefined array key ""` error from the LiipImagineExtension.