### PR TITLE
Increase PHPStan level to 6

### DIFF
--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -13,3 +13,8 @@ parameters:
         - message: "#^Unreachable statement \\- code above always terminates\\.$#"
           count: 1
           path: ../src/Controller/ImagineController.php
+
+        # BC Layer for Symfony < 5.1
+        - message: "#^Parameter \\#2 \\$default of method Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\<string\\>\\:\\:get\\(\\) expects string\\|null, array given\\.$#"
+          count: 1
+          path: ../src/Controller/ImagineController.php

--- a/.phpstan/iterable_types_baseline.neon
+++ b/.phpstan/iterable_types_baseline.neon
@@ -1,0 +1,622 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Command\\\\RemoveCacheCommand\\:\\:resolveInputFiltersAndPaths\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Command/RemoveCacheCommand.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Command\\\\ResolveCacheCommand\\:\\:resolveInputFiltersAndPaths\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Command/ResolveCacheCommand.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Component\\\\Console\\\\Style\\\\ImagineStyle\\:\\:compileString\\(\\) has parameter \\$replacements with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Component/Console/Style/ImagineStyle.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Component\\\\Console\\\\Style\\\\ImagineStyle\\:\\:critBlock\\(\\) has parameter \\$replacements with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Component/Console/Style/ImagineStyle.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Component\\\\Console\\\\Style\\\\ImagineStyle\\:\\:line\\(\\) has parameter \\$replacements with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Component/Console/Style/ImagineStyle.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Component\\\\Console\\\\Style\\\\ImagineStyle\\:\\:okayBlock\\(\\) has parameter \\$replacements with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Component/Console/Style/ImagineStyle.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Component\\\\Console\\\\Style\\\\ImagineStyle\\:\\:text\\(\\) has parameter \\$replacements with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Component/Console/Style/ImagineStyle.php
+
+		-
+			message: "#^Property Liip\\\\ImagineBundle\\\\Config\\\\Stack\\:\\:\\$filters type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Config/Stack.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Config\\\\StackBuilder\\:\\:build\\(\\) has parameter \\$stackData with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Config/StackBuilder.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Config\\\\StackBuilderInterface\\:\\:build\\(\\) has parameter \\$stackData with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Config/StackBuilderInterface.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Config\\\\StackCollection\\:\\:__construct\\(\\) has parameter \\$filtersConfiguration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Config/StackCollection.php
+
+		-
+			message: "#^Property Liip\\\\ImagineBundle\\\\Config\\\\StackCollection\\:\\:\\$filtersConfiguration type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Config/StackCollection.php
+
+		-
+			message: "#^Property Liip\\\\ImagineBundle\\\\Config\\\\StackCollection\\:\\:\\$stacks type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Config/StackCollection.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Controller\\\\ImagineController\\:\\:getFiltersBc\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Controller/ImagineController.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\Factory\\\\FactoryInterface\\:\\:create\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/Factory/FactoryInterface.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\Factory\\\\Loader\\\\ChainLoaderFactory\\:\\:create\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/Factory/Loader/ChainLoaderFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\Factory\\\\Loader\\\\FileSystemLoaderFactory\\:\\:create\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\Factory\\\\Loader\\\\FileSystemLoaderFactory\\:\\:getBundlePathsUsingMetadata\\(\\) has parameter \\$metadata with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\Factory\\\\Loader\\\\FileSystemLoaderFactory\\:\\:resolveDataRoots\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/Factory/Loader/FileSystemLoaderFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\Factory\\\\Loader\\\\FlysystemLoaderFactory\\:\\:create\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/Factory/Loader/FlysystemLoaderFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\Factory\\\\Loader\\\\StreamLoaderFactory\\:\\:create\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/Factory/Loader/StreamLoaderFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\Factory\\\\Resolver\\\\AwsS3ResolverFactory\\:\\:create\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\Factory\\\\Resolver\\\\FlysystemResolverFactory\\:\\:create\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\Factory\\\\Resolver\\\\WebPathResolverFactory\\:\\:create\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/Factory/Resolver/WebPathResolverFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\LiipImagineExtension\\:\\:createFactories\\(\\) has parameter \\$configurations with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/LiipImagineExtension.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\LiipImagineExtension\\:\\:createFactories\\(\\) has parameter \\$factories with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/LiipImagineExtension.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\LiipImagineExtension\\:\\:createFilterSets\\(\\) has parameter \\$defaultFilterSets with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/LiipImagineExtension.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\LiipImagineExtension\\:\\:createFilterSets\\(\\) has parameter \\$filterSets with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/LiipImagineExtension.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\LiipImagineExtension\\:\\:createFilterSets\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/LiipImagineExtension.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\LiipImagineExtension\\:\\:getConfiguration\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/LiipImagineExtension.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\LiipImagineExtension\\:\\:loadLoaders\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/LiipImagineExtension.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\LiipImagineExtension\\:\\:loadResolvers\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/LiipImagineExtension.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\DependencyInjection\\\\LiipImagineExtension\\:\\:loadTwig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/DependencyInjection/LiipImagineExtension.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Exception\\\\Imagine\\\\Filter\\\\PostProcessor\\\\InvalidOptionException\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Exception/Imagine/Filter/PostProcessor/InvalidOptionException.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Exception\\\\Imagine\\\\Filter\\\\PostProcessor\\\\InvalidOptionException\\:\\:stringifyOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Exception/Imagine/Filter/PostProcessor/InvalidOptionException.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\Argument\\\\PointFactory\\:\\:createFromOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/Argument/PointFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\Argument\\\\SizeFactory\\:\\:createFromOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/Argument/SizeFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\AutoRotateFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/AutoRotateFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\BackgroundFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/BackgroundFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\CropFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/CropFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\DownscaleFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/DownscaleFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\FlipFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/FlipFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\GrayscaleFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/GrayscaleFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\InterlaceFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/InterlaceFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\PasteFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/PasteFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\RelativeResizeFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/RelativeResizeFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\ResizeFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/ResizeFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\RotateFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/RotateFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\ScaleFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/ScaleFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\StripFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/StripFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\ThumbnailFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/ThumbnailFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\UpscaleFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/UpscaleFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\Filter\\\\WatermarkFactory\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/Filter/WatermarkFactory.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Factory\\\\Config\\\\FilterFactoryInterface\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Factory/Config/FilterFactoryInterface.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\CacheManager\\:\\:generateUrl\\(\\) has parameter \\$runtimeConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/CacheManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\CacheManager\\:\\:getBrowserPath\\(\\) has parameter \\$runtimeConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/CacheManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\CacheManager\\:\\:getRuntimePath\\(\\) has parameter \\$runtimeConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/CacheManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Resolver\\\\AmazonS3Resolver\\:\\:__construct\\(\\) has parameter \\$objUrlOptions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Resolver/AmazonS3Resolver.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Resolver\\\\AmazonS3Resolver\\:\\:logError\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Resolver/AmazonS3Resolver.php
+
+		-
+			message: "#^Property Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Resolver\\\\AmazonS3Resolver\\:\\:\\$objUrlOptions type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Resolver/AmazonS3Resolver.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Resolver\\\\AwsS3Resolver\\:\\:__construct\\(\\) has parameter \\$getOptions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Resolver/AwsS3Resolver.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Resolver\\\\AwsS3Resolver\\:\\:__construct\\(\\) has parameter \\$putOptions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Resolver/AwsS3Resolver.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Resolver\\\\AwsS3Resolver\\:\\:logError\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Resolver/AwsS3Resolver.php
+
+		-
+			message: "#^Property Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Resolver\\\\AwsS3Resolver\\:\\:\\$getOptions type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Resolver/AwsS3Resolver.php
+
+		-
+			message: "#^Property Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Resolver\\\\AwsS3Resolver\\:\\:\\$putOptions type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Resolver/AwsS3Resolver.php
+
+		-
+			message: "#^Property Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Resolver\\\\ProxyResolver\\:\\:\\$hosts type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Resolver/ProxyResolver.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Resolver\\\\PsrCacheResolver\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Resolver/PsrCacheResolver.php
+
+		-
+			message: "#^Property Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Resolver\\\\PsrCacheResolver\\:\\:\\$options type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Resolver/PsrCacheResolver.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Signer\\:\\:check\\(\\) has parameter \\$runtimeConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Signer.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\Signer\\:\\:sign\\(\\) has parameter \\$runtimeConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/Signer.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\SignerInterface\\:\\:check\\(\\) has parameter \\$runtimeConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/SignerInterface.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Cache\\\\SignerInterface\\:\\:sign\\(\\) has parameter \\$runtimeConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Cache/SignerInterface.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterConfiguration\\:\\:__construct\\(\\) has parameter \\$filters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterConfiguration.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterConfiguration\\:\\:all\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterConfiguration.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterConfiguration\\:\\:get\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterConfiguration.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterConfiguration\\:\\:set\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterConfiguration.php
+
+		-
+			message: "#^Property Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterConfiguration\\:\\:\\$filters type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterConfiguration.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterManager\\:\\:apply\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterManager\\:\\:applyFilter\\(\\) has parameter \\$runtimeConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterManager\\:\\:applyFilters\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterManager\\:\\:applyPostProcessors\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterManager\\:\\:exportConfiguredImageBinary\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterManager\\:\\:sanitizeFilters\\(\\) has parameter \\$filters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterManager\\:\\:sanitizeFilters\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterManager\\:\\:sanitizePostProcessors\\(\\) has parameter \\$processors with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\FilterManager\\:\\:sanitizePostProcessors\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/FilterManager.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\AutoRotateFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/AutoRotateFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\BackgroundFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/BackgroundFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\CropFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/CropFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\FixedFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/FixedFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\FlipFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/FlipFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\FlipFilterLoader\\:\\:sanitizeOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/FlipFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\FlipFilterLoader\\:\\:sanitizeOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/FlipFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\GrayscaleFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/GrayscaleFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\InterlaceFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/InterlaceFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\LoaderInterface\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/LoaderInterface.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\PasteFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/PasteFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\RelativeResizeFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/RelativeResizeFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\ResampleFilterLoader\\:\\:getImagineSaveOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/ResampleFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\ResampleFilterLoader\\:\\:getImagineSaveOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/ResampleFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\ResampleFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/ResampleFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\ResampleFilterLoader\\:\\:resolveOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/ResampleFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\ResampleFilterLoader\\:\\:resolveOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/ResampleFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\ResizeFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/ResizeFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\RotateFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/RotateFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\ScaleFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/ScaleFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\StripFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/StripFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\ThumbnailFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/ThumbnailFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\Loader\\\\WatermarkFilterLoader\\:\\:load\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/Loader/WatermarkFilterLoader.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\PostProcessor\\\\AbstractPostProcessor\\:\\:acquireTemporaryFilePath\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/PostProcessor/AbstractPostProcessor.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\PostProcessor\\\\AbstractPostProcessor\\:\\:createProcess\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/PostProcessor/AbstractPostProcessor.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\PostProcessor\\\\AbstractPostProcessor\\:\\:createProcess\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/PostProcessor/AbstractPostProcessor.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\PostProcessor\\\\AbstractPostProcessor\\:\\:isBinaryTypeMatch\\(\\) has parameter \\$types with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/PostProcessor/AbstractPostProcessor.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\PostProcessor\\\\AbstractPostProcessor\\:\\:writeTemporaryFile\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/PostProcessor/AbstractPostProcessor.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\PostProcessor\\\\JpegOptimPostProcessor\\:\\:process\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/PostProcessor/JpegOptimPostProcessor.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\PostProcessor\\\\MozJpegPostProcessor\\:\\:process\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/PostProcessor/MozJpegPostProcessor.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\PostProcessor\\\\OptiPngPostProcessor\\:\\:process\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/PostProcessor/OptiPngPostProcessor.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\PostProcessor\\\\PngquantPostProcessor\\:\\:process\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/PostProcessor/PngquantPostProcessor.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Imagine\\\\Filter\\\\PostProcessor\\\\PostProcessorInterface\\:\\:process\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Imagine/Filter/PostProcessor/PostProcessorInterface.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Service\\\\FilterPathContainer\\:\\:createWebp\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Service/FilterPathContainer.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Service\\\\FilterService\\:\\:__construct\\(\\) has parameter \\$webpOptions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Service/FilterService.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Service\\\\FilterService\\:\\:getUrlOfFilteredImageWithRuntimeFilters\\(\\) has parameter \\$runtimeFilters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Service/FilterService.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Templating\\\\LazyFilterRuntime\\:\\:filter\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Templating/LazyFilterRuntime.php
+
+		-
+			message: "#^Method Liip\\\\ImagineBundle\\\\Templating\\\\LazyFilterRuntime\\:\\:filterCache\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Templating/LazyFilterRuntime.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,9 @@
 includes:
     - .phpstan/baseline.neon
