### PR TITLE
feat: add a cwebp post-processor for WebP images

### DIFF
--- a/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
@@ -10,16 +10,6 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 class CwebpPostProcessor extends AbstractPostProcessor
 {
     /**
-     * Specify the level of near-lossless image preprocessing. This option adjusts pixel values to help
-     * compressibility, but has minimal impact on the visual quality. It triggers lossless compression mode
-     * automatically. The range is **0** (maximum preprocessing) to **100** (no preprocessing). The typical value is
-     * around **60**. Note that lossy with **-q 100** can at times yield better results.
-     *
-     * @var int
-     */
-    protected $nearLossless;
-
-    /**
      * Specify the compression factor for RGB channels between **0** and **100**. The default is **75**.
      *
      * In case of lossy compression , a small factor produces a smaller file with lower quality. Best quality is
@@ -90,7 +80,6 @@ class CwebpPostProcessor extends AbstractPostProcessor
     public function __construct(
         string $executablePath = '/usr/bin/cwebp',
         string $temporaryRootPath = null,
-        int $nearLossless = null,
         int $q = null,
         int $alphaQ = null,
         int $m = null,
@@ -101,7 +90,6 @@ class CwebpPostProcessor extends AbstractPostProcessor
     ) {
         parent::__construct($executablePath, $temporaryRootPath);
 
-        $this->nearLossless = $nearLossless;
         $this->q = $q;
         $this->alphaQ = $alphaQ;
         $this->m = $m;
@@ -152,15 +140,6 @@ class CwebpPostProcessor extends AbstractPostProcessor
     private function getProcessArguments(array $options = []): array
     {
         $arguments = [$this->executablePath];
-
-        if ($nearLossless = $options['nearLossless'] ?? $this->nearLossless) {
-            if (!\in_array($nearLossless, range(0, 100), true)) {
-                throw new InvalidOptionException('The "nearLossless" option must be an int between 0 and 100', $options);
-            }
-
-            $arguments[] = '-near_lossless';
-            $arguments[] = $nearLossless;
-        }
 
         if ($q = $options['q'] ?? $this->q) {
             if (!\in_array($q, range(0, 100), true)) {

--- a/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Liip\ImagineBundle\Imagine\Filter\PostProcessor;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;
@@ -17,7 +26,6 @@ class CwebpPostProcessor extends AbstractPostProcessor
      *
      * In case of lossless compression (specified by the **-lossless** option), a small factor enables faster
      * compression speed, but produces a larger file. Maximum compression is achieved by using a value of **100**.
-     *
      *
      * @var int
      */
@@ -151,8 +159,7 @@ class CwebpPostProcessor extends AbstractPostProcessor
                 }
 
                 return $value >= 0 && $value <= 100;
-            })
-        ;
+            });
 
         $resolver
             ->setDefault('alphaQ', $this->alphaQ)
@@ -163,8 +170,7 @@ class CwebpPostProcessor extends AbstractPostProcessor
                 }
 
                 return $value >= 0 && $value <= 100;
-            })
-        ;
+            });
 
         $resolver
             ->setDefault('m', $this->m)
@@ -175,25 +181,21 @@ class CwebpPostProcessor extends AbstractPostProcessor
                 }
 
                 return $value >= 0 && $value <= 6;
-            })
-        ;
+            });
 
         $resolver
             ->setDefault('alphaFilter', $this->alphaFilter)
             ->setAllowedTypes('alphaFilter', ['null', 'string'])
-            ->setAllowedValues('alphaFilter', [null, 'none', 'fast', 'best'])
-        ;
+            ->setAllowedValues('alphaFilter', [null, 'none', 'fast', 'best']);
 
         $resolver
             ->setDefault('alphaMethod', $this->alphaMethod)
             ->setAllowedTypes('alphaMethod', ['null', 'int'])
-            ->setAllowedValues('alphaMethod', [null, 0, 1])
-        ;
+            ->setAllowedValues('alphaMethod', [null, 0, 1]);
 
         $resolver
             ->setDefault('exact', $this->exact)
-            ->setAllowedTypes('exact', ['null', 'bool'])
-        ;
+            ->setAllowedTypes('exact', ['null', 'bool']);
 
         $resolver
             ->setDefault('metadata', $this->metadata)
@@ -210,8 +212,7 @@ class CwebpPostProcessor extends AbstractPostProcessor
                 }
 
                 return true;
-            })
-        ;
+            });
     }
 
     /**

--- a/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
@@ -68,12 +68,12 @@ class CwebpPostProcessor extends AbstractPostProcessor
     protected $exact;
 
     /**
-     * A comma separated list of metadata to copy from the input to the output if present. Valid values: **all**,
-     * **none**, **exif**, **icc**, **xmp**.
+     * An array of metadata to copy from the input to the output if present. Valid values: **all**, **none**, **exif**,
+     * **icc**, **xmp**.
      *
      * Note that each input format may not support all combinations.
      *
-     * @var string
+     * @var string[]
      */
     protected $metadata;
 
@@ -86,7 +86,7 @@ class CwebpPostProcessor extends AbstractPostProcessor
         string $alphaFilter = null,
         int $alphaMethod = null,
         bool $exact = null,
