### PR TITLE
fix(deprecation): remove deprecated spaceless filter

### DIFF
--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -1,19 +1,17 @@
 {% block liip_imagine_image_widget %}
-    {% apply spaceless %}
-        {% if image_path %}
-            <div>
-                {% if link_url %}
-                    <a href="{{ link_filter ? link_url|imagine_filter(link_filter): link_url }}" {% for attrname, attrvalue in link_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}>
-                {% endif %}
+    {% if image_path %}
+        <div>
+            {% if link_url %}
+                <a href="{{ link_filter ? link_url|imagine_filter(link_filter): link_url }}" {% for attrname, attrvalue in link_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}>
+            {% endif %}
 
-                <img src="{{ image_path|imagine_filter(image_filter) }}" {% for attrname, attrvalue in image_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %} />
+            <img src="{{ image_path|imagine_filter(image_filter) }}" {% for attrname, attrvalue in image_attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %} />
 
-                {% if link_url %}
-                    </a>
-                {% endif %}
-            </div>
-        {% endif %}
+            {% if link_url %}
+                </a>
+            {% endif %}
+        </div>
+    {% endif %}
 
-        {{ block('form_widget_simple') }}
-    {% endapply %}
+    {{ block('form_widget_simple') }}
 {% endblock %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x and should also merge to 3.x 
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| License | MIT
| Doc | -

This will remove the deprecated `spaceless` filter from twig see: https://github.com/twigphp/Twig/pull/4236