+    - .phpstan/iterable_types_baseline.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
 parameters:
-    level: 4
+    level: 6
     paths:
         - src
     treatPhpDocTypesAsCertain: false

--- a/src/Binary/Loader/AbstractDoctrineLoader.php
+++ b/src/Binary/Loader/AbstractDoctrineLoader.php
@@ -18,8 +18,14 @@ abstract class AbstractDoctrineLoader implements LoaderInterface
 {
     protected ObjectManager $manager;
 
+    /**
+     * @phpstan-var class-string
+     */
     protected string $modelClass;
 
+    /**
+     * @phpstan-param class-string $modelClass
+     */
     public function __construct(ObjectManager $manager, string $modelClass)
     {
         $this->manager = $manager;

--- a/src/Binary/Loader/ChainLoader.php
+++ b/src/Binary/Loader/ChainLoader.php
@@ -49,23 +49,24 @@ class ChainLoader implements LoaderInterface
     }
 
     /**
-     * @param \Exception[] $exceptions
+     * @param array<string, LoaderInterface> $exceptions
+     * @param array<string, LoaderInterface> $loaders
      */
     private static function getLoaderExceptionMessage(string $path, array $exceptions, array $loaders): string
     {
-        array_walk($loaders, function (LoaderInterface &$loader, string $name): void {
-            $loader = sprintf('%s=[%s]', (new \ReflectionObject($loader))->getShortName(), $name);
-        });
+        $loaderMessages = array_map(static function (string $name, LoaderInterface $loader) {
+            return sprintf('%s=[%s]', (new \ReflectionObject($loader))->getShortName(), $name);
+        }, array_keys($loaders), $loaders);
 
-        array_walk($exceptions, function (LoaderInterface &$loader, string $message): void {
-            $loader = sprintf('%s=[%s]', (new \ReflectionObject($loader))->getShortName(), $message);
-        });
+        $exceptionMessages = array_map(static function (string $message, LoaderInterface $loader) {
+            return sprintf('%s=[%s]', (new \ReflectionObject($loader))->getShortName(), $message);
+        }, array_keys($exceptions), $exceptions);
 
         return vsprintf('Source image not resolvable "%s" using "%s" %d loaders (internal exceptions: %s).', [
             $path,
-            implode(', ', $loaders),
+            implode(', ', $loaderMessages),
             \count($loaders),
-            implode(', ', $exceptions),
+            implode(', ', $exceptionMessages),
         ]);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -245,7 +245,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @param FactoryInterface[] $factories
      */
-    private function addConfigurationSections(array $factories, ArrayNodeDefinition $definition, $type): void
+    private function addConfigurationSections(array $factories, ArrayNodeDefinition $definition, string $type): void
     {
         foreach ($factories as $f) {
             $f->addConfiguration($definition->children()->arrayNode($f->getName()));

--- a/src/DependencyInjection/LiipImagineExtension.php
+++ b/src/DependencyInjection/LiipImagineExtension.php
@@ -123,17 +123,17 @@ class LiipImagineExtension extends Extension implements PrependExtensionInterfac
         }, $filterSets);
     }
 
-    private function loadResolvers(array $config, ContainerBuilder $container)
+    private function loadResolvers(array $config, ContainerBuilder $container): void
     {
         $this->createFactories($this->resolversFactories, $config, $container);
     }
 
-    private function loadLoaders(array $config, ContainerBuilder $container)
+    private function loadLoaders(array $config, ContainerBuilder $container): void
     {
         $this->createFactories($this->loadersFactories, $config, $container);
     }
 
-    private function createFactories(array $factories, array $configurations, ContainerBuilder $container)
+    private function createFactories(array $factories, array $configurations, ContainerBuilder $container): void
     {
         foreach ($configurations as $name => $conf) {
             $factories[key($conf)]->create($container, $name, $conf[key($conf)]);

--- a/src/Factory/Config/Filter/Argument/PointFactory.php
+++ b/src/Factory/Config/Filter/Argument/PointFactory.php
@@ -20,7 +20,7 @@ use Liip\ImagineBundle\Exception\InvalidArgumentException;
  */
 final class PointFactory
 {
-    public function create($x = null, $y = null): Point
+    public function create(int $x = null, int $y = null): Point
     {
         return new Point($x, $y);
     }

--- a/src/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
+++ b/src/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
@@ -83,8 +83,14 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
             return;
         }
 
+        $firstFilter = current($filters);
+
+        if (!\is_string($firstFilter) || '' === $firstFilter) {
+            return;
+        }
+
         // TODO: this logic has to be refactored.
-        [$rootCachePath] = explode(current($filters), $this->getFilePath('whateverpath', current($filters)));
+        [$rootCachePath] = explode($firstFilter, $this->getFilePath('whateverpath', $firstFilter));
 
         if (empty($paths)) {
             $filtersCachePaths = [];

--- a/src/Imagine/Cache/Resolver/AwsS3Resolver.php
+++ b/src/Imagine/Cache/Resolver/AwsS3Resolver.php
@@ -110,7 +110,7 @@ class AwsS3Resolver implements ResolverInterface
 
         if (empty($paths)) {
             try {
-                $this->storage->deleteMatchingObjects($this->bucket, null, sprintf(
+                $this->storage->deleteMatchingObjects($this->bucket, '', sprintf(
                     '/%s/i',
                     implode('|', $filters)
                 ));

--- a/src/Imagine/Filter/Loader/FixedFilterLoader.php
+++ b/src/Imagine/Filter/Loader/FixedFilterLoader.php
@@ -45,8 +45,8 @@ class FixedFilterLoader implements LoaderInterface
         // define filters
         $resize = new Resize($size);
         $origin = new Point(
-            floor(($size->getWidth() - $box->getWidth()) / 2),
-            floor(($size->getHeight() - $box->getHeight()) / 2)
+            (int) floor(($size->getWidth() - $box->getWidth()) / 2),
+            (int) floor(($size->getHeight() - $box->getHeight()) / 2)
         );
         $crop = new Crop($origin, $box);
 

--- a/src/Imagine/Filter/Loader/ScaleFilterLoader.php
+++ b/src/Imagine/Filter/Loader/ScaleFilterLoader.php
@@ -64,7 +64,7 @@ class ScaleFilterLoader implements LoaderInterface
         }
 
         if ($this->isImageProcessable($ratio)) {
-            $filter = new Resize(new Box(round($origWidth * $ratio), round($origHeight * $ratio)));
+            $filter = new Resize(new Box((int) round($origWidth * $ratio), (int) round($origHeight * $ratio)));
 
             return $filter->apply($image);
         }

--- a/src/Imagine/Filter/RelativeResize.php
+++ b/src/Imagine/Filter/RelativeResize.php
@@ -23,6 +23,10 @@ use Imagine\Image\ImageInterface;
 class RelativeResize implements FilterInterface
 {
     private string $method;
+
+    /**
+     * @var mixed
+     */
     private $parameter;
 
     /**

--- a/src/Templating/LazyFilterExtension.php
+++ b/src/Templating/LazyFilterExtension.php
@@ -27,10 +27,7 @@ final class LazyFilterExtension extends AbstractExtension
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'liip_imagine_lazy';
     }

--- a/src/Utility/Framework/SymfonyFramework.php
+++ b/src/Utility/Framework/SymfonyFramework.php
@@ -35,6 +35,6 @@ final class SymfonyFramework
 
     private static function kernelVersionCompare(string $operator, int $major, int $minor = null, int $patch = null): bool
     {
-        return version_compare(Kernel::VERSION_ID, sprintf("%d%'.02d%'.02d", $major, $minor ?: 0, $patch ?: 0), $operator);
+        return version_compare((string) Kernel::VERSION_ID, sprintf("%d%'.02d%'.02d", $major, $minor ?: 0, $patch ?: 0), $operator);
     }
 }

--- a/tests/Functional/AbstractSetupWebTestCase.php
+++ b/tests/Functional/AbstractSetupWebTestCase.php
@@ -19,25 +19,13 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class AbstractSetupWebTestCase extends AbstractWebTestCase
 {
-    /**
-     * @var KernelBrowser
-     */
-    protected $client;
+    protected KernelBrowser $client;
 
-    /**
-     * @var Filesystem
-     */
-    protected $filesystem;
+    protected Filesystem $filesystem;
 
-    /**
-     * @var string
-     */
-    protected $webRoot;
+    protected string $webRoot;
 
-    /**
-     * @var string
-     */
-    protected $cacheRoot;
+    protected string $cacheRoot;
 
     protected function setUp(): void
     {

--- a/tests/Functional/AbstractWebTestCase.php
+++ b/tests/Functional/AbstractWebTestCase.php
@@ -23,10 +23,7 @@ abstract class AbstractWebTestCase extends WebTestCase
         return AppKernel::class;
     }
 
-    /**
-     * @return object
-     */
-    protected function getService(string $name)
+    protected function getService(string $name): ?object
     {
         if (property_exists($this, 'container')) {
             return static::$container->get($name);
@@ -48,11 +45,9 @@ abstract class AbstractWebTestCase extends WebTestCase
     }
 
     /**
-     * @param object $object
-     *
      * @return mixed
      */
-    protected function getPrivateProperty($object, string $name)
+    protected function getPrivateProperty(object $object, string $name)
     {
         $r = new \ReflectionObject($object);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 3.x
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc | <!--new features must be documented. it is ok to first submit a draft for review and document once the general idea is accepted-->

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->

This PR raises PHPStan level to 6, the new baseline is only for the iterable array types (I've created a new one so it's easier to regenerate it), it requires quite a lot of work and knowledge about the package to fill all the iterable types. 

There is a `checkMissingIterableValueType` option for that, but IMO is better to start adding these types.