### PR TITLE
Replaced 'twig_mode' by 'liip_imagine.twig.mode' in Filter depreciati…

### DIFF
--- a/Templating/FilterExtension.php
+++ b/Templating/FilterExtension.php
@@ -11,7 +11,7 @@
 
 namespace Liip\ImagineBundle\Templating;
 
-@trigger_error('The '.FilterExtension::class.' class is deprecated since version 2.7 and will be removed in 3.0; configure "twig_mode" to "lazy" instead.', E_USER_DEPRECATED);
+@trigger_error('The '.FilterExtension::class.' class is deprecated since version 2.7 and will be removed in 3.0; configure "liip_imagine.twig.mode" to "lazy" instead.', E_USER_DEPRECATED);
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;


### PR DESCRIPTION
…on message

| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | #1442 
| License | MIT

Just updated the Filter depreciation message in the 2.x
