### PR TITLE
Clarify background transparency option values

### DIFF
--- a/Resources/doc/filters/general.rst
+++ b/Resources/doc/filters/general.rst
@@ -62,7 +62,7 @@ Background Options
     ``bottom``, and ``bottomright``.
 
 **transparency:** ``integer``
-    Sets the background alpha value. The value should be within a range of 0 - 100.
+    Sets the background alpha value. The value should be within a range of 0 (opaque) - 100 (fully transparent).
 
 
 .. _filter-grayscale:


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| License | MIT
| Doc | ok

Doc improvement : I was wondering which value I should choose for a 3/4 transparent background. Hope I got it right, by reading the Imagine documentation.