### PR TITLE
Fix trying to open non-existant manifest file

### DIFF
--- a/DependencyInjection/Compiler/AssetsVersionCompilerPass.php
+++ b/DependencyInjection/Compiler/AssetsVersionCompilerPass.php
@@ -68,6 +68,11 @@ class AssetsVersionCompilerPass extends AbstractCompilerPass
         $runtimeDefinition->setArgument(1, $version);
 
         if (is_a($versionStrategyDefinition->getClass(), JsonManifestVersionStrategy::class, true)) {
+            if (!file_exists($version)) {
+                $this->log($container, 'The manifest file at "'.$version.'" does not yet exist');
+
+                return;
+            }
             $jsonManifestString = file_get_contents($version);
 
             if (!\is_string($jsonManifestString)) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc | <!--new features must be documented. it is ok to first submit a draft for review and document once the general idea is accepted-->

Hello,

Following #1529, `cache:clear` auto-script in fresh composer install for example is crashing because the manifest.json does not exist yet.

![image](https://github.com/liip/LiipImagineBundle/assets/8030342/aa80a56f-d63e-4dda-a069-caf11fb553b8)

This PR add a check on the existence of the file before trying to open it.
