### PR TITLE
Fix PHP str_replace call with parameter #3 is null deprecation

### DIFF
--- a/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
@@ -92,7 +92,7 @@ class AwsS3ResolverFactory extends AbstractResolverFactory
                     ->cannotBeEmpty()
                 ->end()
                 ->scalarNode('cache_prefix')
-                    ->defaultValue(null)
+                    ->defaultValue('')
                 ->end()
                 ->arrayNode('client_config')
                     ->isRequired()

--- a/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/FlysystemResolverFactory.php
@@ -49,7 +49,7 @@ class FlysystemResolverFactory extends AbstractResolverFactory
                     ->cannotBeEmpty()
                 ->end()
                 ->scalarNode('cache_prefix')
-                    ->defaultValue(null)
+                    ->defaultValue('')
                 ->end()
                 ->scalarNode('root_url')
                     ->isRequired()

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -431,7 +431,7 @@ class AwsS3ResolverFactoryTest extends AbstractTest
         $this->assertSame([], $config['get_options']);
 
         $this->assertArrayHasKey('cache_prefix', $config);
-        $this->assertNull($config['cache_prefix']);
+        $this->assertSame('', $config['cache_prefix']);
     }
 
     public function testSupportAwsV3ClientConfig(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? |no
| BC breaks? |no
| Deprecations? |no
| License | MIT

When the cache_prefix is not set for the flysystem resolver, it results in
```
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
```
in the  `FlysystemV2Resolver` while fixing I saw the same should happen for the `AwsS3Resolver`.

There are multiple ways to fix this easily. I decided to do it very early by changing the default value of the configuration property, because null also already violated the doctype string of the parameter in the resolvers.