### PR TITLE
Support disabled acls on s3 buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ for a given releases. Unreleased, upcoming changes will be updated here periodic
 
 ## Next Release
 
+- Allow configuring empty ACLs on AWS S3 resolver to skip ACLs ([deguif](https://github.com/liip/LiipImagineBundle/pull/1629))
 - Add `use_psr_cache` option to AWS S3 resolver configuration in order to support PSR cache. Configuring a doctrine cache now will trigger a deprecation ([deguif](https://github.com/liip/LiipImagineBundle/pull/1630))
 
 ## [2.13.3](https://github.com/liip/LiipImagineBundle/tree/2.13.3)

--- a/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
@@ -96,7 +96,6 @@ class AwsS3ResolverFactory extends AbstractResolverFactory
                 ->end()
                 ->scalarNode('acl')
                     ->defaultValue('public-read')
-                    ->cannotBeEmpty()
                 ->end()
                 ->scalarNode('cache_prefix')
                     ->defaultValue('')


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x 
| Bug fix? | yes/no
| New feature? | yes
| BC breaks? | no
| Deprecations? | yes/no
| Fixed tickets |
| License | MIT
| Doc |

AWS now recommends to disable ACLs on S3 buckets, this PR is adaptating s3 configuration in order to allow to not send acl when the bucket has ACLs disabled.
In the meantime it's possible to send `bucket-owner-full-control` so that bucket with ACL enabled can later be switched to ACL disabled without issues.

Here's the documentation from AWS : https://docs.aws.amazon.com/AmazonS3/latest/userguide/ensure-object-ownership.html