### PR TITLE
Refactor exception handling of `Binary\Loader\ChainLoader` class

### DIFF
--- a/src/Exception/Binary/Loader/ChainAttemptNotLoadableException.php
+++ b/src/Exception/Binary/Loader/ChainAttemptNotLoadableException.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Exception\Binary\Loader;
+
+use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
+
+final class ChainAttemptNotLoadableException extends NotLoadableException
+{
+    private string          $configName;
+    private LoaderInterface $loaderInst;
+
+    public function __construct(string $configName, LoaderInterface $loaderInst, NotLoadableException $loaderException)
+    {
+        $this->configName = $configName;
+        $this->loaderInst = $loaderInst;
+
+        parent::__construct($this->compileFailureText(), 0, $loaderException);
+    }
+
+    public function getLoaderConfigName(): string
+    {
+        return $this->configName;
+    }
+
+    public function getLoaderObjectInst(): LoaderInterface
+    {
+        return $this->loaderInst;
+    }
+
+    public function getLoaderObjectName(): string
+    {
+        return (new \ReflectionObject($this->getLoaderObjectInst()))->getShortName();
+    }
+
+    public function getLoaderPriorError(): string
+    {
+        return $this->getPrevious()->getMessage();
+    }
+
+    private function compileFailureText(): string
+    {
+        return sprintf('%s=[%s]', $this->getLoaderObjectName(), $this->getLoaderConfigName());
+    }
+}

--- a/src/Exception/Binary/Loader/ChainAttemptNotLoadableException.php
+++ b/src/Exception/Binary/Loader/ChainAttemptNotLoadableException.php
@@ -15,39 +15,39 @@ use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
 
 final class ChainAttemptNotLoadableException extends NotLoadableException
 {
-    private string          $configName;
-    private LoaderInterface $loaderInst;
+    private string          $loaderIndex;
+    private LoaderInterface $loaderClass;
 
-    public function __construct(string $configName, LoaderInterface $loaderInst, NotLoadableException $loaderException)
+    public function __construct(string $loaderIndex, LoaderInterface $loaderClass, NotLoadableException $loaderException)
     {
-        $this->configName = $configName;
-        $this->loaderInst = $loaderInst;
+        $this->loaderIndex = $loaderIndex;
+        $this->loaderClass = $loaderClass;
 
-        parent::__construct($this->compileFailureText(), 0, $loaderException);
+        parent::__construct($this->compileMessageTxt(), 0, $loaderException);
     }
 
-    public function getLoaderConfigName(): string
+    public function getLoaderIndex(): string
     {
-        return $this->configName;
+        return $this->loaderIndex;
     }
 
-    public function getLoaderObjectInst(): LoaderInterface
+    public function getLoaderClass(): LoaderInterface
     {
-        return $this->loaderInst;
+        return $this->loaderClass;
     }
 
-    public function getLoaderObjectName(): string
+    public function getLoaderClassName(): string
     {
-        return (new \ReflectionObject($this->getLoaderObjectInst()))->getShortName();
+        return (new \ReflectionObject($this->getLoaderClass()))->getShortName();
     }
 
-    public function getLoaderPriorError(): string
+    public function getLoaderException(): string
     {
         return $this->getPrevious()->getMessage();
     }
 
-    private function compileFailureText(): string
+    private function compileMessageTxt(): string
     {
-        return sprintf('%s=[%s]', $this->getLoaderObjectName(), $this->getLoaderConfigName());
+        return sprintf('%s=[%s]', $this->getLoaderClassName(), $this->getLoaderIndex());
     }
 }

--- a/src/Exception/Binary/Loader/ChainNotLoadableException.php
+++ b/src/Exception/Binary/Loader/ChainNotLoadableException.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Exception\Binary\Loader;
+
+final class ChainNotLoadableException extends NotLoadableException
+{
+    public function __construct(string $path, ChainAttemptNotLoadableException ...$exceptions)
+    {
+        parent::__construct(self::compileExceptionMessage($path, ...$exceptions));
+    }
+
+    private static function compileExceptionMessage(string $path, ChainAttemptNotLoadableException ...$exceptions): string
+    {
+        return vsprintf('Source image not resolvable "%s" using "%s" %d loaders (internal exceptions: %s).', [
+            $path, self::compileLoaderConfigMaps(...$exceptions), \count($exceptions), self::compileLoaderErrorsList(...$exceptions),
+        ]);
+    }
+
+    private static function compileLoaderConfigMaps(ChainAttemptNotLoadableException ...$exceptions): string
+    {
+        return self::implodeArrayMappedExceptions(static function (ChainAttemptNotLoadableException $e): string {
+            return $e->getMessage();
+        }, ...$exceptions);
+    }
+
+    private static function compileLoaderErrorsList(ChainAttemptNotLoadableException ...$exceptions): string
+    {
+        return self::implodeArrayMappedExceptions(static function (ChainAttemptNotLoadableException $e): string {
+            return sprintf('%s=[%s]', $e->getLoaderObjectName(), $e->getLoaderPriorError());
+        }, ...$exceptions);
+    }
+
+    private static function implodeArrayMappedExceptions(\Closure $mapper, ChainAttemptNotLoadableException ...$exceptions): string
+    {
+        return implode(', ', array_map($mapper, $exceptions));
+    }
+}

