### PR TITLE
use our Model, not Guzzle, for tests

### DIFF
--- a/tests/Imagine/Cache/Resolver/AwsS3ResolverTest.php
+++ b/tests/Imagine/Cache/Resolver/AwsS3ResolverTest.php
@@ -12,11 +12,11 @@
 namespace Liip\ImagineBundle\Tests\Imagine\Cache\Resolver;
 
 use Aws\S3\S3Client;
-use Guzzle\Service\Resource\Model;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\AwsS3Resolver;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Tests\AbstractTest;
+use Liip\ImagineBundle\Tests\Fixtures\Model;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 3
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #1451 
| License | MIT

This removes guzzle references from our code, which weren't being used anyway.