### PR TITLE
Allow Flysystem 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "doctrine/cache": "^1.11|^2.0",
         "doctrine/persistence": "^1.3|^2.0",
         "enqueue/enqueue-bundle": "^0.9|^0.10",
-        "league/flysystem": "^1.0|^2.0",
+        "league/flysystem": "^1.0|^2.0|^3.0",
         "phpstan/phpstan": "^0.12.64",
         "psr/cache": "^1.0|^2.0|^3.0",
         "psr/log": "^1.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | N/A
| License | MIT
| Doc | N/A

Flysystem 3.0 [has been released](https://github.com/thephpleague/flysystem/releases/tag/3.0.0).  The only B/C breaks in the new major are a raised PHP minimum and a couple of added methods on the core interfaces, so based on a quick scan through the bundle code, all of the existing logic to support Flysystem 2.x will transparently keep working.