### PR TITLE
Support PSR cache on s3 resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ for a given releases. Unreleased, upcoming changes will be updated here periodic
 
 # 2.x
 
+## Next Release
+
+- Add `use_psr_cache` option to AWS S3 resolver configuration in order to support PSR cache. Configuring a doctrine cache now will trigger a deprecation ([deguif](https://github.com/liip/LiipImagineBundle/pull/1630))
+
 ## [2.13.3](https://github.com/liip/LiipImagineBundle/tree/2.13.3)
 
 - Prevent InvalidArgumentException from FileinfoMimeTypeGuesser when chain loading an image that is not a file ([revoltek-daniel](https://github.com/liip/LiipImagineBundle/pull/1614))

--- a/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
+++ b/DependencyInjection/Factory/Resolver/AwsS3ResolverFactory.php
@@ -57,7 +57,11 @@ class AwsS3ResolverFactory extends AbstractResolverFactory
 
             $container->setDefinition($cachedResolverId, $container->getDefinition($resolverId));
 
-            $cacheResolverDefinition = $this->getChildResolverDefinition('cache');
+            if (false === $config['use_psr_cache']) {
+                trigger_deprecation('liip/imagine-bundle', '2.13.4', \sprintf('Setting the "liip_imagine.resolvers.%s.%s.use_psr_cache" config option to "false" is deprecated.', $resolverName, $this->getName()));
+            }
+
+            $cacheResolverDefinition = $this->getChildResolverDefinition($config['use_psr_cache'] ? 'psr_cache' : 'cache');
             $cacheResolverDefinition->replaceArgument(0, new Reference($config['cache']));
             $cacheResolverDefinition->replaceArgument(1, new Reference($cachedResolverId));
 
@@ -85,6 +89,9 @@ class AwsS3ResolverFactory extends AbstractResolverFactory
                     ->cannotBeEmpty()
                 ->end()
                 ->scalarNode('cache')
+                    ->defaultFalse()
+                ->end()
+                ->booleanNode('use_psr_cache')
                     ->defaultFalse()
                 ->end()
                 ->scalarNode('acl')

--- a/Resources/doc/cache-resolver/aws_s3.rst
+++ b/Resources/doc/cache-resolver/aws_s3.rst
@@ -204,8 +204,12 @@ current. You just need to configure them with defined options.
               aws_s3:
                   #...
                   proxies: ["https://one.domain.com", "https://two.domain.com"]
-                  cache: true
+                  cache: 'cache_name'
 
+.. note::
+
+    The ``cache`` option accepts a doctrine cache, but this is now deprecated.
+    Use the ``use_psr_cache`` boolean option set to ``true`` so that a psr cache can be used instead.
 
 If enabled both first one will be :ref:`Cache <cache-resolver-cache>`, then
 :ref:`Proxy <cache-resolver-proxy>` and after all process delegates to AwsS3 resolver.

--- a/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
+++ b/Tests/DependencyInjection/Factory/Resolver/AwsS3ResolverFactoryTest.php
@@ -15,6 +15,7 @@ use Aws\S3\S3Client;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\AwsS3ResolverFactory;
 use Liip\ImagineBundle\DependencyInjection\Factory\Resolver\ResolverFactoryInterface;
 use Liip\ImagineBundle\Tests\AbstractTest;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -26,6 +27,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class AwsS3ResolverFactoryTest extends AbstractTest
 {
+    use ExpectDeprecationTrait;
+
     public function testImplementsResolverFactoryInterface(): void
     {
         $rc = new \ReflectionClass(AwsS3ResolverFactory::class);
@@ -155,8 +158,13 @@ class AwsS3ResolverFactoryTest extends AbstractTest
         $this->assertSame(['foo'], $resolverDefinition->getArgument(1));
     }
 
+    /**
+     * @group legacy
+     */
     public function testWrapResolverWithCacheOnCreateWithoutProxy(): void
     {
+        $this->expectDeprecation('Since liip/imagine-bundle 2.13.4: Setting the "liip_imagine.resolvers.the_resolver_name.aws_s3.use_psr_cache" config option to "false" is deprecated.');
+
         $container = new ContainerBuilder();
 
         $resolver = new AwsS3ResolverFactory();
@@ -168,6 +176,7 @@ class AwsS3ResolverFactoryTest extends AbstractTest
             'get_options' => [],
             'put_options' => [],
             'cache' => 'the_cache_service_id',
+            'use_psr_cache' => false,
             'proxies' => [],
         ]);
 
@@ -190,7 +199,7 @@ class AwsS3ResolverFactoryTest extends AbstractTest
         $this->assertSame('liip_imagine.cache.resolver.the_resolver_name.cached', (string) $resolverDefinition->getArgument(1));
     }
 
-    public function testWrapResolverWithProxyAndCacheOnCreate(): void
+    public function testWrapResolverWithPsrCacheOnCreateWithoutProxy(): void
     {
         $container = new ContainerBuilder();
 
@@ -203,6 +212,48 @@ class AwsS3ResolverFactoryTest extends AbstractTest
             'get_options' => [],
             'put_options' => [],
             'cache' => 'the_cache_service_id',
+            'use_psr_cache' => true,
+            'proxies' => [],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.cached'));
+        $cachedResolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name.cached');
+        $this->assertInstanceOf(ChildDefinition::class, $cachedResolverDefinition);
+        $this->assertSame('liip_imagine.cache.resolver.prototype.aws_s3', $cachedResolverDefinition->getParent());
+
+        $this->assertFalse($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name.proxied'));
+
+        $this->assertTrue($container->hasDefinition('liip_imagine.cache.resolver.the_resolver_name'));
+        $resolverDefinition = $container->getDefinition('liip_imagine.cache.resolver.the_resolver_name');
+        $this->assertInstanceOf(ChildDefinition::class, $resolverDefinition);
+        $this->assertSame('liip_imagine.cache.resolver.prototype.psr_cache', $resolverDefinition->getParent());
+
+        $this->assertInstanceOf(Reference::class, $resolverDefinition->getArgument(0));
+        $this->assertSame('the_cache_service_id', (string) $resolverDefinition->getArgument(0));
+
+        $this->assertInstanceOf(Reference::class, $resolverDefinition->getArgument(1));
+        $this->assertSame('liip_imagine.cache.resolver.the_resolver_name.cached', (string) $resolverDefinition->getArgument(1));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testWrapResolverWithProxyAndCacheOnCreate(): void
+    {
+        $this->expectDeprecation('Since liip/imagine-bundle 2.13.4: Setting the "liip_imagine.resolvers.the_resolver_name.aws_s3.use_psr_cache" config option to "false" is deprecated.');
+
+        $container = new ContainerBuilder();
+
+        $resolver = new AwsS3ResolverFactory();
+
+        $resolver->create($container, 'the_resolver_name', [
+            'client_config' => [],
+            'bucket' => 'aBucket',
+            'acl' => 'aAcl',
+            'get_options' => [],
+            'put_options' => [],
+            'cache' => 'the_cache_service_id',
+            'use_psr_cache' => false,
             'proxies' => ['foo'],
         ]);
 
@@ -233,8 +284,13 @@ class AwsS3ResolverFactoryTest extends AbstractTest
         $this->assertSame('liip_imagine.cache.resolver.the_resolver_name.cached', (string) $resolverDefinition->getArgument(1));
     }
 
+    /**
+     * @group legacy
+     */
     public function testWrapResolverWithProxyMatchReplaceStrategyOnCreate(): void
     {
+        $this->expectDeprecation('Since liip/imagine-bundle 2.13.4: Setting the "liip_imagine.resolvers.the_resolver_name.aws_s3.use_psr_cache" config option to "false" is deprecated.');
+
         $container = new ContainerBuilder();
 
         $resolver = new AwsS3ResolverFactory();
@@ -246,6 +302,7 @@ class AwsS3ResolverFactoryTest extends AbstractTest
             'get_options' => [],
             'put_options' => [],
             'cache' => 'the_cache_service_id',
+            'use_psr_cache' => false,
             'proxies' => ['foo' => 'bar'],
         ]);
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php": "^7.2|^8.0",
         "ext-mbstring": "*",
         "imagine/imagine": "^1.3.2",
+        "symfony/deprecation-contracts": "^2.5 || ^3",
         "symfony/filesystem": "^3.4|^4.4|^5.3|^6.0|^7.0",
         "symfony/finder": "^3.4|^4.4|^5.3|^6.0|^7.0",
         "symfony/framework-bundle": "^3.4.23|^4.4|^5.3|^6.0|^7.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | https://github.com/liip/LiipImagineBundle/issues/1623
| License | MIT
| Doc | 

Aws S3 resolver currently only supports setting a doctrine cache adapter which is deprecated on this bundle, this PRs fixes that by supporting the PSR cache adapter.
A new config option `use_psr_cache` was added in order to ensure BC layer. It also emits a deprecation warning when the doctrine cache adapter is used.
