### PR TITLE
Clear WebP cache variant on CacheManager::remove()

### DIFF
--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -25,6 +25,13 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEvent
 class CacheManager
 {
     /**
+     * Suffix appended to a cached path to reach its WebP variant.
+     *
+     * @see \Liip\ImagineBundle\Service\FilterPathContainer::createWebp()
+     */
+    private const WEBP_SUFFIX = '.webp';
+
+    /**
      * @var FilterConfiguration
      */
     protected $filterConfig;
@@ -239,6 +246,14 @@ class CacheManager
 
         $paths = array_filter($paths);
         $filters = array_filter($filters);
+
+        // When WebP generation is enabled, each cached image also has a
+        // "<path>.webp" companion (see FilterService::buildFilterPathContainers).
+        // Remove it alongside the original so the WebP cache is not left stale.
+        if ($this->webpGenerate && [] !== $paths) {
+            $webpPaths = array_map(static fn (string $path): string => $path.self::WEBP_SUFFIX, $paths);
+            $paths = array_values(array_unique(array_merge($paths, $webpPaths)));
+        }
 
         $mapping = new \SplObjectStorage();
         foreach ($filters as $filter) {

--- a/Tests/Imagine/Cache/CacheManagerTest.php
+++ b/Tests/Imagine/Cache/CacheManagerTest.php
@@ -520,6 +520,42 @@ class CacheManagerTest extends AbstractTest
         $cacheManager->remove([$expectedPathOne, $expectedPathTwo], $expectedFilter);
     }
 
+    public function testRemoveAlsoClearsWebpVariantWhenWebpGenerationEnabled(): void
+    {
+        $expectedPath = 'thePath';
+        $expectedFilter = 'theFilter';
+
+        $resolver = $this->createCacheResolverInterfaceMock();
+        $resolver
+            ->expects($this->once())
+            ->method('remove')
+            ->with(
+                [$expectedPath, $expectedPath.'.webp'],
+                [$expectedFilter]
+            );
+
+        $config = $this->createFilterConfigurationMock();
+        $config
+            ->expects($this->atLeastOnce())
+            ->method('get')
+            ->willReturnCallback(static function ($filter) {
+                return [
+                    'cache' => $filter,
+                ];
+            });
+
+        $cacheManager = new CacheManager(
+            $config,
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $this->createEventDispatcherInterfaceMock(),
+            null,
+            true
+        );
+        $cacheManager->addResolver($expectedFilter, $resolver);
+        $cacheManager->remove($expectedPath, $expectedFilter);
+    }
+
     public function testRemoveCacheForSomePathsAndSomeFiltersOnRemove(): void
     {
         $expectedPathOne = 'thePath';


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | Fixes #1504
| License | MIT
| Doc | n/a

When `liip_imagine.webp.generate: true`, every cached image is stored twice: the original `<path>` and a WebP companion `<path>.webp` (see `FilterService::buildFilterPathContainers()` / `FilterPathContainer::createWebp()`).

`CacheManager::remove($path, $filter)` only deleted `<path>`, so the `<path>.webp` file was left behind. Callers clearing the cache through the `CacheManager` API directly (as reported in #1504) kept serving the stale WebP version after changing filter settings.

This removes the WebP variant alongside the original whenever WebP generation is enabled. The "remove all" case (`remove(null, ...)`) is untouched — it already clears the whole filter directory, WebP files included. The `liip:imagine:cache:remove` command is unaffected too, since per-image removal there goes through `FilterService::bustCache()`, which was already WebP-aware.

## Test verification (RED → GREEN)

New `CacheManagerTest::testRemoveAlsoClearsWebpVariantWhenWebpGenerationEnabled` builds a `CacheManager` with `webpGenerate = true` and asserts the resolver receives both paths.

RED — on unmodified 2.x:

```
1) Liip\ImagineBundle\Tests\Imagine\Cache\CacheManagerTest::testRemoveAlsoClearsWebpVariantWhenWebpGenerationEnabled
Parameter 0 for invocation ResolverInterface::remove(Array (...), Array (...)) does not match expected value.
--- Expected
+++ Actual
 Array (
     0 => 'thePath'
-    1 => 'thePath.webp'
 )
Tests: 1, Failures: 1.
```

GREEN — with the fix:

```
OK (7 tests, 18 assertions)
```

Full suite stays green (Symfony 6.4, PHP 8.3): `Tests: 1057, Assertions: 2620, Skipped: 29` — same 29 skips as baseline, +1 new passing test, no new failures. `php-cs-fixer` reports 0 files to fix.