### PR TITLE
feat: throw InvalidSignedUrlException on runtime sign check failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ for a given releases. Unreleased, upcoming changes will be updated here periodic
 ## 2.18.0 (unreleased)
 
 - Drop support for PHP 8.0.
+- Throw `InvalidSignedUrlException` (extends `BadRequestHttpException`) when a runtime signed URL fails the HMAC check ([BriceFab](https://github.com/liip/LiipImagineBundle/issues/1656))
 
 ## [2.17.2](https://github.com/liip/LiipImagineBundle/tree/2.17.2)
 

--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -15,6 +15,7 @@ use Imagine\Exception\RuntimeException;
 use Liip\ImagineBundle\Config\Controller\ControllerConfig;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Exception\Imagine\Filter\NonExistingFilterException;
+use Liip\ImagineBundle\Exception\Signer\InvalidSignedUrlException;
 use Liip\ImagineBundle\Imagine\Cache\Helper\PathHelper;
 use Liip\ImagineBundle\Imagine\Cache\SignerInterface;
 use Liip\ImagineBundle\Imagine\Data\DataManager;
@@ -22,7 +23,6 @@ use Liip\ImagineBundle\Service\FilterService;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ImagineController
@@ -109,7 +109,7 @@ class ImagineController
      * @param string $filter
      *
      * @throws RuntimeException
-     * @throws BadRequestHttpException
+     * @throws InvalidSignedUrlException
      * @throws NotFoundHttpException
      *
      * @return RedirectResponse
@@ -121,7 +121,7 @@ class ImagineController
         $runtimeConfig = $this->getFiltersBc($request);
 
         if (true !== $this->signer->check($hash, $path, $runtimeConfig)) {
-            throw new BadRequestHttpException(\sprintf('Signed url does not pass the sign check for path "%s" and filter "%s" and runtime config %s', $path, $filter, json_encode($runtimeConfig)));
+            throw new InvalidSignedUrlException($path, $filter, $runtimeConfig);
         }
 
         return $this->createRedirectResponse(function () use ($path, $filter, $runtimeConfig, $resolver, $request) {

--- a/Exception/Signer/InvalidSignedUrlException.php
+++ b/Exception/Signer/InvalidSignedUrlException.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Exception\Signer;
+
+use Liip\ImagineBundle\Exception\ExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class InvalidSignedUrlException extends BadRequestHttpException implements ExceptionInterface
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var string
+     */
+    private $filter;
+
+    /**
+     * @var array
+     */
+    private $runtimeConfig;
+
+    public function __construct(string $path, string $filter, array $runtimeConfig, ?\Throwable $previous = null)
+    {
+        $this->path = $path;
+        $this->filter = $filter;
+        $this->runtimeConfig = $runtimeConfig;
+
+        parent::__construct(\sprintf(
+            'Signed url does not pass the sign check for path "%s" and filter "%s" and runtime config %s',
+            $path,
+            $filter,
+            json_encode($runtimeConfig)
+        ), $previous);
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getFilter(): string
+    {
+        return $this->filter;
+    }
+
+    public function getRuntimeConfig(): array
+    {
+        return $this->runtimeConfig;
+    }
+}

--- a/Tests/Controller/ImagineControllerTest.php
+++ b/Tests/Controller/ImagineControllerTest.php
@@ -14,6 +14,7 @@ namespace Liip\ImagineBundle\Tests\Controller;
 use Liip\ImagineBundle\Config\Controller\ControllerConfig;
 use Liip\ImagineBundle\Controller\ImagineController;
 use Liip\ImagineBundle\Exception\InvalidArgumentException;
+use Liip\ImagineBundle\Exception\Signer\InvalidSignedUrlException;
 use Liip\ImagineBundle\Tests\AbstractTest;
 use Liip\ImagineBundle\Tests\Config\Controller\ControllerConfigTest;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -96,6 +97,43 @@ class ImagineControllerTest extends AbstractTest
             $redirectResponseCode,
             false
         );
+    }
+
+    public function testFilterRuntimeActionThrowsInvalidSignedUrlExceptionWhenSignCheckFails(): void
+    {
+        $path = 'uploads/foo.jpg';
+        $filter = 'thumbnail';
+        $hash = 'bad-hash';
+        $runtimeConfig = ['thumbnail' => ['size' => [50, 50]]];
+
+        $signer = $this->createSignerInterfaceMock();
+        $signer
+            ->expects($this->once())
+            ->method('check')
+            ->with($hash, $path, $runtimeConfig)
+            ->willReturn(false);
+
+        $controller = new ImagineController(
+            $this->createFilterServiceMock(),
+            $this->createDataManagerMock(),
+            $signer,
+            $this->createControllerConfigInstance()
+        );
+
+        $request = new Request(['filters' => $runtimeConfig]);
+
+        try {
+            $controller->filterRuntimeAction($request, $hash, $path, $filter);
+            $this->fail('Expected InvalidSignedUrlException was not thrown.');
+        } catch (InvalidSignedUrlException $exception) {
+            $this->assertSame($path, $exception->getPath());
+            $this->assertSame($filter, $exception->getFilter());
+            $this->assertSame($runtimeConfig, $exception->getRuntimeConfig());
+            $this->assertSame(
+                'Signed url does not pass the sign check for path "uploads/foo.jpg" and filter "thumbnail" and runtime config {"thumbnail":{"size":[50,50]}}',
+                $exception->getMessage()
+            );
+        }
     }
 
     private function createControllerInstance(string $path, string $filter, string $hash, int $redirectResponseCode, bool $expectation = true): ImagineController

--- a/Tests/Exception/Signer/InvalidSignedUrlExceptionTest.php
+++ b/Tests/Exception/Signer/InvalidSignedUrlExceptionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Exception\Signer;
+
+use Liip\ImagineBundle\Exception\ExceptionInterface;
+use Liip\ImagineBundle\Exception\Signer\InvalidSignedUrlException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * @covers \Liip\ImagineBundle\Exception\Signer\InvalidSignedUrlException
+ */
+class InvalidSignedUrlExceptionTest extends TestCase
+{
+    public function testExtendsBadRequestHttpExceptionAndExposesContext(): void
+    {
+        $exception = new InvalidSignedUrlException(
+            'uploads/foo.jpg',
+            'thumbnail',
+            ['thumbnail' => ['size' => [50, 50]]]
+        );
+
+        $this->assertInstanceOf(BadRequestHttpException::class, $exception);
+        $this->assertInstanceOf(ExceptionInterface::class, $exception);
+        $this->assertSame('uploads/foo.jpg', $exception->getPath());
+        $this->assertSame('thumbnail', $exception->getFilter());
+        $this->assertSame(['thumbnail' => ['size' => [50, 50]]], $exception->getRuntimeConfig());
+        $this->assertSame(
+            'Signed url does not pass the sign check for path "uploads/foo.jpg" and filter "thumbnail" and runtime config {"thumbnail":{"size":[50,50]}}',
+            $exception->getMessage()
+        );
+    }
+}

--- a/Tests/Functional/Controller/ImagineControllerTest.php
+++ b/Tests/Functional/Controller/ImagineControllerTest.php
@@ -12,10 +12,10 @@
 namespace Liip\ImagineBundle\Tests\Functional\Controller;
 
 use Liip\ImagineBundle\Controller\ImagineController;
+use Liip\ImagineBundle\Exception\Signer\InvalidSignedUrlException;
 use Liip\ImagineBundle\Imagine\Cache\Signer;
 use Liip\ImagineBundle\Tests\Functional\AbstractSetupWebTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -167,7 +167,7 @@ class ImagineControllerTest extends AbstractSetupWebTestCase
 
     public function testThrowBadRequestIfSignInvalidWhileUsingCustomFilters(): void
     {
-        $this->expectException(BadRequestHttpException::class);
+        $this->expectException(InvalidSignedUrlException::class);
         $this->expectExceptionMessage('Signed url does not pass the sign check for path "images/cats.jpeg" and filter "thumbnail_web_path" and runtime config {"thumbnail":{"size":["50","50"]}}');
 
         $this->client->request('GET', '/media/cache/resolve/thumbnail_web_path/rc/invalidHash/images/cats.jpeg?'.http_build_query([


### PR DESCRIPTION
## Summary

- Introduce `Liip\ImagineBundle\Exception\Signer\InvalidSignedUrlException` extending `BadRequestHttpException` (and implementing `ExceptionInterface`)
- Throw it from `ImagineController::filterRuntimeAction()` when the HMAC/signature check fails, keeping the **same message** as before (no BC break)
- Expose `path`, `filter`, and `runtimeConfig` via getters for structured handling
- Update unit/functional tests + CHANGELOG

Fixes #1656

## Motivation

Consumers that soft-fail only signature failures (e.g. redirect to the original upload when crawlers/AMP proxies mangle `filters[...]`) currently have to match the exception **message string**. A typed exception lets apps `catch (InvalidSignedUrlException)` without coupling to wording.

Default HTTP semantics stay unchanged (still a 400 `BadRequestHttpException` subclass).

## Test plan

- [x] `Tests/Exception/Signer/InvalidSignedUrlExceptionTest`
- [x] `Tests/Controller/ImagineControllerTest` (including new sign-failure case)
- [x] Functional test still expects the same message; now asserts `InvalidSignedUrlException`
- [x] Validated against FitMetrics soft-fail wrapper (`ImagineRuntimeController`) with a path install of this branch — typed catch redirects to `/uploads/...` as before