### PR TITLE
Avoid redirects documentation - escape full stop in location regex

### DIFF
--- a/Resources/doc/optimizations/avoid-redirects.rst
+++ b/Resources/doc/optimizations/avoid-redirects.rst
@@ -33,7 +33,7 @@ configure your webserver to route requests for missing images to Symfony.
       try_files $uri $uri/ /index.php?$query_string;
     }
 
-    location ~* .(js|jpg|jpeg|gif|png|css|tgz|gz|rar|bz2|doc|pdf|ppt|tar|wav|bmp|rtf|swf|ico|flv|txt|woff|woff2|svg)$ {
+    location ~* \.(js|jpg|jpeg|gif|png|css|tgz|gz|rar|bz2|doc|pdf|ppt|tar|wav|bmp|rtf|swf|ico|flv|txt|woff|woff2|svg)$ {
         expires 30d;
         add_header Pragma "public";
         add_header Cache-Control "public";


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #1576
| License | MIT
| Doc | <!--new features must be documented. it is ok to first submit a draft for review and document once the general idea is accepted-->

Escapes the `.` character appearing in the suggested regex, as it has the potential of matching routes that end in a file type suffix