### PR TITLE
chore: upgrade imagine/imagine to prevent fatal error when using PHP 8.1 & opcache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.1|^8.0",
         "ext-mbstring": "*",
-        "imagine/imagine": "^1.2.4",
+        "imagine/imagine": "^1.3.2",
         "symfony/filesystem": "^3.4|^4.4|^5.3|^6.0",
         "symfony/finder": "^3.4|^4.4|^5.3|^6.0",
         "symfony/framework-bundle": "^3.4.23|^4.4|^5.3|^6.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

When using PHP 8.1 & OPcache preload, I was getting an error:

`preprod-php-1  | <b>Fatal error</b>:  During inheritance of ArrayAccess: Uncaught ErrorException: Return type of Imagine\Image\Metadata\MetadataBag::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /srv/app/vendor/imagine/imagine/src/Image/Metadata/MetadataBag.php:70
preprod-php-1  | Stack trace:
preprod-php-1  | #0 /srv/app/vendor/imagine/imagine/src/Image/Metadata/MetadataBag.php(17): Symfony\Component\DependencyInjection\Dumper\Preloader::Symfony\Component\DependencyInjection\Dumper\{closure}(8192, 'Return type of ...', '/srv/app/vendor...', 70)
preprod-php-1  | #1 /srv/app/vendor/composer/ClassLoader.php(571): include('/srv/app/vendor...')
preprod-php-1  | #2 /srv/app/vendor/composer/ClassLoader.php(428): Composer\Autoload\includeFile('/srv/app/vendor...')
preprod-php-1  | #3 [internal function]: Composer\Autoload\ClassLoader-&gt;loadClass('Imagine\\Image\\M...')
preprod-php-1  | #4 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(80): class_exists('Imagine\\Image\\M...')
preprod-php-1  | #5 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(127): Symfony\Component\DependencyInjection\Dumper\Preloader::doPreload('Imagine\\Image\\M...', Array)
preprod-php-1  | #6 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(109): Symfony\Component\DependencyInjection\Dumper\Preloader::preloadType(Object(ReflectionNamedType), Array)
preprod-php-1  | #7 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(127): Symfony\Component\DependencyInjection\Dumper\Preloader::doPreload('Imagine\\Factory...', Array)
preprod-php-1  | #8 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(109): Symfony\Component\DependencyInjection\Dumper\Preloader::preloadType(Object(ReflectionNamedType), Array)
preprod-php-1  | #9 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(127): Symfony\Component\DependencyInjection\Dumper\Preloader::doPreload('Imagine\\Image\\I...', Array)
preprod-php-1  | #10 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(109): Symfony\Component\DependencyInjection\Dumper\Preloader::preloadType(Object(ReflectionNamedType), Array)
preprod-php-1  | #11 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(127): Symfony\Component\DependencyInjection\Dumper\Preloader::doPreload('Liip\\ImagineBun...', Array)
preprod-php-1  | #12 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(109): Symfony\Component\DependencyInjection\Dumper\Preloader::preloadType(Object(ReflectionNamedType), Array)
preprod-php-1  | #13 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(127): Symfony\Component\DependencyInjection\Dumper\Preloader::doPreload('Liip\\ImagineBun...', Array)
preprod-php-1  | #14 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(109): Symfony\Component\DependencyInjection\Dumper\Preloader::preloadType(Object(ReflectionNamedType), Array)
preprod-php-1  | #15 /srv/app/vendor/symfony/dependency-injection/Dumper/Preloader.php(59): Symfony\Component\DependencyInjection\Dumper\Preloader::doPreload('Liip\\ImagineBun...', Array)
preprod-php-1  | #16 /srv/app/var/cache/prod/App_KernelProdContainer.preload.php(1418): Symfony\Component\DependencyInjection\Dumper\Preloader::preload(Array)
preprod-php-1  | #17 /srv/app/config/preload.php(4): require('/srv/app/var/ca...')
preprod-php-1  | #18 {main} in <b>/srv/app/vendor/imagine/imagine/src/Image/Metadata/MetadataBag.php</b> on line <b>17</b><br />`

LiipImagine is the only library I use which requires `imagine/imagine` dependency. [v1.3.0](https://github.com/php-imagine/Imagine/releases/tag/1.3.0) fixes this issue.