--- a/src/Exception/Binary/Loader/ChainNotLoadableException.php
+++ b/src/Exception/Binary/Loader/ChainNotLoadableException.php
@@ -21,25 +21,28 @@ final class ChainNotLoadableException extends NotLoadableException
     private static function compileExceptionMessage(string $path, ChainAttemptNotLoadableException ...$exceptions): string
     {
         return vsprintf('Source image not resolvable "%s" using "%s" %d loaders (internal exceptions: %s).', [
-            $path, self::compileLoaderConfigMaps(...$exceptions), \count($exceptions), self::compileLoaderErrorsList(...$exceptions),
+            $path,
+            self::compileLoaderConfigMaps(...$exceptions),
+            \count($exceptions),
+            self::compileLoaderErrorsList(...$exceptions),
         ]);
     }
 
     private static function compileLoaderConfigMaps(ChainAttemptNotLoadableException ...$exceptions): string
     {
-        return self::implodeArrayMappedExceptions(static function (ChainAttemptNotLoadableException $e): string {
+        return self::implodeMappedExceptions(static function (ChainAttemptNotLoadableException $e): string {
             return $e->getMessage();
         }, ...$exceptions);
     }
 
     private static function compileLoaderErrorsList(ChainAttemptNotLoadableException ...$exceptions): string
     {
-        return self::implodeArrayMappedExceptions(static function (ChainAttemptNotLoadableException $e): string {
-            return sprintf('%s=[%s]', $e->getLoaderObjectName(), $e->getLoaderPriorError());
+        return self::implodeMappedExceptions(static function (ChainAttemptNotLoadableException $e): string {
+            return sprintf('%s=[%s]', $e->getLoaderClassName(), $e->getLoaderException());
         }, ...$exceptions);
     }
 
-    private static function implodeArrayMappedExceptions(\Closure $mapper, ChainAttemptNotLoadableException ...$exceptions): string
+    private static function implodeMappedExceptions(\Closure $mapper, ChainAttemptNotLoadableException ...$exceptions): string
     {
         return implode(', ', array_map($mapper, $exceptions));
     }

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -271,16 +271,39 @@ abstract class AbstractTest extends TestCase
         return $builder->getMock();
     }
 
-    /**
-     * @param object $object
-     */
+    protected static function getReflectionObject(object $object): \ReflectionObject
+    {
+        return new \ReflectionObject($object);
+    }
+
+    protected static function getReflectionObjectName(object $object): string
+    {
+        return self::getReflectionObject($object)->getName();
+    }
+
     protected function getVisibilityRestrictedMethod($object, string $name): \ReflectionMethod
     {
-        $r = new \ReflectionObject($object);
-
-        $m = $r->getMethod($name);
+        $m = self::getReflectionObject($object)->getMethod($name);
         $m->setAccessible(true);
 
         return $m;
+    }
+
+    protected static function generateRandomInteger(int $lowerBound = null, int $upperBound = null): int
+    {
+        $lowerBound = $lowerBound ?? 0;
+        $upperBound = $upperBound ?? 100000000;
+
+        if ($lowerBound > $upperBound) {
+            throw new \LogicException('Lower-bound argument must be less-than or equal-to upper-bound argument!');
+        }
+
+        try {
+            return random_int($lowerBound, $upperBound);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException(vsprintf('Failed to generate random number between %d and %d: %s', [
+                $lowerBound, $upperBound, $e->getMessage()
+            ]));
+        }
     }
 }

--- a/tests/Binary/Loader/ChainLoaderTest.php
+++ b/tests/Binary/Loader/ChainLoaderTest.php
@@ -23,6 +23,8 @@ use Symfony\Component\Mime\MimeTypes;
 
 /**
  * @covers \Liip\ImagineBundle\Binary\Loader\ChainLoader
+ * @covers \Liip\ImagineBundle\Exception\Binary\Loader\ChainAttemptNotLoadableException
+ * @covers \Liip\ImagineBundle\Exception\Binary\Loader\ChainNotLoadableException
  */
 class ChainLoaderTest extends AbstractTest
 {


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 3.x <!--choose version number and select target branch accordingly-->
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| References | https://github.com/liip/LiipImagineBundle/pull/1432#discussion_r751265173 / https://github.com/liip/LiipImagineBundle/pull/1432#discussion_r753720665
| License | MIT
| Doc | n/a

This is a __work in progress__ toward refactoring the error handling logic of [`Liip\ImagineBundle\Binary\Loader\ChainLoader`](https://github.com/liip/LiipImagineBundle/blob/3.x/src/Binary/Loader/ChainLoader.php#L1) as was originally discussed in code review comments from #1432; see the discussion beginning with *[dbu's #1432 comment](https://github.com/liip/LiipImagineBundle/pull/1432#discussion_r751265173)* and, more specifically, *[my (robfrawley) #1432 comment](https://github.com/liip/LiipImagineBundle/pull/1432#discussion_r753720665)* in response. 

Additional information will be added *as my schedule permits* and *during this PR's progression*.

For the time being, I would *greatly appreciate* any thoughts from @dbu, @franmomu, or any other maintainer/contributor/user as to the current state of this pull request as well as any alternate possible directions to investigate.