-        string $metadata = null
+        array $metadata = []
     ) {
         parent::__construct($executablePath, $temporaryRootPath);
 
@@ -192,16 +192,14 @@ class CwebpPostProcessor extends AbstractPostProcessor
         }
 
         if ($metadata = $options['metadata'] ?? $this->metadata) {
-            $metadataValues = explode(',', $metadata);
-
-            foreach ($metadataValues as $metadataValue) {
+            foreach ($metadata as $metadataValue) {
                 if (!\in_array($metadataValue, ['all', 'none', 'exif', 'icc', 'xmp'], true)) {
-                    throw new InvalidOptionException('The "metadata" option must be a list of string (all, none, exif, icc, xmp)', $options);
+                    throw new InvalidOptionException('The "metadata" option must be an array of string (all, none, exif, icc, xmp)', $options);
                 }
             }
 
             $arguments[] = '-metadata';
-            $arguments[] = $metadata;
+            $arguments[] = implode(',', $metadata);
         }
 
         return $arguments;

--- a/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
@@ -143,10 +143,9 @@ class CwebpPostProcessor extends AbstractPostProcessor
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->define('q')
-            ->default($this->q)
-            ->allowedTypes('null', 'int')
-            ->allowedValues(static function ($value) {
+            ->setDefault('q', $this->q)
+            ->setAllowedTypes('q', ['null', 'int'])
+            ->setAllowedValues('q', static function ($value) {
                 if (null === $value) {
                     return true;
                 }
@@ -156,10 +155,9 @@ class CwebpPostProcessor extends AbstractPostProcessor
         ;
 
         $resolver
-            ->define('alphaQ')
-            ->default($this->alphaQ)
-            ->allowedTypes('null', 'int')
-            ->allowedValues(static function ($value) {
+            ->setDefault('alphaQ', $this->alphaQ)
+            ->setAllowedTypes('alphaQ', ['null', 'int'])
+            ->setAllowedValues('alphaQ', static function ($value) {
                 if (null === $value) {
                     return true;
                 }
@@ -169,10 +167,9 @@ class CwebpPostProcessor extends AbstractPostProcessor
         ;
 
         $resolver
-            ->define('m')
-            ->default($this->m)
-            ->allowedTypes('null', 'int')
-            ->allowedValues(static function ($value) {
+            ->setDefault('m', $this->m)
+            ->setAllowedTypes('m', ['null', 'int'])
+            ->setAllowedValues('m', static function ($value) {
                 if (null === $value) {
                     return true;
                 }
@@ -182,30 +179,26 @@ class CwebpPostProcessor extends AbstractPostProcessor
         ;
 
         $resolver
-            ->define('alphaFilter')
-            ->default($this->alphaFilter)
-            ->allowedTypes('null', 'string')
-            ->allowedValues(null, 'none', 'fast', 'best')
+            ->setDefault('alphaFilter', $this->alphaFilter)
+            ->setAllowedTypes('alphaFilter', ['null', 'string'])
+            ->setAllowedValues('alphaFilter', [null, 'none', 'fast', 'best'])
         ;
 
         $resolver
-            ->define('alphaMethod')
-            ->default($this->alphaMethod)
-            ->allowedTypes('null', 'int')
-            ->allowedValues(null, 0, 1)
+            ->setDefault('alphaMethod', $this->alphaMethod)
+            ->setAllowedTypes('alphaMethod', ['null', 'int'])
+            ->setAllowedValues('alphaMethod', [null, 0, 1])
         ;
 
         $resolver
-            ->define('exact')
-            ->default($this->exact)
-            ->allowedTypes('null', 'bool')
+            ->setDefault('exact', $this->exact)
+            ->setAllowedTypes('exact', ['null', 'bool'])
         ;
 
         $resolver
-            ->define('metadata')
-            ->default($this->metadata)
-            ->allowedTypes('null', 'array')
-            ->allowedValues(static function ($value) {
+            ->setDefault('metadata', $this->metadata)
+            ->setAllowedTypes('metadata', ['null', 'array'])
+            ->setAllowedValues('metadata', static function ($value) {
                 if (null === $value) {
                     return true;
                 }

--- a/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Liip\ImagineBundle\Imagine\Filter\PostProcessor;
+
+use Liip\ImagineBundle\Binary\BinaryInterface;
+use Liip\ImagineBundle\Exception\Imagine\Filter\PostProcessor\InvalidOptionException;
+use Liip\ImagineBundle\Model\Binary;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class CwebpPostProcessor extends AbstractPostProcessor
+{
+    /**
+     * Specify the level of near-lossless image preprocessing. This option adjusts pixel values to help
+     * compressibility, but has minimal impact on the visual quality. It triggers lossless compression mode
+     * automatically. The range is **0** (maximum preprocessing) to **100** (no preprocessing). The typical value is
+     * around **60**. Note that lossy with **-q 100** can at times yield better results.
+     *
+     * @var int
+     */
+    protected $nearLossless;
+
+    /**
+     * Specify the compression factor for RGB channels between **0** and **100**. The default is **75**.
+     *
+     * In case of lossy compression , a small factor produces a smaller file with lower quality. Best quality is
+     * achieved by using a value of **100**.
+     *
+     * In case of lossless compression (specified by the **-lossless** option), a small factor enables faster
+     * compression speed, but produces a larger file. Maximum compression is achieved by using a value of **100**.
+     *
+     *
+     * @var int
+     */
+    protected $q;
+
+    /**
+     * Specify the compression factor for alpha compression between **0** and **100**. Lossless compression of alpha is
+     * achieved using a value of **100**, while the lower values result in a lossy compression.
+     *
+     * @var int
+     */
+    protected $alphaQ;
+
+    /**
+     * Specify the compression method to use. This parameter controls the trade off between encoding speed and the
+     * compressed file size and quality. Possible values range from **0** to **6**. When higher values are used, the
+     * encoder will spend more time inspecting additional encoding possibilities and decide on the quality gain. Lower
+     * value can result in faster processing time at the expense of larger file size and lower compression quality.
+     *
+     * @var int
+     */
+    protected $m;
+
+    /**
+     * Specify the predictive filtering method for the alpha plane. One of **none**, **fast** or **best**, in
+     * increasing complexity and slowness order. Internally, alpha filtering is performed using four possible
+     * predictions (none, horizontal, vertical, gradient). The **best** mode will try each mode in turn and pick the
+     * one which gives the smaller size. The **fast** mode will just try to form an a priori guess without testing all
+     * modes.
+     *
+     * @var string
+     */
+    protected $alphaFilter;
+
+    /**
+     * Specify the algorithm used for alpha compression: **0** or **1**. Algorithm **0** denotes no compression, **1**
+     * uses WebP lossless format for compression.
+     *
+     * @var int
+     */
+    protected $alphaMethod;
+
+    /**
+     * Preserve RGB values in transparent area. The default is off, to help compressibility.
+     *
+     * @var bool
+     */
+    protected $exact;
+
+    /**
+     * A comma separated list of metadata to copy from the input to the output if present. Valid values: **all**,
+     * **none**, **exif**, **icc**, **xmp**.
+     *
+     * Note that each input format may not support all combinations.
+     *
+     * @var string
+     */
+    protected $metadata;
+
+    public function __construct(
+        string $executablePath = '/usr/bin/cwebp',
+        string $temporaryRootPath = null,
+        int $nearLossless = null,
+        int $q = null,
+        int $alphaQ = null,
+        int $m = null,
+        string $alphaFilter = null,
+        int $alphaMethod = null,
+        bool $exact = null,
+        string $metadata = null
+    ) {
+        parent::__construct($executablePath, $temporaryRootPath);
+
+        $this->nearLossless = $nearLossless;
+        $this->q = $q;
+        $this->alphaQ = $alphaQ;
+        $this->m = $m;
+        $this->alphaFilter = $alphaFilter;
+        $this->alphaMethod = $alphaMethod;
+        $this->exact = $exact;
+        $this->metadata = $metadata;
+    }
+
+    public function process(BinaryInterface $binary, array $options = []): BinaryInterface
+    {
+        if (!$this->isBinaryTypeWebpImage($binary)) {
+            return $binary;
+        }
+
+        $file = $this->writeTemporaryFile($binary, $options, 'imagine-post-processor-cwebp');
+        $arguments = $this->getProcessArguments($options);
+        $arguments[] = $file;
+        $arguments[] = '-o';
+        $arguments[] = '-';
+        $process = $this->createProcess($arguments, $options);
+
+        $process->run();
+
+        if (!$this->isSuccessfulProcess($process)) {
+            unlink($file);
+
+            throw new ProcessFailedException($process);
+        }
+
+        $result = new Binary($process->getOutput(), $binary->getMimeType(), $binary->getFormat());
+
+        unlink($file);
+
+        return $result;
+    }
+
+    protected function isBinaryTypeWebpImage(BinaryInterface $binary): bool
+    {
+        return $this->isBinaryTypeMatch($binary, ['image/webp']);
+    }
+
+    /**
+     * @param int|string[] $options
+     *
+     * @return string[]
+     */
+    private function getProcessArguments(array $options = []): array
+    {
+        $arguments = [$this->executablePath];
+
+        if ($nearLossless = $options['nearLossless'] ?? $this->nearLossless) {
+            if (!\in_array($nearLossless, range(0, 100), true)) {
+                throw new InvalidOptionException('The "nearLossless" option must be an int between 0 and 100', $options);
+            }
+
+            $arguments[] = '-near_lossless';
+            $arguments[] = $nearLossless;
+        }
+
+        if ($q = $options['q'] ?? $this->q) {
+            if (!\in_array($q, range(0, 100), true)) {
+                throw new InvalidOptionException('The "q" option must be an int between 0 and 100', $options);
+            }
+
+            $arguments[] = '-q';
+            $arguments[] = $q;
+        }
+
+        if ($alphaQ = $options['alphaQ'] ?? $this->alphaQ) {
+            if (!\in_array($alphaQ, range(0, 100), true)) {
+                throw new InvalidOptionException('The "alphaQ" option must be an int between 0 and 100', $options);
+            }
+
+            $arguments[] = '-alpha_q';
+            $arguments[] = $alphaQ;
+        }
+
+        if ($m = $options['m'] ?? $this->m) {
+            if (!\in_array($m, range(0, 6), true)) {
+                throw new InvalidOptionException('The "m" option must be an int between 0 and 6', $options);
+            }
+
+            $arguments[] = '-m';
+            $arguments[] = $m;
+        }
+
+        if ($alphaFilter = $options['alphaFilter'] ?? $this->alphaFilter) {
+            if (!\in_array($alphaFilter, ['none', 'fast', 'best'], true)) {
+                throw new InvalidOptionException('The "alphaFilter" option must be a string (none, fast or best)', $options);
+            }
+
+            $arguments[] = '-alpha_filter';
+            $arguments[] = $alphaFilter;
+        }
+
+        $alphaMethod = $options['alphaMethod'] ?? $this->alphaMethod;
+        if (null !== $alphaMethod) {
+            if (!\in_array($alphaMethod, range(0, 1), true)) {
+                throw new InvalidOptionException('The "alphaMethod" option must be an int between 0 and 1', $options);
+            }
+
+            $arguments[] = '-alpha_method';
+            $arguments[] = $alphaMethod;
+        }
+
+        if ($options['exact'] ?? $this->exact) {
+            $arguments[] = '-exact';
+        }
+
+        if ($metadata = $options['metadata'] ?? $this->metadata) {
+            $metadataValues = explode(',', $metadata);
+
+            foreach ($metadataValues as $metadataValue) {
+                if (!\in_array($metadataValue, ['all', 'none', 'exif', 'icc', 'xmp'], true)) {
+                    throw new InvalidOptionException('The "metadata" option must be a list of string (all, none, exif, icc, xmp)', $options);
+                }
+            }
+
+            $arguments[] = '-metadata';
+            $arguments[] = $metadata;
+        }
+
+        return $arguments;
+    }
+}

--- a/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
+++ b/Imagine/Filter/PostProcessor/CwebpPostProcessor.php
@@ -185,26 +185,14 @@ class CwebpPostProcessor extends AbstractPostProcessor
             ->define('alphaFilter')
             ->default($this->alphaFilter)
             ->allowedTypes('null', 'string')
-            ->allowedValues(static function ($value) {
-                if (null === $value) {
-                    return true;
-                }
-
-                return \in_array($value, ['none', 'fast', 'best'], true);
-            })
+            ->allowedValues(null, 'none', 'fast', 'best')
         ;
 
         $resolver
             ->define('alphaMethod')
             ->default($this->alphaMethod)
             ->allowedTypes('null', 'int')
-            ->allowedValues(static function ($value) {
-                if (null === $value) {
-                    return true;
-                }
-
-                return $value >= 0 && $value <= 1;
-            })
+            ->allowedValues(null, 0, 1)
         ;
 
         $resolver

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -28,6 +28,18 @@
 
         <parameter key="liip_imagine.mozjpeg.binary">/opt/mozjpeg/bin/cjpeg</parameter>
 
+        <!-- cwebp parameters -->
+
+        <parameter key="liip_imagine.cwebp.binary">/usr/bin/cwebp</parameter>
+        <parameter key="liip_imagine.cwebp.near_lossless">100</parameter>
+        <parameter key="liip_imagine.cwebp.q">75</parameter>
+        <parameter key="liip_imagine.cwebp.alpha_q">100</parameter>
+        <parameter key="liip_imagine.cwebp.m">4</parameter>
+        <parameter key="liip_imagine.cwebp.alpha_filter">fast</parameter>
+        <parameter key="liip_imagine.cwebp.alpha_method">1</parameter>
+        <parameter key="liip_imagine.cwebp.exact">false</parameter>
+        <parameter key="liip_imagine.cwebp.metadata">none</parameter>
+
     </parameters>
 
     <services>
@@ -422,6 +434,11 @@
         <service id="liip_imagine.filter.post_processor.mozjpeg" class="Liip\ImagineBundle\Imagine\Filter\PostProcessor\MozJpegPostProcessor">
             <argument>%liip_imagine.mozjpeg.binary%</argument>
             <tag name="liip_imagine.filter.post_processor" post_processor="mozjpeg" />
+        </service>
+
+        <service id="liip_imagine.filter.post_processor.cwebp" class="Liip\ImagineBundle\Imagine\Filter\PostProcessor\CwebpPostProcessor">
+            <argument>%liip_imagine.cwebp.binary%</argument>
+            <tag name="liip_imagine.filter.post_processor" post_processor="cwebp" />
         </service>
 
     </services>

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -31,7 +31,6 @@
         <!-- cwebp parameters -->
 
         <parameter key="liip_imagine.cwebp.binary">/usr/bin/cwebp</parameter>
-        <parameter key="liip_imagine.cwebp.near_lossless">100</parameter>
         <parameter key="liip_imagine.cwebp.q">75</parameter>
         <parameter key="liip_imagine.cwebp.alpha_q">100</parameter>
         <parameter key="liip_imagine.cwebp.m">4</parameter>

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -38,7 +38,9 @@
         <parameter key="liip_imagine.cwebp.alphaFilter">fast</parameter>
         <parameter key="liip_imagine.cwebp.alphaMethod">1</parameter>
         <parameter key="liip_imagine.cwebp.exact">false</parameter>
-        <parameter key="liip_imagine.cwebp.metadata">none</parameter>
+        <parameter key="liip_imagine.cwebp.metadata" type="collection">
+            <parameter>none</parameter>
+        </parameter>
 
     </parameters>
 

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -31,11 +31,12 @@
         <!-- cwebp parameters -->
 
         <parameter key="liip_imagine.cwebp.binary">/usr/bin/cwebp</parameter>
+        <parameter key="liip_imagine.cwebp.tempDir">null</parameter>
         <parameter key="liip_imagine.cwebp.q">75</parameter>
-        <parameter key="liip_imagine.cwebp.alpha_q">100</parameter>
+        <parameter key="liip_imagine.cwebp.alphaQ">100</parameter>
         <parameter key="liip_imagine.cwebp.m">4</parameter>
-        <parameter key="liip_imagine.cwebp.alpha_filter">fast</parameter>
-        <parameter key="liip_imagine.cwebp.alpha_method">1</parameter>
+        <parameter key="liip_imagine.cwebp.alphaFilter">fast</parameter>
+        <parameter key="liip_imagine.cwebp.alphaMethod">1</parameter>
         <parameter key="liip_imagine.cwebp.exact">false</parameter>
         <parameter key="liip_imagine.cwebp.metadata">none</parameter>
 
@@ -437,6 +438,14 @@
 
         <service id="liip_imagine.filter.post_processor.cwebp" class="Liip\ImagineBundle\Imagine\Filter\PostProcessor\CwebpPostProcessor">
             <argument>%liip_imagine.cwebp.binary%</argument>
+            <argument>%liip_imagine.cwebp.tempDir%</argument>
+            <argument>%liip_imagine.cwebp.q%</argument>
+            <argument>%liip_imagine.cwebp.alphaQ%</argument>
+            <argument>%liip_imagine.cwebp.m%</argument>
+            <argument>%liip_imagine.cwebp.alphaFilter%</argument>
+            <argument>%liip_imagine.cwebp.alphaMethod%</argument>
+            <argument>%liip_imagine.cwebp.exact%</argument>
+            <argument>%liip_imagine.cwebp.metadata%</argument>
             <tag name="liip_imagine.filter.post_processor" post_processor="cwebp" />
         </service>
 

--- a/Resources/doc/post-processors/cwebp.rst
+++ b/Resources/doc/post-processors/cwebp.rst
@@ -1,0 +1,98 @@
+
+.. _post-processor-cweb:
+
+cwebp
+=====
+
+The ``CwebpPostProcessor`` is a built-in post-processor that performs a number of optimizations on *WEBP* encoded
+images.
+
+To add this post-processor to the filter set created in the
+:ref:`thumbnail usage example <usage-create-thumbnails>` use:
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    liip_imagine:
+        filter_sets:
+            my_thumb:
+                filters:
+                    thumbnail: { size: [120, 90], mode: outbound }
+                    background: { size: [124, 94], position: center, color: '#000' }
+                post_processors:
+                    cwebp: { metadata: 'none', q: 70 }
+
+This configuration enables metadata stripping and sets a maximum compression factor of 70 for the resulting image
+binary.
+
+.. note::
+
+    The default executable path is ``/usr/bin/cwebp``. If installed elsewhere
+    on your system, you must set the ``liip_imagine.cwebp.binary`` parameter accordingly.
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+
+        parameters:
+            liip_imagine.cwebp.binary: /your/custom/path/to/cwebp
+
+
+Options
+-------
+
+**q:** ``int``
+    Specify the compression factor for RGB channels between ``0`` and ``100``. The default is ``75``.
+
+**alpha_q:** ``int``
+    Specify the compression factor for alpha compression between ``0`` and ``100``.
+
+**m:** ``int``
+    Specify the compression method to use. Possible values range from ``0`` to ``6``.
+
+**alpha_filter:** ``string``
+    Specify the predictive filtering method for the alpha plane. One of ``none``, ``fast`` or ``best``.
+
+**alpha_method:** ``int``
+    Specify the algorithm used for alpha compression: ``0`` or ``1``.
+
+**exact:** ``bool``
+    Preserve RGB values in transparent area. The default is off, to help compressibility.
+
+**metadata:** ``array``
+    An array of metadata to copy from the input to the output if present. Valid values: ``all``, ``none``, ``exif``,
+    ``icc``, ``xmp``.
+
+
+
+Parameters
+----------
+
+**liip_imagine.cwebp.binary:** ``string``
+    Sets the location of the ``cwebp`` executable. Default is ``/usr/bin/cwebp``.
+
+**liip_imagine.cwebp.tempDir:** ``string``
+    Sets the directory to store temporary files.
+
+**liip_imagine.cwebp.q:** ``int``
+    Specify the compression factor for RGB channels between ``0`` and ``100``. The default is ``75``.
+
+**liip_imagine.cwebp.alphaQ:** ``int``
+    Specify the compression factor for alpha compression between ``0`` and ``100``.
+
+**liip_imagine.cwebp.m:** ``int``
+    Specify the compression method to use. Possible values range from ``0`` to ``6``.
+
+**liip_imagine.cwebp.alphaFilter:** ``string``
+    Specify the predictive filtering method for the alpha plane. One of ``none``, ``fast`` or ``best``.
+
+**liip_imagine.cwebp.alphaMethod:** ``int``
+    Specify the algorithm used for alpha compression: ``0`` or ``1``.
+
+**liip_imagine.cwebp.exact:** ``bool``
+    Preserve RGB values in transparent area. The default is off, to help compressibility.
+
+**liip_imagine.cwebp.metadata:** ``array``
+    An array of metadata to copy from the input to the output if present. Valid values: ``all``, ``none``, ``exif``,
+    ``icc``, ``xmp``.

--- a/Tests/Imagine/Filter/PostProcessor/CwebpPostProcessorTest.php
+++ b/Tests/Imagine/Filter/PostProcessor/CwebpPostProcessorTest.php
@@ -154,8 +154,7 @@ class CwebpPostProcessorTest extends AbstractPostProcessorTestCase
         $binary
             ->expects($this->atLeastOnce())
             ->method('getMimeType')
-            ->willReturn('application/x-php')
-        ;
+            ->willReturn('application/x-php');
 
         $this->assertSame($binary, $this->getPostProcessorInstance()->process($binary, []));
     }

--- a/Tests/Imagine/Filter/PostProcessor/CwebpPostProcessorTest.php
+++ b/Tests/Imagine/Filter/PostProcessor/CwebpPostProcessorTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Imagine\Filter\PostProcessor;
+
+use Liip\ImagineBundle\Exception\Imagine\Filter\PostProcessor\InvalidOptionException;
+use Liip\ImagineBundle\Imagine\Filter\PostProcessor\CwebpPostProcessor;
+use Liip\ImagineBundle\Model\Binary;
+use Liip\ImagineBundle\Model\FileBinary;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Filter\PostProcessor\AbstractPostProcessor
+ * @covers \Liip\ImagineBundle\Imagine\Filter\PostProcessor\PngquantPostProcessor
+ */
+class CwebpPostProcessorTest extends AbstractPostProcessorTestCase
+{
+    public function testNearLosslessOptionThrowsOnOutOfScopeInt(): void
+    {
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The "nearLossless" option must be an int between 0 and 100');
+
+        $this->getProcessArguments(['nearLossless' => 101]);
+    }
+
+    public function testQOptionThrowsOnOutOfScopeInt(): void
+    {
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The "q" option must be an int between 0 and 100');
+
+        $this->getProcessArguments(['q' => 101]);
+    }
+
+    public function testAlphaQOptionThrowsOnOutOfScopeInt(): void
+    {
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The "alphaQ" option must be an int between 0 and 100');
+
+        $this->getProcessArguments(['alphaQ' => 101]);
+    }
+
+    public function testMOptionThrowsOnOutOfScopeInt(): void
+    {
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The "m" option must be an int between 0 and 6');
+
+        $this->getProcessArguments(['m' => 7]);
+    }
+
+    public function testAlphaFilterOptionThrowsOnOutOfScopeInt(): void
+    {
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The "alphaFilter" option must be a string (none, fast or best)');
+
+        $this->getProcessArguments(['alphaFilter' => 'dummy']);
+    }
+
+    public function testAlphaMethodOptionThrowsOnOutOfScopeInt(): void
+    {
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The "alphaMethod" option must be an int between 0 and 1');
+
+        $this->getProcessArguments(['alphaMethod' => 7]);
+    }
+
+    public function testMetadataOptionThrowsOnOutOfScopeInt(): void
+    {
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The "metadata" option must be a list of string (all, none, exif, icc, xmp)');
+
+        $this->getProcessArguments(['metadata' => 'dummy']);
+    }
+
+    public static function provideProcessArgumentsData(): array
+    {
+        $data = [
+            [[], []],
+            [['nearLossless' => 80], ['-near_lossless', 80]],
+            [['q' => 80], ['-q', 80]],
+            [['alphaQ' => 80], ['-alpha_q', 80]],
+            [['m' => 6], ['-m', 6]],
+            [['alphaFilter' => 'best'], ['-alpha_filter', 'best']],
+            [['alphaMethod' => 0], ['-alpha_method', 0]],
+            [['exact' => true], ['-exact']],
+            [['metadata' => 'all'], ['-metadata', 'all']],
+        ];
+
+        return array_map(static function (array $d) {
+            array_unshift($d[1], AbstractPostProcessorTestCase::getPostProcessAsStdInExecutable());
+
+            return $d;
+        }, $data);
+    }
+
+    /**
+     * @dataProvider provideProcessArgumentsData
+     */
+    public function testProcessArguments(array $options, array $expected): void
+    {
+        $this->assertSame($expected, $this->getProcessArguments($options));
+    }
+
+    public static function provideProcessData(): array
+    {
+        $file = 'stdio-file-content-string';
+        $data = [
+            [[], ''],
+            [['nearLossless' => 80], '-near_lossless 80'],
+            [['q' => 80], '-q 80'],
+            [['alphaQ' => 80], '-alpha_q 80'],
+            [['m' => 6], '-m 6'],
+            [['alphaFilter' => 'best'], '-alpha_filter best'],
+            [['alphaMethod' => 0], '-alpha_method 0'],
+            [['exact' => true], '-exact'],
+            [['metadata' => 'all'], '-metadata all'],
+        ];
+
+        return array_map(static function ($d) use ($file) {
+            array_unshift($d, $file);
+
+            return $d;
+        }, $data);
+    }
+
+    /**
+     * @dataProvider provideProcessData
+     */
+    public function testProcess(string $content, array $options, string $expected): void
+    {
+        $file = sys_get_temp_dir().'/test.webp';
+        file_put_contents($file, $content);
+
+        $process = $this->getPostProcessorInstance();
+        $result = $process->process(new FileBinary($file, 'image/webp', 'webp'), $options);
+
+        $this->assertStringContainsString($expected, $result->getContent());
+
+        @unlink($file);
+    }
+
+    /**
+     * @dataProvider provideProcessData
+     */
+    public function testProcessError(string $content, array $options, string $expected): void
+    {
+        $this->expectException(ProcessFailedException::class);
+
+        $process = $this->getPostProcessorInstance([static::getPostProcessAsStdInErrorExecutable()]);
+        $process->process(new Binary('content', 'image/webp', 'webp'), $options);
+    }
+
+    public function testProcessWithNonSupportedMimeType(): void
+    {
+        $binary = $this->getBinaryInterfaceMock();
+
+        $binary
+            ->expects($this->atLeastOnce())
+            ->method('getMimeType')
+            ->willReturn('application/x-php')
+        ;
+
+        $this->assertSame($binary, $this->getPostProcessorInstance()->process($binary, []));
+    }
+
+    protected function getPostProcessorInstance(array $parameters = []): CwebpPostProcessor
+    {
+        return new CwebpPostProcessor($parameters[0] ?? static::getPostProcessAsStdInExecutable());
+    }
+}

--- a/Tests/Imagine/Filter/PostProcessor/CwebpPostProcessorTest.php
+++ b/Tests/Imagine/Filter/PostProcessor/CwebpPostProcessorTest.php
@@ -23,14 +23,6 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
  */
 class CwebpPostProcessorTest extends AbstractPostProcessorTestCase
 {
-    public function testNearLosslessOptionThrowsOnOutOfScopeInt(): void
-    {
-        $this->expectException(InvalidOptionException::class);
-        $this->expectExceptionMessage('The "nearLossless" option must be an int between 0 and 100');
-
-        $this->getProcessArguments(['nearLossless' => 101]);
-    }
-
     public function testQOptionThrowsOnOutOfScopeInt(): void
     {
         $this->expectException(InvalidOptionException::class);
@@ -83,7 +75,6 @@ class CwebpPostProcessorTest extends AbstractPostProcessorTestCase
     {
         $data = [
             [[], []],
-            [['nearLossless' => 80], ['-near_lossless', 80]],
             [['q' => 80], ['-q', 80]],
             [['alphaQ' => 80], ['-alpha_q', 80]],
             [['m' => 6], ['-m', 6]],
@@ -113,7 +104,6 @@ class CwebpPostProcessorTest extends AbstractPostProcessorTestCase
         $file = 'stdio-file-content-string';
         $data = [
             [[], ''],
-            [['nearLossless' => 80], '-near_lossless 80'],
             [['q' => 80], '-q 80'],
             [['alphaQ' => 80], '-alpha_q 80'],
             [['m' => 6], '-m 6'],

--- a/Tests/Imagine/Filter/PostProcessor/CwebpPostProcessorTest.php
+++ b/Tests/Imagine/Filter/PostProcessor/CwebpPostProcessorTest.php
@@ -11,10 +11,10 @@
 
 namespace Liip\ImagineBundle\Tests\Imagine\Filter\PostProcessor;
 
-use Liip\ImagineBundle\Exception\Imagine\Filter\PostProcessor\InvalidOptionException;
 use Liip\ImagineBundle\Imagine\Filter\PostProcessor\CwebpPostProcessor;
 use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Model\FileBinary;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
 /**
@@ -25,48 +25,48 @@ class CwebpPostProcessorTest extends AbstractPostProcessorTestCase
 {
     public function testQOptionThrowsOnOutOfScopeInt(): void
     {
-        $this->expectException(InvalidOptionException::class);
-        $this->expectExceptionMessage('The "q" option must be an int between 0 and 100');
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "q" with value 101 is invalid.');
 
         $this->getProcessArguments(['q' => 101]);
     }
 
     public function testAlphaQOptionThrowsOnOutOfScopeInt(): void
     {
-        $this->expectException(InvalidOptionException::class);
-        $this->expectExceptionMessage('The "alphaQ" option must be an int between 0 and 100');
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "alphaQ" with value 101 is invalid.');
 
         $this->getProcessArguments(['alphaQ' => 101]);
     }
 
     public function testMOptionThrowsOnOutOfScopeInt(): void
     {
-        $this->expectException(InvalidOptionException::class);
-        $this->expectExceptionMessage('The "m" option must be an int between 0 and 6');
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "m" with value 7 is invalid.');
 
         $this->getProcessArguments(['m' => 7]);
     }
 
     public function testAlphaFilterOptionThrowsOnOutOfScopeInt(): void
     {
-        $this->expectException(InvalidOptionException::class);
-        $this->expectExceptionMessage('The "alphaFilter" option must be a string (none, fast or best)');
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "alphaFilter" with value "dummy" is invalid.');
 
         $this->getProcessArguments(['alphaFilter' => 'dummy']);
     }
 
     public function testAlphaMethodOptionThrowsOnOutOfScopeInt(): void
     {
-        $this->expectException(InvalidOptionException::class);
-        $this->expectExceptionMessage('The "alphaMethod" option must be an int between 0 and 1');
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "alphaMethod" with value 7 is invalid.');
 
         $this->getProcessArguments(['alphaMethod' => 7]);
     }
 
     public function testMetadataOptionThrowsOnOutOfScopeInt(): void
     {
-        $this->expectException(InvalidOptionException::class);
-        $this->expectExceptionMessage('The "metadata" option must be an array of string (all, none, exif, icc, xmp)');
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "metadata" with value array is invalid.');
 
         $this->getProcessArguments(['metadata' => ['dummy']]);
     }

--- a/Tests/Imagine/Filter/PostProcessor/CwebpPostProcessorTest.php
+++ b/Tests/Imagine/Filter/PostProcessor/CwebpPostProcessorTest.php
@@ -66,9 +66,9 @@ class CwebpPostProcessorTest extends AbstractPostProcessorTestCase
     public function testMetadataOptionThrowsOnOutOfScopeInt(): void
     {
         $this->expectException(InvalidOptionException::class);
-        $this->expectExceptionMessage('The "metadata" option must be a list of string (all, none, exif, icc, xmp)');
+        $this->expectExceptionMessage('The "metadata" option must be an array of string (all, none, exif, icc, xmp)');
 
-        $this->getProcessArguments(['metadata' => 'dummy']);
+        $this->getProcessArguments(['metadata' => ['dummy']]);
     }
 
     public static function provideProcessArgumentsData(): array
@@ -81,7 +81,7 @@ class CwebpPostProcessorTest extends AbstractPostProcessorTestCase
             [['alphaFilter' => 'best'], ['-alpha_filter', 'best']],
             [['alphaMethod' => 0], ['-alpha_method', 0]],
             [['exact' => true], ['-exact']],
-            [['metadata' => 'all'], ['-metadata', 'all']],
+            [['metadata' => ['exif', 'icc']], ['-metadata', 'exif,icc']],
         ];
 
         return array_map(static function (array $d) {
@@ -110,7 +110,7 @@ class CwebpPostProcessorTest extends AbstractPostProcessorTestCase
             [['alphaFilter' => 'best'], '-alpha_filter best'],
             [['alphaMethod' => 0], '-alpha_method 0'],
             [['exact' => true], '-exact'],
-            [['metadata' => 'all'], '-metadata all'],
+            [['metadata' => ['all']], '-metadata all'],
         ];
 
         return array_map(static function ($d) use ($file) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Doc | <!--new features must be documented. it is ok to first submit a draft for review and document once the general idea is accepted-->

Add a new `cwebp` post-processor for filters. It use [`cwebp`](https://developers.google.com/speed/webp/docs/cwebp) to optimize the input `webp` file.

Available options are: 
* q
  * Specify the compression factor for RGB channels between **0** and **100**. The default is **75**.
  * In case of lossy compression , a small factor produces a smaller file with lower quality. Best quality is achieved by using a value of **100**.
  * In case of lossless compression (specified by the **-lossless** option), a small factor enables faster compression speed, but produces a larger file. Maximum compression is achieved by using a value of **100**.
* alphaQ
  * Specify the compression factor for alpha compression between **0** and **100**. Lossless compression of alpha is achieved using a value of **100**, while the lower values result in a lossy compression.
* m
  * Specify the compression method to use. This parameter controls the trade off between encoding speed and the compressed file size and quality. Possible values range from **0** to **6**. When higher values are used, the encoder will spend more time inspecting additional encoding possibilities and decide on the quality gain. Lower value can result in faster processing time at the expense of larger file size and lower compression quality.
* alphaFilter
  * Specify the predictive filtering method for the alpha plane. One of **none**, **fast** or **best**, in increasing complexity and slowness order. Internally, alpha filtering is performed using four possible predictions (none, horizontal, vertical, gradient). The **best** mode will try each mode in turn and pick the one which gives the smaller size. The **fast** mode will just try to form an a priori guess without testing all modes.
* alphaMethod
  * Specify the algorithm used for alpha compression: **0** or **1**. Algorithm **0** denotes no compression, **1** uses WebP lossless format for compression.
* exact
  * Preserve RGB values in transparent area. The default is off, to help compressibility.
* metadata
  * A comma separated list of metadata to copy from the input to the output if present. Valid values: **all**, **none**, **exif**, **icc**, **xmp**.
  * Note that each input format may not support all combinations.
