### PR TITLE
Add aliases for manager services for improved autowiring support

### DIFF
--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -125,6 +125,7 @@
             <argument type="service" id="liip_imagine" />
             <argument type="service" id="liip_imagine.binary.mime_type_guesser" />
         </service>
+        <service id="Liip\ImagineBundle\Imagine\Filter\FilterManager" alias="liip_imagine.filter.manager"/>
 
         <service id="liip_imagine.data.manager" class="Liip\ImagineBundle\Imagine\Data\DataManager" public="true">
             <argument type="service" id="liip_imagine.binary.mime_type_guesser" />
@@ -133,6 +134,7 @@
             <argument>%liip_imagine.binary.loader.default%</argument>
             <argument>%liip_imagine.default_image%</argument>
         </service>
+        <service id="Liip\ImagineBundle\Imagine\Data\DataManager" alias="liip_imagine.data.manager"/>
 
         <service id="liip_imagine.cache.manager" class="Liip\ImagineBundle\Imagine\Cache\CacheManager" public="true">
             <argument type="service" id="liip_imagine.filter.configuration" />
@@ -142,6 +144,7 @@
             <argument>%liip_imagine.cache.resolver.default%</argument>
             <argument>%liip_imagine.webp.generate%</argument>
         </service>
+        <service id="Liip\ImagineBundle\Imagine\Cache\CacheManager" alias="liip_imagine.cache.manager"/>
 
         <service id="liip_imagine.filter.configuration" class="Liip\ImagineBundle\Imagine\Filter\FilterConfiguration">
             <argument>%liip_imagine.filter_sets%</argument>


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | N/A
| License | MIT
| Doc | N/A

The `liip_imagine.cache.manager`, `liip_imagine.data.manager`, and `liip_imagine.filter.manager` services cannot be autowired at present, requiring folks to either manually create aliases in their app's configuration or to use one of the newer dependency injection attributes to specify the right service in their classes.  This PR adds the appropriate service aliases to support autowiring and remove that little bit of extra overhead needed to use these three services.