### PR TITLE
Fix Symfony 6.1 deprecations

### DIFF
--- a/Command/RemoveCacheCommand.php
+++ b/Command/RemoveCacheCommand.php
@@ -24,8 +24,6 @@ class RemoveCacheCommand extends Command
 {
     use CacheCommandTrait;
 
-    protected static $defaultName = 'liip:imagine:cache:remove';
-
     /**
      * @var FilterService
      */
@@ -43,6 +41,7 @@ class RemoveCacheCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('liip:imagine:cache:remove')
             ->setDescription('Remove cache entries for given paths and filters.')
             ->addArgument('paths', InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
                 'Image file path(s) to run resolution on.')

--- a/Command/ResolveCacheCommand.php
+++ b/Command/ResolveCacheCommand.php
@@ -24,8 +24,6 @@ class ResolveCacheCommand extends Command
 {
     use CacheCommandTrait;
 
-    protected static $defaultName = 'liip:imagine:cache:resolve';
-
     /**
      * @var FilterService
      */
@@ -43,6 +41,7 @@ class ResolveCacheCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('liip:imagine:cache:resolve')
             ->setDescription('Warms up the cache for the specified image sources with all or specified filters applied, and prints the list of cache files.')
             ->addArgument('paths', InputArgument::REQUIRED | InputArgument::IS_ARRAY,
                 'Image file path(s) for which to generate the cached images.')


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | no
| BC breaks? |no
| Deprecations? | yes
| License | MIT
| Doc | <!--new features must be documented. it is ok to first submit a draft for review and document once the general idea is accepted-->

Since Symfony 6.1 setting the $defaultName is deprecated. Prefer to use "AsCommand" attribute, but that not supported yet in PHP ^7.1, so I moved it to the "setName" method.

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->
