### PR TITLE
Drop support PHP < 7.4 and add type declarations to Imagine folder

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,13 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.4', '8.0']
         dependencies: [highest]
         symfony: ['*']
         stability: ['stable']
         include:
           # Minimum supported dependencies with the oldest supported PHP version
-          - php: '7.1'
+          - php: '7.4'
             dependencies: lowest
             symfony: '*'
             stability: 'stable'
@@ -32,12 +32,12 @@ jobs:
             stability: 'stable'
 
           # Test each supported Symfony version with lowest supported PHP version
-          - php: '7.1'
+          - php: '7.4'
             dependencies: highest
             symfony: '4.4.*'
             stability: 'stable'
 
-          - php: '7.2'
+          - php: '7.4'
             dependencies: highest
             symfony: '5.3.*'
             stability: 'stable'

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.4|^8.0",
         "ext-mbstring": "*",
         "imagine/imagine": "^1.2.4",
         "symfony/filesystem": "^4.4|^5.3",

--- a/src/Imagine/Cache/CacheManager.php
+++ b/src/Imagine/Cache/CacheManager.php
@@ -23,54 +23,33 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class CacheManager
 {
-    /**
-     * @var FilterConfiguration
-     */
-    protected $filterConfig;
+    protected FilterConfiguration $filterConfig;
 
-    /**
-     * @var RouterInterface
-     */
-    protected $router;
+    protected RouterInterface $router;
 
     /**
      * @var ResolverInterface[]
      */
-    protected $resolvers = [];
+    protected array $resolvers = [];
 
-    /**
-     * @var SignerInterface
-     */
-    protected $signer;
+    protected SignerInterface $signer;
 
-    /**
-     * @var EventDispatcherInterface
-     */
-    protected $dispatcher;
+    protected EventDispatcherInterface $dispatcher;
 
-    /**
-     * @var string
-     */
-    protected $defaultResolver;
+    protected string $defaultResolver;
 
-    /**
-     * @var bool
-     */
-    private $webpGenerate;
+    private bool $webpGenerate;
 
     /**
      * Constructs the cache manager to handle Resolvers based on the provided FilterConfiguration.
-     *
-     * @param string $defaultResolver
-     * @param bool   $webpGenerate
      */
     public function __construct(
         FilterConfiguration $filterConfig,
         RouterInterface $router,
         SignerInterface $signer,
         EventDispatcherInterface $dispatcher,
-        $defaultResolver = null,
-        $webpGenerate = false
+        ?string $defaultResolver = null,
+        bool $webpGenerate = false
     ) {
         $this->filterConfig = $filterConfig;
         $this->router = $router;
@@ -82,10 +61,8 @@ class CacheManager
 
     /**
      * Adds a resolver to handle cached images for the given filter.
-     *
-     * @param string $filter
      */
-    public function addResolver($filter, ResolverInterface $resolver)
+    public function addResolver(string $filter, ResolverInterface $resolver): void
     {
         $this->resolvers[$filter] = $resolver;
 
@@ -98,14 +75,9 @@ class CacheManager
      * Gets filtered path for rendering in the browser.
      * It could be the cached one or an url of filter action.
      *
-     * @param string $path          The path where the resolved file is expected
-     * @param string $filter
-     * @param string $resolver
-     * @param int    $referenceType
-     *
-     * @return string
+     * @param string $path The path where the resolved file is expected
      */
-    public function getBrowserPath($path, $filter, array $runtimeConfig = [], $resolver = null, $referenceType = UrlGeneratorInterface::ABSOLUTE_URL)
+    public function getBrowserPath(string $path, string $filter, array $runtimeConfig = [], ?string $resolver = null, int $referenceType = UrlGeneratorInterface::ABSOLUTE_URL): string
     {
         if (!empty($runtimeConfig)) {
             $rcPath = $this->getRuntimePath($path, $runtimeConfig);
@@ -122,12 +94,8 @@ class CacheManager
 
     /**
      * Get path to runtime config image.
-     *
-     * @param string $path
-     *
-     * @return string
      */
-    public function getRuntimePath($path, array $runtimeConfig)
+    public function getRuntimePath(string $path, array $runtimeConfig): string
     {
         $path = ltrim($path, '/');
 
@@ -139,12 +107,9 @@ class CacheManager
      *
      * @param string $path          The path where the resolved file is expected
      * @param string $filter        The name of the imagine filter in effect
-     * @param string $resolver
      * @param int    $referenceType The type of reference to be generated (one of the UrlGenerator constants)
-     *
-     * @return string
      */
-    public function generateUrl($path, $filter, array $runtimeConfig = [], $resolver = null, $referenceType = UrlGeneratorInterface::ABSOLUTE_URL)
+    public function generateUrl(string $path, string $filter, array $runtimeConfig = [], ?string $resolver = null, int $referenceType = UrlGeneratorInterface::ABSOLUTE_URL): string
     {
         $params = [
             'path' => ltrim($path, '/'),
@@ -169,14 +134,8 @@ class CacheManager
 
     /**
      * Checks whether the path is already stored within the respective Resolver.
-     *
-     * @param string $path
-     * @param string $filter
-     * @param string $resolver
-     *
-     * @return bool
      */
-    public function isStored($path, $filter, $resolver = null)
+    public function isStored(string $path, string $filter, ?string $resolver = null): bool
     {
         return $this->getResolver($filter, $resolver)->isStored($path, $filter);
     }
@@ -184,15 +143,11 @@ class CacheManager
     /**
      * Resolves filtered path for rendering in the browser.
      *
-     * @param string $path
-     * @param string $filter
-     * @param string $resolver
-     *
      * @throws NotFoundHttpException if the path can not be resolved
      *
      * @return string The url of resolved image
      */
-    public function resolve($path, $filter, $resolver = null)
+    public function resolve(string $path, string $filter, ?string $resolver = null): string
     {
         if (false !== mb_strpos($path, '/../') || 0 === mb_strpos($path, '../')) {
             throw new NotFoundHttpException(sprintf("Source image was searched with '%s' outside of the defined root path", $path));
@@ -211,12 +166,8 @@ class CacheManager
 
     /**
      * @see ResolverInterface::store
-     *
-     * @param string $path
-     * @param string $filter
-     * @param string $resolver
      */
-    public function store(BinaryInterface $binary, $path, $filter, $resolver = null)
+    public function store(BinaryInterface $binary, string $path, string $filter, ?string $resolver = null): void
     {
         $this->getResolver($filter, $resolver)->store($binary, $path, $filter);
     }
@@ -225,7 +176,7 @@ class CacheManager
      * @param string|string[]|null $paths
      * @param string|string[]|null $filters
      */
-    public function remove($paths = null, $filters = null)
+    public function remove($paths = null, $filters = null): void
     {
         if (null === $filters) {
             $filters = array_keys($this->filterConfig->all());
@@ -260,14 +211,9 @@ class CacheManager
      *
      * In case there is no specific resolver, but a default resolver has been configured, the default will be returned.
      *
-     * @param string $filter
-     * @param string $resolver
-     *
      * @throws \OutOfBoundsException If neither a specific nor a default resolver is available
-     *
-     * @return ResolverInterface
      */
-    protected function getResolver($filter, $resolver)
+    protected function getResolver(string $filter, ?string $resolver): ResolverInterface
     {
         // BC
         if (!$resolver) {

--- a/src/Imagine/Cache/CacheManagerAwareInterface.php
+++ b/src/Imagine/Cache/CacheManagerAwareInterface.php
@@ -13,5 +13,5 @@ namespace Liip\ImagineBundle\Imagine\Cache;
 
 interface CacheManagerAwareInterface
 {
-    public function setCacheManager(CacheManager $cacheManager);
+    public function setCacheManager(CacheManager $cacheManager): void;
 }

--- a/src/Imagine/Cache/CacheManagerAwareTrait.php
+++ b/src/Imagine/Cache/CacheManagerAwareTrait.php
@@ -13,12 +13,9 @@ namespace Liip\ImagineBundle\Imagine\Cache;
 
 trait CacheManagerAwareTrait
 {
-    /**
-     * @var CacheManager
-     */
-    protected $cacheManager;
+    protected CacheManager $cacheManager;
 
-    public function setCacheManager(CacheManager $cacheManager)
+    public function setCacheManager(CacheManager $cacheManager): void
     {
         $this->cacheManager = $cacheManager;
     }

--- a/src/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
+++ b/src/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
@@ -20,29 +20,15 @@ use Symfony\Component\HttpFoundation\Request;
 
 abstract class AbstractFilesystemResolver implements ResolverInterface, CacheManagerAwareInterface
 {
-    /**
-     * @var Filesystem
-     */
-    protected $filesystem;
+    protected Filesystem $filesystem;
 
-    /**
-     * @var string
-     */
-    protected $basePath = '';
+    protected string $basePath = '';
 
-    /**
-     * @var CacheManager
-     */
-    protected $cacheManager;
+    protected CacheManager $cacheManager;
 
-    /**
-     * @var int
-     */
-    protected $folderPermissions = 0777;
-    /**
-     * @var Request
-     */
-    private $request;
+    protected int $folderPermissions = 0777;
+
+    private Request $request;
 
     /**
      * Constructs a filesystem based cache resolver.
@@ -52,49 +38,35 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
         $this->filesystem = $filesystem;
     }
 
-    /**
-     * @param Request $request
-     */
-    public function setRequest(Request $request = null)
+    public function setRequest(Request $request = null): void
     {
         $this->request = $request;
     }
 
-    public function setCacheManager(CacheManager $cacheManager)
+    public function setCacheManager(CacheManager $cacheManager): void
     {
         $this->cacheManager = $cacheManager;
     }
 
     /**
      * Set the base path to.
-     *
-     * @param $basePath
      */
-    public function setBasePath($basePath)
+    public function setBasePath(string $basePath): void
     {
         $this->basePath = $basePath;
     }
 
-    /**
-     * @param int $folderPermissions
-     */
-    public function setFolderPermissions($folderPermissions)
+    public function setFolderPermissions(int $folderPermissions): void
     {
         $this->folderPermissions = $folderPermissions;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isStored($path, $filter)
+    public function isStored(string $path, string $filter): bool
     {
         return file_exists($this->getFilePath($path, $filter));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function store(BinaryInterface $binary, $path, $filter)
+    public function store(BinaryInterface $binary, string $path, string $filter): void
     {
         $filePath = $this->getFilePath($path, $filter);
 
@@ -105,10 +77,7 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
         file_put_contents($filePath, $binary->getContent());
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function remove(array $paths, array $filters)
+    public function remove(array $paths, array $filters): void
     {
         if (empty($paths) && empty($filters)) {
             return;
@@ -140,10 +109,8 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
 
     /**
      * @throws \LogicException
-     *
-     * @return Request
      */
-    protected function getRequest()
+    protected function getRequest(): Request
     {
         if (false === $this->request) {
             throw new \LogicException('The request was not injected, inject it before using resolver.');
@@ -153,11 +120,9 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
     }
 
     /**
-     * @param string $dir
-     *
      * @throws \RuntimeException
      */
-    protected function makeFolder($dir)
+    protected function makeFolder(string $dir): void
     {
         if (!is_dir($dir)) {
             $parent = \dirname($dir);
@@ -178,8 +143,6 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
      * @param string $filter The name of the imagine filter
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     *
-     * @return string
      */
-    abstract protected function getFilePath($path, $filter);
+    abstract protected function getFilePath(string $path, string $filter): string;
 }

--- a/src/Imagine/Cache/Resolver/AmazonS3Resolver.php
+++ b/src/Imagine/Cache/Resolver/AmazonS3Resolver.php
@@ -17,30 +17,15 @@ use Psr\Log\LoggerInterface;
 
 class AmazonS3Resolver implements ResolverInterface
 {
-    /**
-     * @var \AmazonS3
-     */
-    protected $storage;
+    protected \AmazonS3 $storage;
 
-    /**
-     * @var string
-     */
-    protected $bucket;
+    protected string $bucket;
 
-    /**
-     * @var string
-     */
-    protected $acl;
+    protected string $acl;
 
-    /**
-     * @var array
-     */
-    protected $objUrlOptions;
+    protected array $objUrlOptions;
 
-    /**
-     * @var LoggerInterface
-     */
-    protected $logger;
+    protected ?LoggerInterface $logger = null;
 
     /**
      * Constructs a cache resolver storing images on Amazon S3.
@@ -50,7 +35,7 @@ class AmazonS3Resolver implements ResolverInterface
      * @param string    $acl           The ACL to use when storing new objects. Default: owner read/write, public read
      * @param array     $objUrlOptions A list of options to be passed when retrieving the object url from Amazon S3
      */
-    public function __construct(\AmazonS3 $storage, $bucket, $acl = \AmazonS3::ACL_PUBLIC, array $objUrlOptions = [])
+    public function __construct(\AmazonS3 $storage, string $bucket, string $acl = \AmazonS3::ACL_PUBLIC, array $objUrlOptions = [])
     {
         $this->storage = $storage;
         $this->bucket = $bucket;
@@ -58,7 +43,7 @@ class AmazonS3Resolver implements ResolverInterface
         $this->objUrlOptions = $objUrlOptions;
     }
 
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }
@@ -66,7 +51,7 @@ class AmazonS3Resolver implements ResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function isStored($path, $filter)
+    public function isStored(string $path, string $filter): bool
     {
         return $this->objectExists($this->getObjectPath($path, $filter));
     }
@@ -74,7 +59,7 @@ class AmazonS3Resolver implements ResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve($path, $filter)
+    public function resolve(string $path, string $filter): string
     {
         return $this->getObjectUrl($this->getObjectPath($path, $filter));
     }
@@ -82,7 +67,7 @@ class AmazonS3Resolver implements ResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function store(BinaryInterface $binary, $path, $filter)
+    public function store(BinaryInterface $binary, string $path, string $filter): void
     {
         $objectPath = $this->getObjectPath($path, $filter);
 
@@ -107,7 +92,7 @@ class AmazonS3Resolver implements ResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function remove(array $paths, array $filters)
+    public function remove(array $paths, array $filters): void
     {
         if (empty($paths) && empty($filters)) {
             return;
@@ -147,14 +132,14 @@ class AmazonS3Resolver implements ResolverInterface
      *
      * If the option is already set, it will be overwritten.
      *
-     * @see \AmazonS3::get_object_url() for available options
-     *
      * @param string $key   The name of the option
      * @param mixed  $value The value to be set
      *
      * @return AmazonS3Resolver $this
+     *
+     * @see \AmazonS3::get_object_url() for available options
      */
-    public function setObjectUrlOption($key, $value)
+    public function setObjectUrlOption(string $key, $value): self
     {
         $this->objUrlOptions[$key] = $value;
 
@@ -169,19 +154,15 @@ class AmazonS3Resolver implements ResolverInterface
      *
      * @return string The path of the object on S3
      */
-    protected function getObjectPath($path, $filter)
+    protected function getObjectPath(string $path, string $filter): string
     {
         return str_replace('//', '/', $filter.'/'.$path);
     }
 
     /**
      * Returns the URL for an object saved on Amazon S3.
-     *
-     * @param string $path
-     *
-     * @return string
      */
-    protected function getObjectUrl($path)
+    protected function getObjectUrl(string $path): string
     {
         return $this->storage->get_object_url($this->bucket, $path, 0, $this->objUrlOptions);
     }
@@ -189,13 +170,9 @@ class AmazonS3Resolver implements ResolverInterface
     /**
      * Checks whether an object exists.
      *
-     * @param string $objectPath
-     *
      * @throws \S3_Exception
-     *
-     * @return bool
      */
-    protected function objectExists($objectPath)
+    protected function objectExists(string $objectPath): bool
     {
         return $this->storage->if_object_exists($this->bucket, $objectPath);
     }
@@ -203,7 +180,7 @@ class AmazonS3Resolver implements ResolverInterface
     /**
      * @param mixed $message
      */
-    protected function logError($message, array $context = [])
+    protected function logError($message, array $context = []): void
     {
         if ($this->logger) {
             $this->logger->error($message, $context);

--- a/src/Imagine/Cache/Resolver/AwsS3Resolver.php
+++ b/src/Imagine/Cache/Resolver/AwsS3Resolver.php
@@ -18,42 +18,22 @@ use Psr\Log\LoggerInterface;
 
 class AwsS3Resolver implements ResolverInterface
 {
-    /**
-     * @var S3Client
-     */
-    protected $storage;
+    protected S3Client $storage;
 
-    /**
-     * @var string
-     */
-    protected $bucket;
+    protected string $bucket;
 
-    /**
-     * @var string
-     */
-    protected $acl;
+    protected string $acl;
 
-    /**
-     * @var array
-     */
-    protected $getOptions;
+    protected array $getOptions;
 
     /**
      * Object options added to PUT requests.
-     *
-     * @var array
      */
-    protected $putOptions;
+    protected array $putOptions;
 
-    /**
-     * @var LoggerInterface
-     */
-    protected $logger;
+    protected ?LoggerInterface $logger = null;
 
-    /**
-     * @var string
-     */
-    protected $cachePrefix;
+    protected string $cachePrefix = '';
 
     /**
      * Constructs a cache resolver storing images on Amazon S3.
@@ -64,7 +44,7 @@ class AwsS3Resolver implements ResolverInterface
      * @param array    $getOptions A list of options to be passed when retrieving the object url from Amazon S3
      * @param array    $putOptions A list of options to be passed when saving the object to Amazon S3
      */
-    public function __construct(S3Client $storage, $bucket, $acl = 'public-read', array $getOptions = [], $putOptions = [])
+    public function __construct(S3Client $storage, string $bucket, string $acl = 'public-read', array $getOptions = [], $putOptions = [])
     {
         $this->storage = $storage;
         $this->bucket = $bucket;
@@ -73,39 +53,27 @@ class AwsS3Resolver implements ResolverInterface
         $this->putOptions = $putOptions;
     }
 
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }
 
-    /**
-     * @param string $cachePrefix
-     */
-    public function setCachePrefix($cachePrefix)
+    public function setCachePrefix(string $cachePrefix): void
     {
         $this->cachePrefix = $cachePrefix;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isStored($path, $filter)
+    public function isStored(string $path, string $filter): bool
     {
         return $this->objectExists($this->getObjectPath($path, $filter));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function resolve($path, $filter)
+    public function resolve(string $path, string $filter): string
     {
         return $this->getObjectUrl($this->getObjectPath($path, $filter));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function store(BinaryInterface $binary, $path, $filter)
+    public function store(BinaryInterface $binary, string $path, string $filter): void
     {
         $objectPath = $this->getObjectPath($path, $filter);
 
@@ -134,10 +102,7 @@ class AwsS3Resolver implements ResolverInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function remove(array $paths, array $filters)
+    public function remove(array $paths, array $filters): void
     {
         if (empty($paths) && empty($filters)) {
             return;
@@ -189,14 +154,14 @@ class AwsS3Resolver implements ResolverInterface
      *
      * If the option is already set, it will be overwritten.
      *
-     * @see \Aws\S3\S3Client::getObjectUrl() for available options
-     *
      * @param string $key   The name of the option
      * @param mixed  $value The value to be set
      *
      * @return $this
+     *
+     * @see \Aws\S3\S3Client::getObjectUrl() for available options
      */
-    public function setGetOption($key, $value)
+    public function setGetOption(string $key, $value): self
     {
         $this->getOptions[$key] = $value;
 
@@ -208,14 +173,14 @@ class AwsS3Resolver implements ResolverInterface
      *
      * If the option is already set, it will be overwritten.
      *
-     * @see \Aws\S3\S3Client::putObject() for available options
-     *
      * @param string $key   The name of the option
      * @param mixed  $value The value to be set
      *
      * @return $this
+     *
+     * @see \Aws\S3\S3Client::putObject() for available options
      */
-    public function setPutOption($key, $value)
+    public function setPutOption(string $key, $value): self
     {
         $this->putOptions[$key] = $value;
 
@@ -230,7 +195,7 @@ class AwsS3Resolver implements ResolverInterface
      *
      * @return string The path of the object on S3
      */
-    protected function getObjectPath($path, $filter)
+    protected function getObjectPath(string $path, string $filter): string
     {
         $path = $this->cachePrefix
             ? sprintf('%s/%s/%s', $this->cachePrefix, $filter, $path)
@@ -241,24 +206,16 @@ class AwsS3Resolver implements ResolverInterface
 
     /**
      * Returns the URL for an object saved on Amazon S3.
-     *
-     * @param string $path
-     *
-     * @return string
      */
-    protected function getObjectUrl($path)
+    protected function getObjectUrl(string $path): string
     {
         return $this->storage->getObjectUrl($this->bucket, $path, 0, $this->getOptions);
     }
 
     /**
      * Checks whether an object exists.
-     *
-     * @param string $objectPath
-     *
-     * @return bool
      */
-    protected function objectExists($objectPath)
+    protected function objectExists(string $objectPath): bool
     {
         return $this->storage->doesObjectExist($this->bucket, $objectPath);
     }
@@ -266,7 +223,7 @@ class AwsS3Resolver implements ResolverInterface
     /**
      * @param mixed $message
      */
-    protected function logError($message, array $context = [])
+    protected function logError($message, array $context = []): void
     {
         if ($this->logger) {
             $this->logger->error($message, $context);

--- a/src/Imagine/Cache/Resolver/FlysystemResolver.php
+++ b/src/Imagine/Cache/Resolver/FlysystemResolver.php
@@ -19,53 +19,32 @@ use Symfony\Component\Routing\RequestContext;
 
 class FlysystemResolver implements ResolverInterface
 {
-    /**
-     * @var FilesystemInterface
-     */
-    protected $flysystem;
+    protected FilesystemInterface $flysystem;
 
-    /**
-     * @var RequestContext
-     */
-    protected $requestContext;
+    protected RequestContext $requestContext;
 
-    /**
-     * @var string
-     */
-    protected $webRoot;
+    protected string $webRoot;
 
-    /**
-     * @var string
-     */
-    protected $cachePrefix;
+    protected string $cachePrefix;
 
-    /**
-     * @var string
-     */
-    protected $cacheRoot;
+    protected string $cacheRoot;
 
     /**
      * Flysystem specific visibility.
      *
      * @see AdapterInterface
-     *
-     * @var string
      */
-    protected $visibility;
+    protected string $visibility;
 
     /**
      * FlysystemResolver constructor.
-     *
-     * @param string $rootUrl
-     * @param string $cachePrefix
-     * @param string $visibility
      */
     public function __construct(
         FilesystemInterface $flysystem,
         RequestContext $requestContext,
-        $rootUrl,
-        $cachePrefix = 'media/cache',
-        $visibility = AdapterInterface::VISIBILITY_PUBLIC
+        string $rootUrl,
+        string $cachePrefix = 'media/cache',
+        string $visibility = AdapterInterface::VISIBILITY_PUBLIC
     ) {
         $this->flysystem = $flysystem;
         $this->requestContext = $requestContext;
@@ -78,13 +57,8 @@ class FlysystemResolver implements ResolverInterface
 
     /**
      * Checks whether the given path is stored within this Resolver.
-     *
-     * @param string $path
-     * @param string $filter
-     *
-     * @return bool
      */
-    public function isStored($path, $filter)
+    public function isStored(string $path, string $filter): bool
     {
         return $this->flysystem->has($this->getFilePath($path, $filter));
     }
@@ -99,7 +73,7 @@ class FlysystemResolver implements ResolverInterface
      *
      * @return string The absolute URL of the cached image
      */
-    public function resolve($path, $filter)
+    public function resolve(string $path, string $filter): string
     {
         return sprintf(
             '%s/%s',
@@ -115,7 +89,7 @@ class FlysystemResolver implements ResolverInterface
      * @param string          $path   The path where the original file is expected to be
      * @param string          $filter The name of the imagine filter in effect
      */
-    public function store(BinaryInterface $binary, $path, $filter)
+    public function store(BinaryInterface $binary, string $path, string $filter): void
     {
         $this->flysystem->put(
             $this->getFilePath($path, $filter),
@@ -128,7 +102,7 @@ class FlysystemResolver implements ResolverInterface
      * @param string[] $paths   The paths where the original files are expected to be
      * @param string[] $filters The imagine filters in effect
      */
-    public function remove(array $paths, array $filters)
+    public function remove(array $paths, array $filters): void
     {
         if (empty($paths) && empty($filters)) {
             return;
@@ -152,18 +126,12 @@ class FlysystemResolver implements ResolverInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFilePath($path, $filter)
+    protected function getFilePath(string $path, string $filter): string
     {
         return $this->getFileUrl($path, $filter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFileUrl($path, $filter)
+    protected function getFileUrl(string $path, string $filter): string
     {
         // crude way of sanitizing URL scheme ("protocol") part
         $path = str_replace('://', '---', $path);

--- a/src/Imagine/Cache/Resolver/FlysystemV2Resolver.php
+++ b/src/Imagine/Cache/Resolver/FlysystemV2Resolver.php
@@ -20,53 +20,32 @@ use Symfony\Component\Routing\RequestContext;
 
 class FlysystemV2Resolver implements ResolverInterface
 {
-    /**
-     * @var FilesystemOperator
-     */
-    protected $flysystem;
+    protected FilesystemOperator $flysystem;
 
-    /**
-     * @var RequestContext
-     */
-    protected $requestContext;
+    protected RequestContext $requestContext;
 
-    /**
-     * @var string
-     */
-    protected $webRoot;
+    protected string $webRoot;
 
-    /**
-     * @var string
-     */
-    protected $cachePrefix;
+    protected string $cachePrefix;
 
-    /**
-     * @var string
-     */
-    protected $cacheRoot;
+    protected string $cacheRoot;
 
     /**
      * Flysystem specific visibility.
      *
      * @see Visibility
-     *
-     * @var string
      */
-    protected $visibility;
+    protected string $visibility;
 
     /**
      * FlysystemResolver constructor.
-     *
-     * @param string $rootUrl
-     * @param string $cachePrefix
-     * @param string $visibility
      */
     public function __construct(
         FilesystemOperator $flysystem,
         RequestContext $requestContext,
-        $rootUrl,
-        $cachePrefix = 'media/cache',
-        $visibility = Visibility::PUBLIC
+        string $rootUrl,
+        string $cachePrefix = 'media/cache',
+        string $visibility = Visibility::PUBLIC
     ) {
         $this->flysystem = $flysystem;
         $this->requestContext = $requestContext;
@@ -79,13 +58,8 @@ class FlysystemV2Resolver implements ResolverInterface
 
     /**
      * Checks whether the given path is stored within this Resolver.
-     *
-     * @param string $path
-     * @param string $filter
-     *
-     * @return bool
      */
-    public function isStored($path, $filter)
+    public function isStored(string $path, string $filter): bool
     {
         return $this->flysystem->fileExists($this->getFilePath($path, $filter));
     }
@@ -100,7 +74,7 @@ class FlysystemV2Resolver implements ResolverInterface
      *
      * @return string The absolute URL of the cached image
      */
-    public function resolve($path, $filter)
+    public function resolve(string $path, string $filter): string
     {
         return sprintf(
             '%s/%s',
@@ -116,7 +90,7 @@ class FlysystemV2Resolver implements ResolverInterface
      * @param string          $path   The path where the original file is expected to be
      * @param string          $filter The name of the imagine filter in effect
      */
-    public function store(BinaryInterface $binary, $path, $filter)
+    public function store(BinaryInterface $binary, string $path, string $filter): void
     {
         $this->flysystem->write(
             $this->getFilePath($path, $filter),
@@ -129,7 +103,7 @@ class FlysystemV2Resolver implements ResolverInterface
      * @param string[] $paths   The paths where the original files are expected to be
      * @param string[] $filters The imagine filters in effect
      */
-    public function remove(array $paths, array $filters)
+    public function remove(array $paths, array $filters): void
     {
         if (empty($paths) && empty($filters)) {
             return;
@@ -153,18 +127,12 @@ class FlysystemV2Resolver implements ResolverInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFilePath($path, $filter)
+    protected function getFilePath(string $path, string $filter): string
     {
         return $this->getFileUrl($path, $filter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFileUrl($path, $filter)
+    protected function getFileUrl(string $path, string $filter): string
     {
         // crude way of sanitizing URL scheme ("protocol") part
         $path = str_replace('://', '---', $path);

--- a/src/Imagine/Cache/Resolver/FormatExtensionResolver.php
+++ b/src/Imagine/Cache/Resolver/FormatExtensionResolver.php
@@ -16,15 +16,9 @@ use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 
 class FormatExtensionResolver implements ResolverInterface
 {
-    /**
-     * @var ResolverInterface
-     */
-    private $resolver;
+    private ResolverInterface $resolver;
 
-    /**
-     * @var FilterConfiguration
-     */
-    private $filterConfig;
+    private FilterConfiguration $filterConfig;
 
     public function __construct(ResolverInterface $resolver, FilterConfiguration $filterConfig)
     {
@@ -35,37 +29,28 @@ class FormatExtensionResolver implements ResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve($path, $filter)
+    public function resolve(string $path, string $filter): string
     {
         $path = $this->replaceExtension($path, $filter);
 
         return $this->resolver->resolve($path, $filter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function store(BinaryInterface $binary, $targetPath, $filter)
+    public function store(BinaryInterface $binary, string $path, string $filter): void
     {
-        $targetPath = $this->replaceExtension($targetPath, $filter);
+        $path = $this->replaceExtension($path, $filter);
 
-        return $this->resolver->store($binary, $targetPath, $filter);
+        $this->resolver->store($binary, $path, $filter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isStored($path, $filter)
+    public function isStored(string $path, string $filter): bool
     {
         $path = $this->replaceExtension($path, $filter);
 
         return $this->resolver->isStored($path, $filter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function remove(array $paths, array $filters)
+    public function remove(array $paths, array $filters): void
     {
         $newPaths = [];
         foreach ($paths as $path) {
@@ -77,7 +62,7 @@ class FormatExtensionResolver implements ResolverInterface
             }
         }
 
-        return $this->resolver->remove($newPaths, $filters);
+        $this->resolver->remove($newPaths, $filters);
     }
 
     private function replaceExtension(string $path, string $filter): string

--- a/src/Imagine/Cache/Resolver/NoCacheWebPathResolver.php
+++ b/src/Imagine/Cache/Resolver/NoCacheWebPathResolver.php
@@ -17,10 +17,7 @@ use Symfony\Component\Routing\RequestContext;
 
 class NoCacheWebPathResolver implements ResolverInterface
 {
-    /**
-     * @var RequestContext
-     */
-    private $requestContext;
+    private RequestContext $requestContext;
 
     public function __construct(RequestContext $requestContext)
     {
@@ -30,7 +27,7 @@ class NoCacheWebPathResolver implements ResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function isStored($path, $filter)
+    public function isStored(string $path, string $filter): bool
     {
         return true;
     }
@@ -38,7 +35,7 @@ class NoCacheWebPathResolver implements ResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve($path, $filter)
+    public function resolve(string $path, string $filter): string
     {
         $port = '';
         if ('https' === $this->requestContext->getScheme() && 443 !== $this->requestContext->getHttpsPort()) {
@@ -56,17 +53,11 @@ class NoCacheWebPathResolver implements ResolverInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function store(BinaryInterface $binary, $path, $filter)
+    public function store(BinaryInterface $binary, string $path, string $filter): void
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function remove(array $paths, array $filters)
+    public function remove(array $paths, array $filters): void
     {
     }
 }

--- a/src/Imagine/Cache/Resolver/ProxyResolver.php
+++ b/src/Imagine/Cache/Resolver/ProxyResolver.php
@@ -20,17 +20,12 @@ use Liip\ImagineBundle\Binary\BinaryInterface;
  */
 class ProxyResolver implements ResolverInterface
 {
-    /**
-     * @var ResolverInterface
-     */
-    protected $resolver;
+    protected ResolverInterface $resolver;
 
     /**
      * a list of proxy hosts (picks a random one for each generation to seed browser requests among multiple hosts).
-     *
-     * @var array
      */
-    protected $hosts = [];
+    protected array $hosts = [];
 
     /**
      * @param string[] $hosts
@@ -41,44 +36,27 @@ class ProxyResolver implements ResolverInterface
         $this->hosts = $hosts;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function resolve($path, $filter)
+    public function resolve(string $path, string $filter): string
     {
         return $this->rewriteUrl($this->resolver->resolve($path, $filter));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function store(BinaryInterface $binary, $targetPath, $filter)
+    public function store(BinaryInterface $binary, string $path, string $filter): void
     {
-        return $this->resolver->store($binary, $targetPath, $filter);
+        $this->resolver->store($binary, $path, $filter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isStored($path, $filter)
+    public function isStored(string $path, string $filter): bool
     {
         return $this->resolver->isStored($path, $filter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function remove(array $paths, array $filters)
+    public function remove(array $paths, array $filters): void
     {
-        return $this->resolver->remove($paths, $filters);
+        $this->resolver->remove($paths, $filters);
     }
 
-    /**
-     * @param $url
-     *
-     * @return string
-     */
-    protected function rewriteUrl($url)
+    protected function rewriteUrl(string $url): string
     {
         if (empty($this->hosts)) {
             return $url;

--- a/src/Imagine/Cache/Resolver/PsrCacheResolver.php
+++ b/src/Imagine/Cache/Resolver/PsrCacheResolver.php
@@ -31,20 +31,11 @@ final class PsrCacheResolver implements ResolverInterface
         '.',
     ];
 
-    /**
-     * @var CacheItemPoolInterface
-     */
-    private $cache;
+    private CacheItemPoolInterface $cache;
 
-    /**
-     * @var array
-     */
-    private $options = [];
+    private array $options = [];
 
-    /**
-     * @var ResolverInterface
-     */
-    private $resolver;
+    private ResolverInterface $resolver;
 
     /**
      * Constructor.
@@ -56,8 +47,6 @@ final class PsrCacheResolver implements ResolverInterface
      *   A "local" prefix for this wrapper. This is useful when re-using the same resolver for multiple filters.
      * * index_key
      *   The name of the index key being used to save a list of created cache keys regarding one image and filter pairing.
-     *
-     * @param OptionsResolver $optionsResolver
      */
     public function __construct(CacheItemPoolInterface $cache, ResolverInterface $cacheResolver, array $options = [], OptionsResolver $optionsResolver = null)
     {
@@ -72,10 +61,7 @@ final class PsrCacheResolver implements ResolverInterface
         $this->options = $optionsResolver->resolve($options);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isStored($path, $filter)
+    public function isStored(string $path, string $filter): bool
     {
         $cacheKey = $this->generateCacheKey($path, $filter);
 
@@ -84,10 +70,7 @@ final class PsrCacheResolver implements ResolverInterface
             $this->resolver->isStored($path, $filter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function resolve($path, $filter)
+    public function resolve(string $path, string $filter): string
     {
         $key = $this->generateCacheKey($path, $filter);
         $item = $this->cache->getItem($key);
@@ -103,18 +86,12 @@ final class PsrCacheResolver implements ResolverInterface
         return $resolved;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function store(BinaryInterface $binary, $path, $filter)
+    public function store(BinaryInterface $binary, string $path, string $filter): void
     {
         $this->resolver->store($binary, $path, $filter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function remove(array $paths, array $filters)
+    public function remove(array $paths, array $filters): void
     {
         $this->resolver->remove($paths, $filters);
 
@@ -136,10 +113,8 @@ final class PsrCacheResolver implements ResolverInterface
      *
      * @param string $path   The image path in use
      * @param string $filter The filter in use
-     *
-     * @return string
      */
-    public function generateCacheKey($path, $filter)
+    public function generateCacheKey(?string $path, string $filter): string
     {
         return implode('.', [
             $this->sanitizeCacheKeyPart($this->options['global_prefix']),
@@ -149,7 +124,7 @@ final class PsrCacheResolver implements ResolverInterface
         ]);
     }
 
-    private function removePathAndFilter($path, $filter)
+    private function removePathAndFilter(?string $path, string $filter): void
     {
         $indexKey = $this->generateIndexKey($this->generateCacheKey($path, $filter));
         $indexItem = $this->cache->getItem($indexKey);
@@ -185,12 +160,8 @@ final class PsrCacheResolver implements ResolverInterface
      * Generate the index key for the given cacheKey.
      *
      * The index contains a list of cache keys related to an image and a filter.
-     *
-     * @param string $cacheKey
-     *
-     * @return string
      */
-    private function generateIndexKey($cacheKey)
+    private function generateIndexKey(string $cacheKey): string
     {
         $cacheKeyStack = explode('.', $cacheKey);
 
@@ -202,22 +173,19 @@ final class PsrCacheResolver implements ResolverInterface
         ]);
     }
 
-    /**
-     * @param string $cacheKeyPart
-     *
-     * @return string
-     */
-    private function sanitizeCacheKeyPart($cacheKeyPart)
+    private function sanitizeCacheKeyPart(?string $cacheKeyPart): string
     {
+        if (null === $cacheKeyPart) {
+            return '';
+        }
+
         return str_replace(self::RESERVED_CHARACTERS, '_', $cacheKeyPart);
     }
 
     /**
      * Save the given content to the cache and update the cache index.
-     *
-     * @return bool
      */
-    private function saveToCache(CacheItemInterface $item)
+    private function saveToCache(CacheItemInterface $item): bool
     {
         $cacheKey = $item->getKey();
 
@@ -241,7 +209,7 @@ final class PsrCacheResolver implements ResolverInterface
         return $this->cache->commit();
     }
 
-    private function configureOptions(OptionsResolver $resolver)
+    private function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'global_prefix' => 'liip_imagine.resolver_psr_cache',
@@ -258,10 +226,5 @@ final class PsrCacheResolver implements ResolverInterface
         foreach ($allowedTypesList as $option => $allowedTypes) {
             $resolver->setAllowedTypes($option, $allowedTypes);
         }
-    }
-
-    private function setDefaultOptions(OptionsResolver $resolver)
-    {
-        $this->configureOptions($resolver);
     }
 }

--- a/src/Imagine/Cache/Resolver/ResolverInterface.php
+++ b/src/Imagine/Cache/Resolver/ResolverInterface.php
@@ -18,13 +18,8 @@ interface ResolverInterface
 {
     /**
      * Checks whether the given path is stored within this Resolver.
-     *
-     * @param string $path
-     * @param string $filter
-     *
-     * @return bool
      */
-    public function isStored($path, $filter);
+    public function isStored(string $path, string $filter): bool;
 
     /**
      * Resolves filtered path for rendering in the browser.
@@ -36,7 +31,7 @@ interface ResolverInterface
      *
      * @return string The absolute URL of the cached image
      */
-    public function resolve($path, $filter);
+    public function resolve(string $path, string $filter): string;
 
     /**
      * Stores the content of the given binary.
@@ -45,11 +40,11 @@ interface ResolverInterface
      * @param string          $path   The path where the original file is expected to be
      * @param string          $filter The name of the imagine filter in effect
      */
-    public function store(BinaryInterface $binary, $path, $filter);
+    public function store(BinaryInterface $binary, string $path, string $filter): void;
 
     /**
      * @param string[] $paths   The paths where the original files are expected to be
      * @param string[] $filters The imagine filters in effect
      */
-    public function remove(array $paths, array $filters);
+    public function remove(array $paths, array $filters): void;
 }

--- a/src/Imagine/Cache/Resolver/WebPathResolver.php
+++ b/src/Imagine/Cache/Resolver/WebPathResolver.php
@@ -18,40 +18,21 @@ use Symfony\Component\Routing\RequestContext;
 
 class WebPathResolver implements ResolverInterface
 {
-    /**
-     * @var Filesystem
-     */
-    protected $filesystem;
+    protected Filesystem $filesystem;
 
-    /**
-     * @var RequestContext
-     */
-    protected $requestContext;
+    protected RequestContext $requestContext;
 
-    /**
-     * @var string
-     */
-    protected $webRoot;
+    protected string $webRoot;
 
-    /**
-     * @var string
-     */
-    protected $cachePrefix;
+    protected string $cachePrefix;
 
-    /**
-     * @var string
-     */
-    protected $cacheRoot;
+    protected string $cacheRoot;
 
-    /**
-     * @param string $webRootDir
-     * @param string $cachePrefix
-     */
     public function __construct(
         Filesystem $filesystem,
         RequestContext $requestContext,
-        $webRootDir,
-        $cachePrefix = 'media/cache'
+        string $webRootDir,
+        string $cachePrefix = 'media/cache'
     ) {
         $this->filesystem = $filesystem;
         $this->requestContext = $requestContext;
@@ -61,10 +42,7 @@ class WebPathResolver implements ResolverInterface
         $this->cacheRoot = $this->webRoot.'/'.$this->cachePrefix;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function resolve($path, $filter)
+    public function resolve(string $path, string $filter): string
     {
         return sprintf('%s/%s',
             rtrim($this->getBaseUrl(), '/'),
@@ -72,18 +50,12 @@ class WebPathResolver implements ResolverInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isStored($path, $filter)
+    public function isStored(string $path, string $filter): bool
     {
         return is_file($this->getFilePath($path, $filter));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function store(BinaryInterface $binary, $path, $filter)
+    public function store(BinaryInterface $binary, string $path, string $filter): void
     {
         $this->filesystem->dumpFile(
             $this->getFilePath($path, $filter),
@@ -91,10 +63,7 @@ class WebPathResolver implements ResolverInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function remove(array $paths, array $filters)
+    public function remove(array $paths, array $filters): void
     {
         if (empty($paths) && empty($filters)) {
             return;
@@ -118,26 +87,17 @@ class WebPathResolver implements ResolverInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFilePath($path, $filter)
+    protected function getFilePath(string $path, string $filter): string
     {
         return $this->webRoot.'/'.$this->getFullPath($path, $filter);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFileUrl($path, $filter)
+    protected function getFileUrl(string $path, string $filter): string
     {
         return PathHelper::filePathToUrlPath($this->getFullPath($path, $filter));
     }
 
-    /**
-     * @return string
-     */
-    protected function getBaseUrl()
+    protected function getBaseUrl(): string
     {
         $port = '';
         if ('https' === $this->requestContext->getScheme() && 443 !== $this->requestContext->getHttpsPort()) {
@@ -162,7 +122,7 @@ class WebPathResolver implements ResolverInterface
         );
     }
 
-    private function getFullPath($path, $filter)
+    private function getFullPath(string $path, string $filter): string
     {
         // crude way of sanitizing URL scheme ("protocol") part
         $path = str_replace('://', '---', $path);

--- a/src/Imagine/Cache/Signer.php
+++ b/src/Imagine/Cache/Signer.php
@@ -13,23 +13,14 @@ namespace Liip\ImagineBundle\Imagine\Cache;
 
 class Signer implements SignerInterface
 {
-    /**
-     * @var string
-     */
-    private $secret;
+    private string $secret;
 
-    /**
-     * @param string $secret
-     */
-    public function __construct($secret)
+    public function __construct(string $secret)
     {
         $this->secret = $secret;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function sign($path, array $runtimeConfig = null)
+    public function sign(string $path, array $runtimeConfig = null): string
     {
         if ($runtimeConfig) {
             array_walk_recursive($runtimeConfig, function (&$value) {
@@ -40,10 +31,7 @@ class Signer implements SignerInterface
         return mb_substr(preg_replace('/[^a-zA-Z0-9-_]/', '', base64_encode(hash_hmac('sha256', ltrim($path, '/').(null === $runtimeConfig ?: serialize($runtimeConfig)), $this->secret, true))), 0, 8);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function check($hash, $path, array $runtimeConfig = null)
+    public function check(string $hash, string $path, array $runtimeConfig = null): bool
     {
         return $hash === $this->sign($path, $runtimeConfig);
     }

--- a/src/Imagine/Cache/SignerInterface.php
+++ b/src/Imagine/Cache/SignerInterface.php
@@ -15,22 +15,11 @@ interface SignerInterface
 {
     /**
      * Return the hash for path and runtime config.
-     *
-     * @param string $path
-     * @param array  $runtimeConfig
-     *
-     * @return string
      */
-    public function sign($path, array $runtimeConfig = null);
+    public function sign(string $path, array $runtimeConfig = null): string;
 
     /**
      * Check hash is correct.
-     *
-     * @param string $hash
-     * @param string $path
-     * @param array  $runtimeConfig
-     *
-     * @return bool
      */
-    public function check($hash, $path, array $runtimeConfig = null);
+    public function check(string $hash, string $path, array $runtimeConfig = null): bool;
 }

--- a/src/Imagine/Data/DataManager.php
+++ b/src/Imagine/Data/DataManager.php
@@ -21,46 +21,27 @@ use Symfony\Component\Mime\MimeTypesInterface;
 
 class DataManager
 {
-    /**
-     * @var MimeTypeGuesserInterface
-     */
-    protected $mimeTypeGuesser;
+    protected MimeTypeGuesserInterface $mimeTypeGuesser;
 
-    /**
-     * @var MimeTypesInterface
-     */
-    protected $extensionGuesser;
+    protected MimeTypesInterface $extensionGuesser;
 
-    /**
-     * @var FilterConfiguration
-     */
-    protected $filterConfig;
+    protected FilterConfiguration $filterConfig;
 
-    /**
-     * @var string|null
-     */
-    protected $defaultLoader;
+    protected ?string $defaultLoader;
 
-    /**
-     * @var string|null
-     */
-    protected $globalDefaultImage;
+    protected ?string $globalDefaultImage;
 
     /**
      * @var LoaderInterface[]
      */
-    protected $loaders = [];
+    protected array $loaders = [];
 
-    /**
-     * @param string $defaultLoader
-     * @param string $globalDefaultImage
-     */
     public function __construct(
         MimeTypeGuesserInterface $mimeTypeGuesser,
         MimeTypesInterface $extensionGuesser,
         FilterConfiguration $filterConfig,
-        $defaultLoader = null,
-        $globalDefaultImage = null
+        ?string $defaultLoader = null,
+        ?string $globalDefaultImage = null
     ) {
         $this->mimeTypeGuesser = $mimeTypeGuesser;
         $this->filterConfig = $filterConfig;
@@ -71,10 +52,8 @@ class DataManager
 
     /**
      * Adds a loader to retrieve images for the given filter.
-     *
-     * @param string $filter
      */
-    public function addLoader($filter, LoaderInterface $loader)
+    public function addLoader(string $filter, LoaderInterface $loader): void
     {
         $this->loaders[$filter] = $loader;
     }
@@ -82,13 +61,9 @@ class DataManager
     /**
      * Returns a loader previously attached to the given filter.
      *
-     * @param string $filter
-     *
      * @throws \InvalidArgumentException
-     *
-     * @return LoaderInterface
      */
-    public function getLoader($filter)
+    public function getLoader(string $filter): LoaderInterface
     {
         $config = $this->filterConfig->get($filter);
 
@@ -104,14 +79,9 @@ class DataManager
     /**
      * Retrieves an image with the given filter applied.
      *
-     * @param string $filter
-     * @param string $path
-     *
      * @throws LogicException
-     *
-     * @return BinaryInterface
      */
-    public function find($filter, $path)
+    public function find(string $filter, string $path): BinaryInterface
     {
         $loader = $this->getLoader($filter);
 
@@ -140,12 +110,8 @@ class DataManager
 
     /**
      * Get default image url with the given filter applied.
-     *
-     * @param string $filter
-     *
-     * @return string|null
      */
-    public function getDefaultImageUrl($filter)
+    public function getDefaultImageUrl(string $filter): ?string
     {
         $config = $this->filterConfig->get($filter);
 

--- a/src/Imagine/Filter/FilterConfiguration.php
+++ b/src/Imagine/Filter/FilterConfiguration.php
@@ -15,10 +15,7 @@ use Liip\ImagineBundle\Exception\Imagine\Filter\NonExistingFilterException;
 
 class FilterConfiguration
 {
-    /**
-     * @var array
-     */
-    protected $filters = [];
+    protected array $filters = [];
 
     public function __construct(array $filters = [])
     {
@@ -28,13 +25,9 @@ class FilterConfiguration
     /**
      * Gets a previously configured filter.
      *
-     * @param string $filter
-     *
      * @throws NonExistingFilterException
-     *
-     * @return array
      */
-    public function get($filter)
+    public function get(string $filter): array
     {
         if (false === \array_key_exists($filter, $this->filters)) {
             throw new NonExistingFilterException(sprintf('Could not find configuration for a filter: %s', $filter));
@@ -45,20 +38,16 @@ class FilterConfiguration
 
     /**
      * Sets a configuration on the given filter.
-     *
-     * @param string $filter
      */
-    public function set($filter, array $config)
+    public function set(string $filter, array $config): void
     {
         $this->filters[$filter] = $config;
     }
 
     /**
      * Get all filters.
-     *
-     * @return array
      */
-    public function all()
+    public function all(): array
     {
         return $this->filters;
     }

--- a/src/Imagine/Filter/FilterManager.php
+++ b/src/Imagine/Filter/FilterManager.php
@@ -22,30 +22,21 @@ use Liip\ImagineBundle\Model\Binary;
 
 class FilterManager
 {
-    /**
-     * @var FilterConfiguration
-     */
-    protected $filterConfig;
+    protected FilterConfiguration $filterConfig;
 
-    /**
-     * @var ImagineInterface
-     */
-    protected $imagine;
+    protected ImagineInterface $imagine;
 
-    /**
-     * @var MimeTypeGuesserInterface
-     */
-    protected $mimeTypeGuesser;
+    protected MimeTypeGuesserInterface $mimeTypeGuesser;
 
     /**
      * @var LoaderInterface[]
      */
-    protected $loaders = [];
+    protected array $loaders = [];
 
     /**
      * @var PostProcessorInterface[]
      */
-    protected $postProcessors = [];
+    protected array $postProcessors = [];
 
     public function __construct(FilterConfiguration $filterConfig, ImagineInterface $imagine, MimeTypeGuesserInterface $mimeTypeGuesser)
     {
@@ -111,13 +102,9 @@ class FilterManager
     /**
      * Apply the provided filter set on the given binary.
      *
-     * @param string $filter
-     *
      * @throws \InvalidArgumentException
-     *
-     * @return BinaryInterface
      */
-    public function applyFilter(BinaryInterface $binary, $filter, array $runtimeConfig = [])
+    public function applyFilter(BinaryInterface $binary, string $filter, array $runtimeConfig = []): BinaryInterface
     {
         $config = array_replace_recursive(
             $this->getFilterConfiguration()->get($filter),

--- a/src/Imagine/Filter/Loader/AutoRotateFilterLoader.php
+++ b/src/Imagine/Filter/Loader/AutoRotateFilterLoader.php
@@ -24,7 +24,7 @@ class AutoRotateFilterLoader implements LoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $filter = new Autorotate();
 

--- a/src/Imagine/Filter/Loader/BackgroundFilterLoader.php
+++ b/src/Imagine/Filter/Loader/BackgroundFilterLoader.php
@@ -18,10 +18,7 @@ use Imagine\Image\Point;
 
 class BackgroundFilterLoader implements LoaderInterface
 {
-    /**
-     * @var ImagineInterface
-     */
-    protected $imagine;
+    protected ImagineInterface $imagine;
 
     public function __construct(ImagineInterface $imagine)
     {
@@ -31,7 +28,7 @@ class BackgroundFilterLoader implements LoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $background = $image->palette()->color(
             isset($options['color']) ? $options['color'] : '#fff',

--- a/src/Imagine/Filter/Loader/CropFilterLoader.php
+++ b/src/Imagine/Filter/Loader/CropFilterLoader.php
@@ -21,7 +21,7 @@ class CropFilterLoader implements LoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $x = isset($options['start'][0]) ? $options['start'][0] : null;
         $y = isset($options['start'][1]) ? $options['start'][1] : null;

--- a/src/Imagine/Filter/Loader/DownscaleFilterLoader.php
+++ b/src/Imagine/Filter/Loader/DownscaleFilterLoader.php
@@ -23,12 +23,12 @@ class DownscaleFilterLoader extends ScaleFilterLoader
         parent::__construct('max', 'by', false);
     }
 
-    protected function calcAbsoluteRatio($ratio)
+    protected function calcAbsoluteRatio(float $ratio): float
     {
         return 1 - ($ratio > 1 ? $ratio - floor($ratio) : $ratio);
     }
 
-    protected function isImageProcessable($ratio)
+    protected function isImageProcessable(float $ratio): bool
     {
         return $ratio < 1;
     }

--- a/src/Imagine/Filter/Loader/FixedFilterLoader.php
+++ b/src/Imagine/Filter/Loader/FixedFilterLoader.php
@@ -25,10 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FixedFilterLoader implements LoaderInterface
 {
-    /**
-     * @return ImageInterface
-     */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $optionsResolver = new OptionsResolver();
         $optionsResolver->setRequired(['width', 'height']);

--- a/src/Imagine/Filter/Loader/FlipFilterLoader.php
+++ b/src/Imagine/Filter/Loader/FlipFilterLoader.php
@@ -19,20 +19,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FlipFilterLoader implements LoaderInterface
 {
-    /**
-     * @return ImageInterface
-     */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $options = $this->sanitizeOptions($options);
 
         return 'x' === $options['axis'] ? $image->flipHorizontally() : $image->flipVertically();
     }
 
-    /**
-     * @return array
-     */
-    private function sanitizeOptions(array $options)
+    private function sanitizeOptions(array $options): array
     {
         $resolver = new OptionsResolver();
         $resolver->setDefault('axis', 'x');

--- a/src/Imagine/Filter/Loader/GrayscaleFilterLoader.php
+++ b/src/Imagine/Filter/Loader/GrayscaleFilterLoader.php
@@ -21,10 +21,7 @@ use Imagine\Image\ImageInterface;
  */
 class GrayscaleFilterLoader implements LoaderInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $filter = new Grayscale();
 

--- a/src/Imagine/Filter/Loader/InterlaceFilterLoader.php
+++ b/src/Imagine/Filter/Loader/InterlaceFilterLoader.php
@@ -15,10 +15,7 @@ use Imagine\Image\ImageInterface;
 
 class InterlaceFilterLoader implements LoaderInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $mode = ImageInterface::INTERLACE_LINE;
         if (!empty($options['mode'])) {

--- a/src/Imagine/Filter/Loader/LoaderInterface.php
+++ b/src/Imagine/Filter/Loader/LoaderInterface.php
@@ -17,8 +17,6 @@ interface LoaderInterface
 {
     /**
      * Loads and applies a filter on the given image.
-     *
-     * @return ImageInterface
      */
-    public function load(ImageInterface $image, array $options = []);
+    public function load(ImageInterface $image, array $options = []): ImageInterface;
 }

--- a/src/Imagine/Filter/Loader/PasteFilterLoader.php
+++ b/src/Imagine/Filter/Loader/PasteFilterLoader.php
@@ -17,17 +17,11 @@ use Imagine\Image\Point;
 
 class PasteFilterLoader implements LoaderInterface
 {
-    /**
-     * @var ImagineInterface
-     */
-    protected $imagine;
+    private ImagineInterface $imagine;
 
-    /**
-     * @var string
-     */
-    protected $projectDir;
+    private string $projectDir;
 
-    public function __construct(ImagineInterface $imagine, $projectDir)
+    public function __construct(ImagineInterface $imagine, string $projectDir)
     {
         $this->imagine = $imagine;
         $this->projectDir = $projectDir;
@@ -35,10 +29,8 @@ class PasteFilterLoader implements LoaderInterface
 
     /**
      * @see \Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface::load()
-     *
-     * @return ImageInterface|static
      */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $x = isset($options['start'][0]) ? $options['start'][0] : null;
         $y = isset($options['start'][1]) ? $options['start'][1] : null;

--- a/src/Imagine/Filter/Loader/RelativeResizeFilterLoader.php
+++ b/src/Imagine/Filter/Loader/RelativeResizeFilterLoader.php
@@ -22,10 +22,7 @@ use Liip\ImagineBundle\Imagine\Filter\RelativeResize;
  */
 class RelativeResizeFilterLoader implements LoaderInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         foreach ($options as $method => $parameter) {
             $filter = new RelativeResize($method, $parameter);

--- a/src/Imagine/Filter/Loader/ResampleFilterLoader.php
+++ b/src/Imagine/Filter/Loader/ResampleFilterLoader.php
@@ -21,10 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ResampleFilterLoader implements LoaderInterface
 {
-    /**
-     * @var ImagineInterface
-     */
-    private $imagine;
+    private ImagineInterface $imagine;
 
     public function __construct(ImagineInterface $imagine)
     {
@@ -33,10 +30,8 @@ class ResampleFilterLoader implements LoaderInterface
 
     /**
      * @throws LoadFilterException
-     *
-     * @return ImageInterface
      */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $options = $this->resolveOptions($options);
         $tmpFile = $this->getTemporaryFile($options['temp_dir']);

--- a/src/Imagine/Filter/Loader/ResizeFilterLoader.php
+++ b/src/Imagine/Filter/Loader/ResizeFilterLoader.php
@@ -22,10 +22,7 @@ use Imagine\Image\ImageInterface;
  */
 class ResizeFilterLoader implements LoaderInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $width = isset($options['size'][0]) ? $options['size'][0] : null;
         $height = isset($options['size'][1]) ? $options['size'][1] : null;

--- a/src/Imagine/Filter/Loader/RotateFilterLoader.php
+++ b/src/Imagine/Filter/Loader/RotateFilterLoader.php
@@ -12,7 +12,6 @@
 namespace Liip\ImagineBundle\Imagine\Filter\Loader;
 
 use Imagine\Image\ImageInterface;
-use Imagine\Image\ManipulatorInterface;
 
 /**
  * Loader for Imagine's basic rotate method.
@@ -21,12 +20,7 @@ use Imagine\Image\ManipulatorInterface;
  */
 class RotateFilterLoader implements LoaderInterface
 {
-    /**
-     * Loads and applies a filter on the given image.
-     *
-     * @return ManipulatorInterface
-     */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $angle = isset($options['angle']) ? (int) $options['angle'] : 0;
 

--- a/src/Imagine/Filter/Loader/ScaleFilterLoader.php
+++ b/src/Imagine/Filter/Loader/ScaleFilterLoader.php
@@ -22,32 +22,20 @@ use Imagine\Image\ImageInterface;
  */
 class ScaleFilterLoader implements LoaderInterface
 {
-    /**
-     * @var string
-     */
-    protected $dimensionKey;
+    private string $dimensionKey;
 
-    /**
-     * @var string
-     */
-    protected $ratioKey;
+    private string $ratioKey;
 
-    /**
-     * @var bool
-     */
-    protected $absoluteRatio;
+    private bool $absoluteRatio;
 
-    public function __construct($dimensionKey = 'dim', $ratioKey = 'to', $absoluteRatio = true)
+    public function __construct(string $dimensionKey = 'dim', string $ratioKey = 'to', bool $absoluteRatio = true)
     {
         $this->dimensionKey = $dimensionKey;
         $this->ratioKey = $ratioKey;
         $this->absoluteRatio = $absoluteRatio;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         if (!isset($options[$this->dimensionKey]) && !isset($options[$this->ratioKey])) {
             throw new \InvalidArgumentException("Missing $this->dimensionKey or $this->ratioKey option.");
@@ -84,12 +72,12 @@ class ScaleFilterLoader implements LoaderInterface
         return $image;
     }
 
-    protected function calcAbsoluteRatio($ratio)
+    protected function calcAbsoluteRatio(float $ratio): float
     {
         return $ratio;
     }
 
-    protected function isImageProcessable($ratio)
+    protected function isImageProcessable(float $ratio): bool
     {
         return true;
     }

--- a/src/Imagine/Filter/Loader/StripFilterLoader.php
+++ b/src/Imagine/Filter/Loader/StripFilterLoader.php
@@ -16,7 +16,7 @@ use Imagine\Image\ImageInterface;
 
 class StripFilterLoader implements LoaderInterface
 {
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $filter = new Strip();
         $image = $filter->apply($image);

--- a/src/Imagine/Filter/Loader/ThumbnailFilterLoader.php
+++ b/src/Imagine/Filter/Loader/ThumbnailFilterLoader.php
@@ -17,10 +17,7 @@ use Imagine\Image\ImageInterface;
 
 class ThumbnailFilterLoader implements LoaderInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $mode = ImageInterface::THUMBNAIL_OUTBOUND;
         if (!empty($options['mode']) && 'inset' === $options['mode']) {

--- a/src/Imagine/Filter/Loader/UpscaleFilterLoader.php
+++ b/src/Imagine/Filter/Loader/UpscaleFilterLoader.php
@@ -24,12 +24,12 @@ class UpscaleFilterLoader extends ScaleFilterLoader
         parent::__construct('min', 'by', false);
     }
 
-    protected function calcAbsoluteRatio($ratio)
+    protected function calcAbsoluteRatio(float $ratio): float
     {
         return 1 + $ratio;
     }
 
-    protected function isImageProcessable($ratio)
+    protected function isImageProcessable(float $ratio): bool
     {
         return $ratio > 1;
     }

--- a/src/Imagine/Filter/Loader/WatermarkFilterLoader.php
+++ b/src/Imagine/Filter/Loader/WatermarkFilterLoader.php
@@ -18,28 +18,17 @@ use Imagine\Image\Point;
 
 class WatermarkFilterLoader implements LoaderInterface
 {
-    /**
-     * @var ImagineInterface
-     */
-    protected $imagine;
+    protected ImagineInterface $imagine;
 
-    /**
-     * @var string
-     */
-    protected $projectDir;
+    protected string $projectDir;
 
-    public function __construct(ImagineInterface $imagine, $projectDir)
+    public function __construct(ImagineInterface $imagine, string $projectDir)
     {
         $this->imagine = $imagine;
         $this->projectDir = $projectDir;
     }
 
-    /**
-     * @see \Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface::load()
-     *
-     * @return ImageInterface|static
-     */
-    public function load(ImageInterface $image, array $options = [])
+    public function load(ImageInterface $image, array $options = []): ImageInterface
     {
         $options += [
             'size' => null,

--- a/src/Imagine/Filter/PostProcessor/AbstractPostProcessor.php
+++ b/src/Imagine/Filter/PostProcessor/AbstractPostProcessor.php
@@ -19,22 +19,13 @@ use Symfony\Component\Process\Process;
 
 abstract class AbstractPostProcessor implements PostProcessorInterface
 {
-    /**
-     * @var string
-     */
-    protected $executablePath;
+    protected string $executablePath;
 
-    /**
-     * @var string|null
-     */
-    protected $temporaryRootPath;
+    protected ?string $temporaryRootPath;
 
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
+    private Filesystem $filesystem;
 
-    public function __construct(string $executablePath, string $temporaryRootPath = null)
+    public function __construct(string $executablePath, ?string $temporaryRootPath = null)
     {
         $this->executablePath = $executablePath;
         $this->temporaryRootPath = $temporaryRootPath;

--- a/src/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
+++ b/src/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
@@ -20,33 +20,29 @@ class JpegOptimPostProcessor extends AbstractPostProcessor
 {
     /**
      * If set --strip-all will be passed to jpegoptim.
-     *
-     * @var bool
      */
-    protected $strip;
+    protected bool $strip;
 
     /**
      * If set, --max=$value will be passed to jpegoptim.
      *
      * @var int
      */
-    protected $quality;
+    protected ?int $quality;
 
     /**
      * If set to true --all-progressive will be passed to jpegoptim, otherwise --all-normal will be passed.
-     *
-     * @var bool
      */
-    protected $progressive;
+    protected bool $progressive;
 
     /**
-     * @param string $executablePath    Path to the jpegoptim binary
-     * @param bool   $strip             Strip all markers from output
-     * @param int    $quality           Set maximum image quality factor
-     * @param bool   $progressive       Force output to be progressive
-     * @param string $temporaryRootPath Directory where temporary file will be written
+     * @param string      $executablePath    Path to the jpegoptim binary
+     * @param bool        $strip             Strip all markers from output
+     * @param int|null    $quality           Set maximum image quality factor
+     * @param bool        $progressive       Force output to be progressive
+     * @param string|null $temporaryRootPath Directory where temporary file will be written
      */
-    public function __construct($executablePath = '/usr/bin/jpegoptim', $strip = true, $quality = null, $progressive = true, $temporaryRootPath = null)
+    public function __construct(string $executablePath = '/usr/bin/jpegoptim', bool $strip = true, ?int $quality = null, bool $progressive = true, ?string $temporaryRootPath = null)
     {
         parent::__construct($executablePath, $temporaryRootPath);
 

--- a/src/Imagine/Filter/PostProcessor/MozJpegPostProcessor.php
+++ b/src/Imagine/Filter/PostProcessor/MozJpegPostProcessor.php
@@ -28,13 +28,13 @@ class MozJpegPostProcessor extends AbstractPostProcessor
     /**
      * @var int|null Quality factor
      */
-    protected $quality;
+    protected ?int $quality;
 
     /**
      * @param string   $executablePath Path to the mozjpeg cjpeg binary
      * @param int|null $quality        Quality factor
      */
-    public function __construct($executablePath = '/opt/mozjpeg/bin/cjpeg', $quality = null)
+    public function __construct(string $executablePath = '/opt/mozjpeg/bin/cjpeg', ?int $quality = null)
     {
         parent::__construct($executablePath);
 

--- a/src/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
+++ b/src/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
@@ -20,25 +20,21 @@ class OptiPngPostProcessor extends AbstractPostProcessor
 {
     /**
      * If set --oN will be passed to optipng.
-     *
-     * @var int
      */
-    protected $level;
+    protected int $level;
 
     /**
      * If set --strip=all will be passed to optipng.
-     *
-     * @var bool
      */
-    protected $strip;
+    protected bool $strip;
 
     /**
-     * @param string $executablePath    Path to the optipng binary
-     * @param int    $level             Optimization level
-     * @param bool   $strip             Strip metadata objects
-     * @param string $temporaryRootPath Directory where temporary file will be written
+     * @param string      $executablePath    Path to the optipng binary
+     * @param int         $level             Optimization level
+     * @param bool        $strip             Strip metadata objects
+     * @param string|null $temporaryRootPath Directory where temporary file will be written
      */
-    public function __construct($executablePath = '/usr/bin/optipng', $level = 7, $strip = true, $temporaryRootPath = null)
+    public function __construct(string $executablePath = '/usr/bin/optipng', int $level = 7, bool $strip = true, ?string $temporaryRootPath = null)
     {
         parent::__construct($executablePath, $temporaryRootPath);
 

--- a/src/Imagine/Filter/PostProcessor/PngquantPostProcessor.php
+++ b/src/Imagine/Filter/PostProcessor/PngquantPostProcessor.php
@@ -28,15 +28,14 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 class PngquantPostProcessor extends AbstractPostProcessor
 {
     /**
-     * @var string Quality to pass to pngquant
+     * @var int|int[] Quality to pass to pngquant
      */
     protected $quality;
 
     /**
-     * @param string $executablePath
-     * @param array  $quality
+     * @param int|int[] $quality
      */
-    public function __construct($executablePath = '/usr/bin/pngquant', $quality = [80, 100])
+    public function __construct(string $executablePath = '/usr/bin/pngquant', $quality = [80, 100])
     {
         parent::__construct($executablePath);
 

--- a/src/Imagine/Filter/RelativeResize.php
+++ b/src/Imagine/Filter/RelativeResize.php
@@ -22,7 +22,7 @@ use Imagine\Image\ImageInterface;
  */
 class RelativeResize implements FilterInterface
 {
-    private $method;
+    private string $method;
     private $parameter;
 
     /**
@@ -33,7 +33,7 @@ class RelativeResize implements FilterInterface
      *
      * @throws \Imagine\Exception\InvalidArgumentException
      */
-    public function __construct($method, $parameter)
+    public function __construct(string $method, $parameter)
     {
         if (!\in_array($method, ['heighten', 'increase', 'scale', 'widen'], true)) {
             throw new InvalidArgumentException(sprintf('Unsupported method: %s', $method));
@@ -43,10 +43,7 @@ class RelativeResize implements FilterInterface
         $this->parameter = $parameter;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function apply(ImageInterface $image)
+    public function apply(ImageInterface $image): ImageInterface
     {
         return $image->resize(\call_user_func([$image->getSize(), $this->method], $this->parameter));
     }

--- a/tests/Imagine/Cache/CacheManagerTest.php
+++ b/tests/Imagine/Cache/CacheManagerTest.php
@@ -352,8 +352,7 @@ class CacheManagerTest extends AbstractTest
         $resolver
             ->expects($this->once())
             ->method('remove')
-            ->with(['/thumbs/cats.jpeg'], ['thumbnail'])
-            ->willReturn(true);
+            ->with(['/thumbs/cats.jpeg'], ['thumbnail']);
 
         $config = $this->createFilterConfigurationMock();
         $config

--- a/tests/Imagine/Cache/Resolver/AmazonS3ResolverTest.php
+++ b/tests/Imagine/Cache/Resolver/AmazonS3ResolverTest.php
@@ -35,7 +35,8 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('get_object_url')
-            ->with('images.example.com', 'thumb/some-folder/path.jpg');
+            ->with('images.example.com', 'thumb/some-folder/path.jpg')
+            ->willReturn('http://images.example.com/some-folder/path.jpg');
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->resolve('/some-folder/path.jpg', 'thumb');
@@ -47,7 +48,8 @@ class AmazonS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('get_object_url')
-            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, ['torrent' => true]);
+            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, ['torrent' => true])
+            ->willReturn('http://images.example.com/some-folder/path.jpg');
 
         $resolver = new AmazonS3Resolver($s3, 'images.example.com');
         $resolver->setObjectUrlOption('torrent', true);

--- a/tests/Imagine/Cache/Resolver/AwsS3ResolverTest.php
+++ b/tests/Imagine/Cache/Resolver/AwsS3ResolverTest.php
@@ -37,7 +37,8 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('getObjectUrl')
-            ->with('images.example.com', 'thumb/some-folder/path.jpg');
+            ->with('images.example.com', 'thumb/some-folder/path.jpg')
+            ->willReturn('http://images.example.com/some-folder/path.jpg');
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
         $resolver->resolve('/some-folder/path.jpg', 'thumb');
@@ -49,7 +50,8 @@ class AwsS3ResolverTest extends AbstractTest
         $s3
             ->expects($this->once())
             ->method('getObjectUrl')
-            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, ['torrent' => true]);
+            ->with('images.example.com', 'thumb/some-folder/path.jpg', 0, ['torrent' => true])
+            ->willReturn('http://images.example.com/some-folder/path.jpg');
 
         $resolver = new AwsS3Resolver($s3, 'images.example.com');
         $resolver->setGetOption('torrent', true);

--- a/tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
+++ b/tests/Imagine/Filter/Loader/DownscaleFilterLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Liip\ImagineBundle\Tests\Image\Filter\Loader;
 
 use Imagine\Image\Box;
+use Imagine\Image\ImageInterface;
 use Liip\ImagineBundle\Imagine\Filter\Loader\DownscaleFilterLoader;
 use Liip\ImagineBundle\Tests\AbstractTest;
 
@@ -61,8 +62,10 @@ class DownscaleFilterLoaderTest extends AbstractTest
             ->willReturn($initialSize);
         $image
             ->method('resize')
-            ->willReturnCallback(function ($box) use (&$resultSize) {
+            ->willReturnCallback(function (Box $box) use ($image, &$resultSize): ImageInterface {
                 $resultSize = $box;
+
+                return $image;
             });
 
         $loader->load($image, ['max' => [100, 90]]);


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 3.x
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc | <!--new features must be documented. it is ok to first submit a draft for review and document once the general idea is accepted-->

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->

Adding type declarations to the whole code would be quite painful to review, this PR has two commits:
- drop support for PHP < 7.4 
- add type declarations to `Imagine` folder

I'll add a couple of comments in the code