### PR TITLE
[Doc] Misc fixes in some doc pages

### DIFF
--- a/Resources/doc/cache-resolver/aws_s3.rst
+++ b/Resources/doc/cache-resolver/aws_s3.rst
@@ -307,7 +307,7 @@ You can also use the constructor of the resolver to directly inject multiple opt
             tags:
                 - { name: "liip_imagine.cache.resolver", resolver: "aws_s3_resolver" }
 
-You can find an example with private ACL and signed url on the :doc:`events chapter <../events.rst>`.
+You can find an example with private ACL and signed url on the :doc:`events chapter </events>`.
 
 .. _`aws-sdk-php`: https://github.com/amazonwebservices/aws-sdk-for-php
 .. _`S3 SDK documentation`: https://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.S3Client.html#_putObject

--- a/Resources/doc/filters/general.rst
+++ b/Resources/doc/filters/general.rst
@@ -197,13 +197,13 @@ Resample Options
 
 **filter:** ``string``
     Sets the optional filter to use during the resampling operation. It must be a string resolvable
-    as a constant from `Imagine\Image\ImageInterface`_ (you may omit the ``FILTER_`` prefix)
+    as a constant from ``Imagine\Image\ImageInterface`` (you may omit the ``FILTER_`` prefix)
     or a valid fully qualified constant. By default it is set to ``FILTER_UNDEFINED``.
 
 **tmp_dir:** ``string``
     Sets the optional temporary work directory. This filter requires a temporary location to save
     out and read back in the image binary, as these operations are requires to resample an image.
-    By default, it is set to the value of the `sys_get_temp_dir()`_ function.
+    By default, it is set to the value of the ``sys_get_temp_dir()`` function.
 
 .. _filter-strip:
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| License | MIT
| Doc | -

Fixes these errors shown when building the docs:

```
Found invalid reference "../events.rst" in file "cache-resolver/aws_s3"
Found invalid reference "Imagine\Image\ImageInterface" in file "filters/general"
Found invalid reference "sys_get_temp_dir()" in file "filters/general"
```