### PR TITLE
Fix lazy Twig mode dropping the path for absolute image URLs

### DIFF
--- a/Templating/LazyFilterRuntime.php
+++ b/Templating/LazyFilterRuntime.php
@@ -76,7 +76,8 @@ final class LazyFilterRuntime implements RuntimeExtensionInterface
 
     private function cleanPath(string $path): string
     {
-        // strip absolute URLs (e.g. remote filesystems like S3) to their path, but leave local paths with "?" or "#" untouched
+        // strip absolute URLs (e.g. remote filesystems like S3) to their path
+        // host guard: parse_url(PHP_URL_PATH) would also truncate local names at "?"/"#" and strip the version query string
         if (null !== parse_url($path, PHP_URL_HOST)) {
             $path = parse_url($path, PHP_URL_PATH) ?? $path;
         }

--- a/Templating/LazyFilterRuntime.php
+++ b/Templating/LazyFilterRuntime.php
@@ -76,6 +76,11 @@ final class LazyFilterRuntime implements RuntimeExtensionInterface
 
     private function cleanPath(string $path): string
     {
+        // strip absolute URLs (e.g. remote filesystems like S3) to their path, but leave local paths with "?" or "#" untouched
+        if (null !== parse_url($path, PHP_URL_HOST)) {
+            $path = parse_url($path, PHP_URL_PATH) ?? $path;
+        }
+
         if (!$this->assetVersion && !$this->jsonManifest) {
             return $path;
         }

--- a/Tests/Templating/LazyFilterRuntimeTest.php
+++ b/Tests/Templating/LazyFilterRuntimeTest.php
@@ -48,22 +48,23 @@ class LazyFilterRuntimeTest extends AbstractTest
 
     public function provideImageNames(): iterable
     {
-        yield 'regular' => ['image' => 'cats.jpeg', 'urlimage' => 'cats.jpeg'];
-        yield 'whitespace' => ['image' => 'white cat.jpeg', 'urlimage' => 'white%20cat.jpeg'];
-        yield 'plus' => ['image' => 'cat+plus.jpeg', 'urlimage' => 'cat%2Bplus.jpeg'];
-        yield 'questionmark' => ['image' => 'cat?question.jpeg', 'urlimage' => 'cat%3Fquestion.jpeg'];
-        yield 'hash' => ['image' => 'cat#hash.jpeg', 'urlimage' => 'cat%23hash.jpeg'];
+        yield 'regular' => ['image' => 'cats.jpeg', 'callingimage' => 'cats.jpeg', 'urlimage' => 'cats.jpeg'];
+        yield 'whitespace' => ['image' => 'white cat.jpeg', 'callingimage' => 'white cat.jpeg', 'urlimage' => 'white%20cat.jpeg'];
+        yield 'plus' => ['image' => 'cat+plus.jpeg', 'callingimage' => 'cat+plus.jpeg', 'urlimage' => 'cat%2Bplus.jpeg'];
+        yield 'questionmark' => ['image' => 'cat?question.jpeg', 'callingimage' => 'cat?question.jpeg', 'urlimage' => 'cat%3Fquestion.jpeg'];
+        yield 'hash' => ['image' => 'cat#hash.jpeg', 'callingimage' => 'cat#hash.jpeg', 'urlimage' => 'cat%23hash.jpeg'];
+        yield 'absolute url' => ['image' => 'https://www.example.org/images/dogs.jpg', 'callingimage' => '/images/dogs.jpg', 'urlimage' => '/media/cache/thumbnail/images/dogs.jpg'];
     }
 
     /**
      * @dataProvider provideImageNames
      */
-    public function testInvokeFilterMethod($image, $urlimage): void
+    public function testInvokeFilterMethod($image, $callingimage, $urlimage): void
     {
         $this->manager
             ->expects($this->once())
             ->method('getBrowserPath')
-            ->with($image, self::FILTER)
+            ->with($callingimage, self::FILTER)
             ->willReturn($urlimage);
 
         $actualPath = $this->runtime->filter($image, self::FILTER);
@@ -183,6 +184,22 @@ class LazyFilterRuntimeTest extends AbstractTest
             ->willReturn($expectedCachePath);
 
         $actualPath = $this->runtime->filterCache($expectedInputPath, self::FILTER);
+
+        $this->assertSame($expectedCachePath, $actualPath);
+    }
+
+    public function testInvokeFilterCacheMethodWithAbsoluteUrl(): void
+    {
+        $expectedInputPath = '/images/dogs.jpg';
+        $expectedCachePath = '/media/cache/thumbnail/images/dogs.jpg';
+
+        $this->manager
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($expectedInputPath, self::FILTER)
+            ->willReturn($expectedCachePath);
+
+        $actualPath = $this->runtime->filterCache('https://www.example.org/images/dogs.jpg', self::FILTER);
 
         $this->assertSame($expectedCachePath, $actualPath);
     }

--- a/Tests/Templating/LazyFilterRuntimeTest.php
+++ b/Tests/Templating/LazyFilterRuntimeTest.php
@@ -72,6 +72,20 @@ class LazyFilterRuntimeTest extends AbstractTest
         $this->assertSame($urlimage, $actualPath);
     }
 
+    public function testLocalPathContainingQuestionMarkIsNotTruncated(): void
+    {
+        // guards the host check in cleanPath(): without it, parse_url() would reduce this to "cat"
+        $path = 'cat?question.jpeg';
+
+        $this->manager
+            ->expects($this->once())
+            ->method('getBrowserPath')
+            ->with($path, self::FILTER)
+            ->willReturn('irrelevant');
+
+        $this->runtime->filter($path, self::FILTER);
+    }
+
     public function testVersionHandling(): void
     {
         $this->runtime = new LazyFilterRuntime($this->manager, self::VERSION);


### PR DESCRIPTION
| Q              | A
| ---            | ---
| Branch?        | 2.x
| Bug fix?       | yes
| New feature?   | no
| BC breaks?     | no
| Deprecations?  | no
| Fixed tickets  | #1447
| License        | MIT
| Doc            | n/a

Fixes #1447.

In `lazy` Twig mode, absolute image URLs (S3/Flysystem/VichUploader) break:
the full URL is passed to the `CacheManager` unchanged. Legacy mode always
ran `parse_url($path, PHP_URL_PATH)` first; `LazyFilterRuntime` dropped it
(commit 13a32e4f).

This restores that normalization in `cleanPath()` — covering both `filter()`
and `filterCache()` — but only when the path has a host, so local filenames
containing `?` or `#` are left untouched.

A reproducing test case is included: the new `absolute url` cases fail
without the fix and pass with it, while existing cases stay green.
