### PR TITLE
animated gifs can not be transformed to the webp format

### DIFF
--- a/Imagine/Filter/FilterManager.php
+++ b/Imagine/Filter/FilterManager.php
@@ -160,7 +160,17 @@ class FilterManager
         }
 
         $filteredFormat = $config['format'] ?? $binary->getFormat();
-        $filteredString = $image->get($filteredFormat, $options);
+        try {
+            $filteredString = $image->get($filteredFormat, $options);
+        } catch (\Exception $exception) {
+            // we don't support converting an animated gif into webp.
+            // we can't efficiently check the input data, therefore we retry with target format gif in case of an error.
+            if ('webp' !== $filteredFormat || !\array_key_exists('animated', $options) || true !== $options['animated']) {
+                throw $exception;
+            }
+            $filteredFormat = 'gif';
+            $filteredString = $image->get($filteredFormat, $options);
+        }
 
         $this->destroyImage($image);
 


### PR DESCRIPTION
We can't efficiently check if the input is an animated gif, therefore we
catch the exception and try to convert to gif if converting to webp
failed.

continue fix #1440

| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| License | MIT
| Doc | -

When we configure the use of webp

```yaml
...
    webp:
        generate: true
...
```

and we try to generate image from a gif, we get this error

`Animated picture is currently only supported on gif`

Now, it's possible to generate animated webp. I will propose an evolution on `imagine/imagine` but for the moment, this PR fix the bug. 

Thanks a lot for your review !
