### PR TITLE
Fix test suite bash helper scripts on systems with multiple (and older) bash versions

### DIFF
--- a/tests/Fixtures/bin/post-process-as-file-error.bash
+++ b/tests/Fixtures/bin/post-process-as-file-error.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "`cd $(dirname ${BASH_SOURCE[0]}) && pwd`/post-process-as-file.bash"
 

--- a/tests/Fixtures/bin/post-process-as-file.bash
+++ b/tests/Fixtures/bin/post-process-as-file.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "`cd $(dirname ${BASH_SOURCE[0]}) && pwd`/post-process-common.bash"
 

--- a/tests/Fixtures/bin/post-process-as-stdin-error.bash
+++ b/tests/Fixtures/bin/post-process-as-stdin-error.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "`cd $(dirname ${BASH_SOURCE[0]}) && pwd`/post-process-as-stdin.bash"
 

--- a/tests/Fixtures/bin/post-process-as-stdin.bash
+++ b/tests/Fixtures/bin/post-process-as-stdin.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "`cd $(dirname ${BASH_SOURCE[0]}) && pwd`/post-process-common.bash"
 

--- a/tests/Fixtures/bin/post-process-common.bash
+++ b/tests/Fixtures/bin/post-process-common.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function writeScriptInformation()
 {
@@ -36,7 +36,7 @@ function writeScriptInformation()
 
 function writeScriptDebugFile()
 {
-  local debugFile="/tmp/post-process-fixture-bin.log"
+  local debugFile="${TMPDIR:-/tmp}/post-process-fixture-bin.log"
 
   if read -t 0; then
     cat | tee "${debugFile}"


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 3.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | n/a
| License | MIT
| Doc | n/a

On systems like macOS, the provided Bash version is *insanely outdated* and __not__ compatible with our test suite. Their current OS release ships with Bash version `3.2.57`, a product of the [version `3` major release from `2004-08-03`](https://ftp.gnu.org/gnu/bash/).

This project's command and arguments compilation unit tests require a set of associated Bash stub scripts that are called in lieu of any real image processing commands to verify proper functionality, but these scripts require features dependent on newer versions of Bash than what is provided in macOS. As such, just like anyone else developing on macOS, I turned to the excellent [Homebrew](https://brew.sh/) project to install a current release of Bash, specifically [version `5.1.8` from `2021-06-15`](https://ftp.gnu.org/gnu/bash/).

The issue with our current Bash scripts is that *they provide an absolute Bash executable path for the Shebang line* such that only the bash command located at `/bin/bash` can be used when the script is invoked like a command (as done by our test suite) and the interpreter directive is read by the program loader mechanism of the OS.

To solve this, I've modified the Shebang line of our test stub Bash scripts to instead invoke the `env` command using the following: `#!/usr/bin/env bash`. This results in the same behavior as prior (calling of `/bin/bash`), unless the user configures their `$PATH` environment variable to prioritize one version of Bash over another (in my case, by adding `/usr/local/bin` earlier in the `$PATH` variable such that the `env` call resolves to `/usr/local/bin/bash` instead of `/bin/bash`).

While I encountered this issue using an older Macbook Pro that I am currently working on while my normal Linux-powered Thinkpad is being repaired, this issue could easily arise in any environment where multiple versions of Bash are available. Generally, it is good practice to use `env` in script Shebang directives anyway, so I don't see this change causing any issues (unless people improperly set up their shell environment).

Lastly, I added a check for the environment variable `$TMPDIR` when defining the temporary path root for log file output. Some systems define this, others do not. If this variable is not assigned, the default value of `/tmp` continues to be used, just as before.