### PR TITLE
Update dependencies, including dev-develop for imagine

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - 1.x
-      - 2.x
+      - 3.x
 
 jobs:
   phpstan:
@@ -17,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.0
           coverage: none
 
       - name: Update project dependencies

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^7.4|^8.0",
         "ext-mbstring": "*",
         "imagine/imagine": "dev-develop",
         "symfony/filesystem": "^4.4|^5.3|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^8.0",
         "ext-mbstring": "*",
-        "imagine/imagine": "^1.2.4",
+        "imagine/imagine": "dev-develop",
         "symfony/filesystem": "^4.4|^5.3|^6.0",
         "symfony/finder": "^4.4|^5.3|^6.0",
         "symfony/framework-bundle": "^3.4.23|^4.4|^5.3|^6.0",
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-gd": "*",
-        "aws/aws-sdk-php": "^2.4|^3.2",
+        "aws/aws-sdk-php": "^3.2",
         "doctrine/persistence": "^1.3|^2.0",
         "league/flysystem": "^1.0|^2.0|^3.0",
         "phpstan/phpstan": "^1.0",
@@ -49,7 +49,6 @@
         "symfony/form": "^4.4|^5.3|^6.0",
         "symfony/messenger": "^4.4|^5.3|^6.0",
         "symfony/phpunit-bridge": "^5.3|^6.0",
-        "symfony/templating": "^4.4|^5.3|^6.0",
         "symfony/validator": "^4.4|^5.3|^6.0",
         "symfony/yaml": "^4.4|^5.3|^6.0"
     },
@@ -65,8 +64,7 @@
         "doctrine/mongodb-odm": "required to use mongodb-backed doctrine components",
         "league/flysystem": "required to use FlySystem data loader or cache resolver",
         "monolog/monolog": "A psr/log compatible logger is required to enable logging",
-        "symfony/messenger": "If you like to process images in background",
-        "symfony/templating": "required to use deprecated Templating component instead of Twig"
+        "symfony/messenger": "If you like to process images in background"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "ext-mbstring": "*",
         "imagine/imagine": "^1.2.4",
         "symfony/filesystem": "^4.4|^5.3|^6.0",
@@ -35,14 +35,13 @@
     },
     "require-dev": {
         "ext-gd": "*",
-        "amazonwebservices/aws-sdk-for-php": "^1.0",
-        "aws/aws-sdk-php": "^2.4",
+        "aws/aws-sdk-php": "^2.4|^3.2",
         "doctrine/persistence": "^1.3|^2.0",
-        "league/flysystem": "^1.0|^2.0",
+        "league/flysystem": "^1.0|^2.0|^3.0",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-symfony": "^1.0",
         "psr/cache": "^1.0|^2.0|^3.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "symfony/browser-kit": "^4.4|^5.3|^6.0",
         "symfony/cache": "^4.4|^5.3|^6.0",
         "symfony/console": "^4.4|^5.3|^6.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 3
| Bug fix? | no
| New feature? | no
| BC breaks? | maybe
| Deprecations? | yes!  All the imagine ones.
| Fixed tickets | #1457 
| License | MIT

Since this bundle is a wrapper around php-imagine, and version 3 is our dev version, I've updated the require-dev components to allow the latest versions of everything.  By using the dev-develop version of imagine, all the deprecation notices from that library disappeared.

Tests pass.

However, I don't know how stable dev-develop is.  So should v3 of this bundle support dev-develop?  Maybe someone from the imagine library can jump in.

