### PR TITLE
mark asset mapper factory service template abstract like the other services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ for a given releases. Unreleased, upcoming changes will be updated here periodic
 
 # 2.x
 
+## 2.17.1
+
+- Fix for AssetMapperLoaderFactory to not fail when not configured ([dbu](https://github.com/liip/LiipImagineBundle/pull/1649))
+
 ## [2.17.0](https://github.com/liip/LiipImagineBundle/tree/2.17.0)
 
 - Add AssetMapperLocator to work with the asset mapper in development mode ([tito10047](https://github.com/liip/LiipImagineBundle/pull/1645))

--- a/Resources/config/imagine.php
+++ b/Resources/config/imagine.php
@@ -431,12 +431,12 @@ return static function (ContainerConfigurator $container) {
         ])
         ->tag('liip_imagine.binary.locator', ['shared' => false]);
     $services->set('liip_imagine.binary.locator.asset_mapper', AssetMapperLocator::class)
-        ->share(true)
-        ->public()
+        ->abstract()
+        ->private()
         ->args([
             '', // will be injected by AssetMapperLoaderFactory
         ])
-        ->tag('liip_imagine.binary.locator', ['shared' => false]);
+        ->tag('liip_imagine.binary.locator', ['shared' => true]);
 
     $services->set('liip_imagine.binary.locator.filesystem_insecure', FileSystemInsecureLocator::class)
         ->share(false)


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fix #1648
| License | MIT
| Doc | -

As per #1648 service must be abstract.
Also aligning some other settings like defining it private.