### PR TITLE
Enable autowiring for filter service

### DIFF
--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -158,6 +158,7 @@
             <argument>%liip_imagine.webp.options%</argument>
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
+        <service id="Liip\ImagineBundle\Service\FilterService" alias="liip_imagine.service.filter"/>
 
         <!-- Config -->
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc | <!--new features must be documented. it is ok to first submit a draft for review and document once the general idea is accepted-->

Add an alias on filter service to allow autowiring it.