### PR TITLE
change "directory" to "location"

### DIFF
--- a/Resources/doc/data-loader/flysystem.rst
+++ b/Resources/doc/data-loader/flysystem.rst
@@ -46,7 +46,7 @@ Using `OneupFlysystemBundle`_, a basic configuration might look as follows:
         adapters:
             profile_photos:
                 local:
-                    directory:  "path/to/profile/photos"
+                    location:  "path/to/profile/photos"
 
         filesystems:
             profile_photos:


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes (bug in documentation)
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| License | MIT
| Doc | doc fix

Trying to follow this doc, i have error `Unrecognized option "directory" under "oneup_flysystem.adapters.profile_photos.local". Available options are "lazy", "linkHandling", "location", "mimeTypeDetector", "permissions", "writeFlags".`

Replaced "directory" by "location".
