### PR TITLE
Add support for JsonManifestVersionStrategy

### DIFF
--- a/DependencyInjection/Compiler/AssetsVersionCompilerPass.php
+++ b/DependencyInjection/Compiler/AssetsVersionCompilerPass.php
@@ -56,7 +56,6 @@ class AssetsVersionCompilerPass extends AbstractCompilerPass
         }
         $version = $versionStrategyDefinition->getArgument(0);
         $format = $versionStrategyDefinition->getArgument(1);
-
         $format = $container->resolveEnvPlaceholders($format);
         if ($format && !$this->str_ends_with($format, '?%%s')) {
             $this->log($container, 'Can not handle assets versioning with custom format "'.$format.'". asset twig function can likely not be used with the imagine_filter');
@@ -67,15 +66,15 @@ class AssetsVersionCompilerPass extends AbstractCompilerPass
         $runtimeDefinition->setArgument(1, $version);
 
         if (is_a($versionStrategyDefinition->getClass(), JsonManifestVersionStrategy::class, true)) {
-            $jsonManifest = file_get_contents($version);
+            $jsonManifestString = file_get_contents($version);
 
-            if (!is_string($jsonManifest)) {
+            if (!\is_string($jsonManifestString)) {
                 $this->log($container, 'Can not handle assets versioning with "'.$versionStrategyDefinition->getClass().'". The manifest file at "'.$version.' " could not be read');
 
                 return;
             }
-            $jsonManifest = \json_decode($jsonManifest, true);
-            if (!is_array($jsonManifest)) {
+            $jsonManifest = json_decode($jsonManifestString, true);
+            if (!\is_array($jsonManifest)) {
                 $this->log($container, 'Can not handle assets versioning with "'.$versionStrategyDefinition->getClass().'". The manifest file at "'.$version.' " does not contain valid JSON');
 
                 return;

--- a/DependencyInjection/Compiler/AssetsVersionCompilerPass.php
+++ b/DependencyInjection/Compiler/AssetsVersionCompilerPass.php
@@ -34,7 +34,7 @@ class AssetsVersionCompilerPass extends AbstractCompilerPass
 {
     public function process(ContainerBuilder $container): void
     {
-        if (!class_exists(StaticVersionStrategy::class) || !class_exists(JsonManifestVersionStrategy::class)
+        if (!class_exists(StaticVersionStrategy::class)
             // this application has no asset version configured
             || !$container->has('assets._version__default')
             // we are not using the new LazyFilterRuntime

--- a/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
+++ b/Imagine/Cache/Resolver/AbstractFilesystemResolver.php
@@ -52,9 +52,6 @@ abstract class AbstractFilesystemResolver implements ResolverInterface, CacheMan
         $this->filesystem = $filesystem;
     }
 
-    /**
-     * @param Request $request
-     */
     public function setRequest(Request $request = null)
     {
         $this->request = $request;

--- a/Imagine/Cache/Resolver/CacheResolver.php
+++ b/Imagine/Cache/Resolver/CacheResolver.php
@@ -43,8 +43,6 @@ class CacheResolver implements ResolverInterface
      *   A "local" prefix for this wrapper. This is useful when re-using the same resolver for multiple filters.
      * * index_key
      *   The name of the index key being used to save a list of created cache keys regarding one image and filter pairing.
-     *
-     * @param OptionsResolver $optionsResolver
      */
     public function __construct(Cache $cache, ResolverInterface $cacheResolver, array $options = [], OptionsResolver $optionsResolver = null)
     {

--- a/Imagine/Cache/Resolver/PsrCacheResolver.php
+++ b/Imagine/Cache/Resolver/PsrCacheResolver.php
@@ -55,8 +55,6 @@ final class PsrCacheResolver implements ResolverInterface
      *   A "local" prefix for this wrapper. This is useful when re-using the same resolver for multiple filters.
      * * index_key
      *   The name of the index key being used to save a list of created cache keys regarding one image and filter pairing.
-     *
-     * @param OptionsResolver $optionsResolver
      */
     public function __construct(CacheItemPoolInterface $cache, ResolverInterface $cacheResolver, array $options = [], OptionsResolver $optionsResolver = null)
     {

--- a/Imagine/Cache/SignerInterface.php
+++ b/Imagine/Cache/SignerInterface.php
@@ -17,7 +17,6 @@ interface SignerInterface
      * Return the hash for path and runtime config.
      *
      * @param string $path
-     * @param array  $runtimeConfig
      *
      * @return string
      */
@@ -28,7 +27,6 @@ interface SignerInterface
      *
      * @param string $hash
      * @param string $path
-     * @param array  $runtimeConfig
      *
      * @return bool
      */

--- a/Resources/config/imagine_twig_mode_lazy.xml
+++ b/Resources/config/imagine_twig_mode_lazy.xml
@@ -14,6 +14,7 @@
             <tag name="twig.runtime" />
             <argument type="service" id="liip_imagine.cache.manager" />
             <argument>null</argument>
+            <argument>null</argument>
         </service>
 
     </services>

--- a/Templating/LazyFilterRuntime.php
+++ b/Templating/LazyFilterRuntime.php
@@ -109,7 +109,10 @@ final class LazyFilterRuntime implements RuntimeExtensionInterface
         }
 
         if (\array_key_exists($path, $this->jsonManifest)) {
-            $resolvedPath = str_replace($path, $this->jsonManifest[$path], $resolvedPath);
+            $prefixedSlash = '/' !== mb_substr($path, 0, 1) && '/' === mb_substr($this->jsonManifest[$path], 0, 1);
+            $versionedPath = $prefixedSlash ? mb_substr($this->jsonManifest[$path], 1) : $this->jsonManifest[$path];
+
+            $resolvedPath = str_replace($path, $versionedPath, $resolvedPath);
         }
 
         return $resolvedPath;

--- a/Templating/LazyFilterRuntime.php
+++ b/Templating/LazyFilterRuntime.php
@@ -100,7 +100,7 @@ final class LazyFilterRuntime implements RuntimeExtensionInterface
 
             return $resolvedPath.$separator.$this->assetVersion;
         } elseif ($this->jsonManifest) {
-            $manifestVersion = array_key_exists($path, $this->jsonManifest) ? $this->jsonManifest[$path] : null;
+            $manifestVersion = \array_key_exists($path, $this->jsonManifest) ? $this->jsonManifest[$path] : null;
             if ($manifestVersion) {
                 $resolvedPath = str_replace($path, $manifestVersion, $resolvedPath);
             }

--- a/Templating/LazyFilterRuntime.php
+++ b/Templating/LazyFilterRuntime.php
@@ -102,11 +102,7 @@ final class LazyFilterRuntime implements RuntimeExtensionInterface
         } elseif ($this->jsonManifest) {
             $manifestVersion = array_key_exists($path, $this->jsonManifest) ? $this->jsonManifest[$path] : null;
             if ($manifestVersion) {
-                $resolvedPath = str_replace($path, $resolvedPath, $manifestVersion);
-
-                if (str_starts_with($manifestVersion, '/') && !str_starts_with($resolvedPath, '/')) {
-                    $resolvedPath = '/' . $resolvedPath;
-                }
+                $resolvedPath = str_replace($path, $manifestVersion, $resolvedPath);
             }
         }
 

--- a/Tests/Templating/LazyFilterRuntimeTest.php
+++ b/Tests/Templating/LazyFilterRuntimeTest.php
@@ -15,6 +15,7 @@ use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Templating\LazyFilterRuntime;
 use Liip\ImagineBundle\Tests\AbstractTest;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @covers \Liip\ImagineBundle\Templating\LazyFilterRuntime
@@ -109,8 +110,8 @@ class LazyFilterRuntimeTest extends AbstractTest
         $sourcePath = array_keys(self::JSON_MANIFEST)[0];
         $versionedPath = array_values(self::JSON_MANIFEST)[0];
 
-        $cachePath = str_replace('image/', 'image/cache/' . self::FILTER . '/', $sourcePath);
-        $expectedPath = str_replace('image/', 'image/cache/' . self::FILTER . '/', $versionedPath);
+        $cachePath = 'image/cache/' . self::FILTER . '/' . $sourcePath;
+        $expectedPath = 'image/cache/' . self::FILTER . '/' . $versionedPath;
 
         $this->manager
             ->expects($this->once())
@@ -118,7 +119,9 @@ class LazyFilterRuntimeTest extends AbstractTest
             ->with($sourcePath, self::FILTER)
             ->willReturn($cachePath);
 
-        $this->assertSame($expectedPath, $this->runtime->filter($versionedPath, self::FILTER));
+        $actualPath = $this->runtime->filter($versionedPath, self::FILTER);
+
+        $this->assertSame($expectedPath, $actualPath);
     }
 
     public function testInvokeFilterCacheMethod(): void

--- a/Tests/Templating/LazyFilterRuntimeTest.php
+++ b/Tests/Templating/LazyFilterRuntimeTest.php
@@ -23,6 +23,7 @@ class LazyFilterRuntimeTest extends AbstractTest
 {
     private const FILTER = 'thumbnail';
     private const VERSION = 'v2';
+    private const JSON_MANIFEST = ['image/cats.png' => '/image/cats.png?v2'];
 
     /**
      * @var LazyFilterRuntime
@@ -99,6 +100,25 @@ class LazyFilterRuntimeTest extends AbstractTest
         $actualPath = $this->runtime->filter($sourcePath, self::FILTER);
 
         $this->assertSame($cachePath.'?'.self::VERSION, $actualPath);
+    }
+
+    public function testJsonManifestVersionHandling(): void
+    {
+        $this->runtime = new LazyFilterRuntime($this->manager, null, self::JSON_MANIFEST);
+
+        $sourcePath = array_keys(self::JSON_MANIFEST)[0];
+        $versionedPath = array_values(self::JSON_MANIFEST)[0];
+
+        $cachePath = str_replace('image/', 'image/cache/' . self::FILTER . '/', $sourcePath);
+        $expectedPath = str_replace('image/', 'image/cache/' . self::FILTER . '/', $versionedPath);
+
+        $this->manager
+            ->expects($this->once())
+            ->method('getBrowserPath')
+            ->with($sourcePath, self::FILTER)
+            ->willReturn($cachePath);
+
+        $this->assertSame($expectedPath, $this->runtime->filter($versionedPath, self::FILTER));
     }
 
     public function testInvokeFilterCacheMethod(): void

--- a/Tests/Templating/LazyFilterRuntimeTest.php
+++ b/Tests/Templating/LazyFilterRuntimeTest.php
@@ -15,7 +15,6 @@ use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Templating\LazyFilterRuntime;
 use Liip\ImagineBundle\Tests\AbstractTest;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @covers \Liip\ImagineBundle\Templating\LazyFilterRuntime
@@ -110,8 +109,8 @@ class LazyFilterRuntimeTest extends AbstractTest
         $sourcePath = array_keys(self::JSON_MANIFEST)[0];
         $versionedPath = array_values(self::JSON_MANIFEST)[0];
 
-        $cachePath = 'image/cache/' . self::FILTER . '/' . $sourcePath;
-        $expectedPath = 'image/cache/' . self::FILTER . '/' . $versionedPath;
+        $cachePath = 'image/cache/'.self::FILTER.'/'.$sourcePath;
+        $expectedPath = 'image/cache/'.self::FILTER.'/'.$versionedPath;
 
         $this->manager
             ->expects($this->once())

--- a/Tests/Templating/LazyFilterRuntimeTest.php
+++ b/Tests/Templating/LazyFilterRuntimeTest.php
@@ -23,7 +23,12 @@ class LazyFilterRuntimeTest extends AbstractTest
 {
     private const FILTER = 'thumbnail';
     private const VERSION = 'v2';
-    private const JSON_MANIFEST = ['image/cats.png' => '/image/cats.png?v2'];
+    private const JSON_MANIFEST = [
+        'image/cats.png' => '/image/cats.png?v=bc321bd12a',
+        'image/dogs.png' => '/image/dogs.ac38d2a1bc.png',
+        '/image/cows.png' => '/image/cows.png?v=a5de32a2c4',
+        '/image/sheep.png' => '/image/sheep.7ca26b36af.png',
+    ];
 
     /**
      * @var LazyFilterRuntime
@@ -102,15 +107,15 @@ class LazyFilterRuntimeTest extends AbstractTest
         $this->assertSame($cachePath.'?'.self::VERSION, $actualPath);
     }
 
-    public function testJsonManifestVersionHandling(): void
+    /**
+     * @dataProvider provideJsonManifest
+     */
+    public function testJsonManifestVersionHandling(string $sourcePath, string $versionedPath): void
     {
         $this->runtime = new LazyFilterRuntime($this->manager, null, self::JSON_MANIFEST);
 
-        $sourcePath = array_keys(self::JSON_MANIFEST)[0];
-        $versionedPath = array_values(self::JSON_MANIFEST)[0];
-
-        $cachePath = 'image/cache/'.self::FILTER.'/'.$sourcePath;
-        $expectedPath = 'image/cache/'.self::FILTER.'/'.$versionedPath;
+        $cachePath = 'image/cache/'.self::FILTER.'/'.('/' === (mb_substr($sourcePath, 0, 1)) ? mb_substr($sourcePath, 1) : $sourcePath);
+        $expectedPath = 'image/cache/'.self::FILTER.'/'.('/' === (mb_substr($versionedPath, 0, 1)) ? mb_substr($versionedPath, 1) : $versionedPath);
 
         $this->manager
             ->expects($this->once())
@@ -121,6 +126,16 @@ class LazyFilterRuntimeTest extends AbstractTest
         $actualPath = $this->runtime->filter($versionedPath, self::FILTER);
 
         $this->assertSame($expectedPath, $actualPath);
+    }
+
+    public function provideJsonManifest(): array
+    {
+        return [
+            'query parameter, no slash' => [array_keys(self::JSON_MANIFEST)[0], array_values(self::JSON_MANIFEST)[0]],
+            'in filename, no slash' => [array_keys(self::JSON_MANIFEST)[1], array_values(self::JSON_MANIFEST)[1]],
+            'query parameter, slash' => [array_keys(self::JSON_MANIFEST)[2], array_values(self::JSON_MANIFEST)[2]],
+            'in filename, slash' => [array_keys(self::JSON_MANIFEST)[3], array_values(self::JSON_MANIFEST)[3]],
+        ];
     }
 
     public function testInvokeFilterCacheMethod(): void

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
     },
     "suggest": {
         "ext-exif": "required to read EXIF metadata from images",
+        "ext-json": "required to read JSON manifest versioning",
         "ext-gd": "required to use gd driver",
         "ext-gmagick": "required to use gmagick driver",
         "ext-imagick": "required to use imagick driver",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #1524
| License | MIT
| Doc | 

This PR adds in support for JsonManifestVersionStrategy that is available in Symfony. 
In a JSON manifest, we have a key => value structure where the key is the original filepath, and the value the versioned filestring, e.g:
```
{
  "build/images/cats.jpg": "/build/images/cats.jpg?v=dda78c62c1f2a8793334"
  "build/images/dogs.jpg": "/build/images/dogs.e6fbd6606990f549c912.jpg"
}
```


Similar to `StaticVersionStrategy` that loads it's configuration from the container, this reads the JSON Manifest file defined 

```

framework:
    assets:
        json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'
        
```

The LazyFilterRuntime has been extended to load the JSON Manifest file contents, and the various methods within to handle both Static & Json versioning.

Note that the current 2.x branch has unrelated failing CI.

I don't think this PR breaks current implementations although test coverage for AssetsVersionCompilerPass currently is lacking.

