### PR TITLE
Check if path is a file in FileSystemLoader

### DIFF
--- a/Binary/Loader/FileSystemLoader.php
+++ b/Binary/Loader/FileSystemLoader.php
@@ -12,6 +12,7 @@
 namespace Liip\ImagineBundle\Binary\Loader;
 
 use Liip\ImagineBundle\Binary\Locator\LocatorInterface;
+use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Exception\InvalidArgumentException;
 use Liip\ImagineBundle\Model\FileBinary;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface as DeprecatedExtensionGuesserInterface;
@@ -69,6 +70,11 @@ class FileSystemLoader implements LoaderInterface
     public function find($path)
     {
         $path = $this->locator->locate($path);
+        
+        if (\is_file($path) === false) {
+            throw new NotLoadableException(\sprintf('Source image: "%s" is no file.', $path));
+        }
+        
         $mimeType = $this->mimeTypeGuesser instanceof DeprecatedMimeTypeGuesserInterface ? $this->mimeTypeGuesser->guess($path) : $this->mimeTypeGuesser->guessMimeType($path);
         $extension = $this->getExtension($mimeType);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

If the resolve URL is called without a file like "media/cache/resolve/image_xs/media/image/40/93/" the FileinfoMimeTypeGuesser will fail with a InvalidArgumentException, because the mime type checker will check if the path is a file. https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Mime/FileinfoMimeTypeGuesser.php#L47

So we should check before if it is a file or catch the exception.