### PR TITLE
Refactor `Request::get()` usages

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -85,6 +85,7 @@ class ImagineController
     public function filterAction(Request $request, $path, $filter)
     {
         $path = PathHelper::urlPathToFilePath($path);
+        // TODO once we limit `symfony/http-foundation` to 6.4 or newer, use `$request->query->getString()`
         $resolver = $request->query->has('resolver') ? (string) $request->query->get('resolver') : null;
 
         return $this->createRedirectResponse(function () use ($path, $filter, $resolver, $request) {

--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -85,7 +85,7 @@ class ImagineController
     public function filterAction(Request $request, $path, $filter)
     {
         $path = PathHelper::urlPathToFilePath($path);
-        $resolver = $request->get('resolver');
+        $resolver = $request->query->has('resolver') ? (string) $request->query->get('resolver') : null;
 
         return $this->createRedirectResponse(function () use ($path, $filter, $resolver, $request) {
             return $this->filterService->getUrlOfFilteredImage(
@@ -116,7 +116,7 @@ class ImagineController
      */
     public function filterRuntimeAction(Request $request, $hash, $path, $filter)
     {
-        $resolver = $request->get('resolver');
+        $resolver = $request->query->has('resolver') ? (string) $request->query->get('resolver') : null;
         $path = PathHelper::urlPathToFilePath($path);
         $runtimeConfig = $this->getFiltersBc($request);
 

--- a/Tests/Controller/ImagineControllerTest.php
+++ b/Tests/Controller/ImagineControllerTest.php
@@ -90,9 +90,9 @@ class ImagineControllerTest extends AbstractTest
     {
         $this->expectException(InvalidArgumentException::class);
         $this->createControllerInstance(
-            $path = '/foo',
-            $filter = 'filter',
-            $hash = 'hash',
+            '/foo',
+            'filter',
+            'hash',
             $redirectResponseCode,
             false
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x 
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | https://github.com/liip/LiipImagineBundle/issues/1635
| License | MIT
| Doc | <!--new features must be documented. it is ok to first submit a draft for review and document once the general idea is accepted-->

Refactor deprecated `Request::get()` usages.