### PR TITLE
Add return types to silence Symfony 6.3 deprecations

### DIFF
--- a/DependencyInjection/Compiler/AssetsVersionCompilerPass.php
+++ b/DependencyInjection/Compiler/AssetsVersionCompilerPass.php
@@ -29,7 +29,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class AssetsVersionCompilerPass extends AbstractCompilerPass
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!class_exists(StaticVersionStrategy::class)
             // this application has no asset version configured

--- a/DependencyInjection/Compiler/DriverCompilerPass.php
+++ b/DependencyInjection/Compiler/DriverCompilerPass.php
@@ -21,10 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class DriverCompilerPass extends AbstractCompilerPass
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $liipImagineDriver = $container->getParameter('liip_imagine.driver_service');
 

--- a/DependencyInjection/Compiler/FiltersCompilerPass.php
+++ b/DependencyInjection/Compiler/FiltersCompilerPass.php
@@ -16,10 +16,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class FiltersCompilerPass extends AbstractCompilerPass
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $tags = $container->findTaggedServiceIds('liip_imagine.filter.loader');
 

--- a/DependencyInjection/Compiler/LoadersCompilerPass.php
+++ b/DependencyInjection/Compiler/LoadersCompilerPass.php
@@ -16,10 +16,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class LoadersCompilerPass extends AbstractCompilerPass
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $tags = $container->findTaggedServiceIds('liip_imagine.binary.loader');
 

--- a/DependencyInjection/Compiler/MaybeSetMimeServicesAsAliasesCompilerPass.php
+++ b/DependencyInjection/Compiler/MaybeSetMimeServicesAsAliasesCompilerPass.php
@@ -23,9 +23,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 final class MaybeSetMimeServicesAsAliasesCompilerPass extends AbstractCompilerPass
 {
-    /**
-     * {@inheritdoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         if ($container->hasDefinition('mime_types')) {

--- a/DependencyInjection/Compiler/MetadataReaderCompilerPass.php
+++ b/DependencyInjection/Compiler/MetadataReaderCompilerPass.php
@@ -34,9 +34,6 @@ class MetadataReaderCompilerPass extends AbstractCompilerPass
      */
     private static $metadataReaderExifClass = 'Imagine\Image\Metadata\ExifMetadataReader';
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         if (!$this->isExifExtensionLoaded() && $this->isExifMetadataReaderSet($container)) {

--- a/DependencyInjection/Compiler/NonFunctionalFilterExceptionPass.php
+++ b/DependencyInjection/Compiler/NonFunctionalFilterExceptionPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class NonFunctionalFilterExceptionPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $canFiltersStillFunction = $container->hasParameter('kernel.root_dir');
         $throwWarning = function (string $filterName) use ($canFiltersStillFunction) {

--- a/DependencyInjection/Compiler/PostProcessorsCompilerPass.php
+++ b/DependencyInjection/Compiler/PostProcessorsCompilerPass.php
@@ -21,10 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class PostProcessorsCompilerPass extends AbstractCompilerPass
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $tags = $container->findTaggedServiceIds('liip_imagine.filter.post_processor');
 

--- a/DependencyInjection/Compiler/ResolversCompilerPass.php
+++ b/DependencyInjection/Compiler/ResolversCompilerPass.php
@@ -16,10 +16,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class ResolversCompilerPass extends AbstractCompilerPass
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $tags = $container->findTaggedServiceIds('liip_imagine.cache.resolver');
 

--- a/DependencyInjection/LiipImagineExtension.php
+++ b/DependencyInjection/LiipImagineExtension.php
@@ -61,7 +61,7 @@ class LiipImagineExtension extends Extension implements PrependExtensionInterfac
     /**
      * @see \Symfony\Component\DependencyInjection\Extension.ExtensionInterface::load()
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration(
             $this->getConfiguration($configs, $container),

--- a/LiipImagineBundle.php
+++ b/LiipImagineBundle.php
@@ -36,10 +36,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class LiipImagineBundle extends Bundle
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | N/A
| License | MIT
| Doc | N/A

Symfony 6.3 added a number of return types to the framework. This PR should cover all the ones that popped up when beta testing an application.

Because all affected classes are non-final/internal, doc block annotations are used.