### PR TITLE
Add native return type to RelativeResize::apply()

### DIFF
--- a/Imagine/Filter/RelativeResize.php
+++ b/Imagine/Filter/RelativeResize.php
@@ -43,7 +43,7 @@ class RelativeResize implements FilterInterface
         $this->parameter = $parameter;
     }
 
-    public function apply(ImageInterface $image)
+    public function apply(ImageInterface $image): ImageInterface
     {
         return $image->resize(\call_user_func([$image->getSize(), $this->method], $this->parameter));
     }

--- a/Tests/Imagine/Filter/RelativeResizeTest.php
+++ b/Tests/Imagine/Filter/RelativeResizeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Imagine\Filter;
+
+use Imagine\Gd\Imagine;
+use Imagine\Image\Box;
+use Imagine\Image\ImageInterface;
+use Liip\ImagineBundle\Imagine\Filter\RelativeResize;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Filter\RelativeResize
+ */
+class RelativeResizeTest extends TestCase
+{
+    public function testApplyReturnsResizedImage(): void
+    {
+        $image = (new Imagine())->create(new Box(200, 100));
+
+        $result = (new RelativeResize('heighten', 50))->apply($image);
+
+        $this->assertInstanceOf(ImageInterface::class, $result);
+        $this->assertSame(50, $result->getSize()->getHeight());
+        $this->assertSame(100, $result->getSize()->getWidth());
+    }
+
+    public function testApplyDeclaresNativeReturnType(): void
+    {
+        $returnType = (new \ReflectionMethod(RelativeResize::class, 'apply'))->getReturnType();
+
+        $this->assertInstanceOf(\ReflectionNamedType::class, $returnType);
+        $this->assertSame(ImageInterface::class, $returnType->getName());
+    }
+}

--- a/Tests/Imagine/Filter/RelativeResizeTest.php
+++ b/Tests/Imagine/Filter/RelativeResizeTest.php
@@ -32,12 +32,4 @@ class RelativeResizeTest extends TestCase
         $this->assertSame(50, $result->getSize()->getHeight());
         $this->assertSame(100, $result->getSize()->getWidth());
     }
-
-    public function testApplyDeclaresNativeReturnType(): void
-    {
-        $returnType = (new \ReflectionMethod(RelativeResize::class, 'apply'))->getReturnType();
-
-        $this->assertInstanceOf(\ReflectionNamedType::class, $returnType);
-        $this->assertSame(ImageInterface::class, $returnType->getName());
-    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | Fixes #1618
| License | MIT
| Doc | n/a

Applying the `relative_resize` filter emits a Symfony self-deprecation:

> Method "Imagine\Filter\FilterInterface::apply()" might add "\Imagine\Image\ImageInterface" as a native return type declaration in the future. Do the same in implementation "Liip\ImagineBundle\Imagine\Filter\RelativeResize" now to avoid errors or add an explicit @return annotation to suppress this message.

`RelativeResize` is the only class in this bundle implementing `Imagine\Filter\FilterInterface`, and its `apply()` already returns an `ImageInterface`. This declares the native return type to silence the notice and stay forward-compatible. Since the project requires PHP `^8.1`, the covariant return type is safe.

The focused test exercises `RelativeResize::apply()` and verifies the resized image dimensions.

Validation on PHP 8.2: `Tests: 1058, Assertions: 2613, Skipped: 29`; container lint, PHPStan, and PHP-CS-Fixer pass. The upstream baseline has `1057` tests, `2610` assertions, and the same `29` skips.
