### PR TITLE
Apply quality to all Vips image formats

### DIFF
--- a/Imagine/Filter/FilterManager.php
+++ b/Imagine/Filter/FilterManager.php
@@ -13,6 +13,7 @@ namespace Liip\ImagineBundle\Imagine\Filter;
 
 use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
+use Imagine\Vips\Imagine as VipsImagine;
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Binary\FileBinaryInterface;
 use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
@@ -22,6 +23,15 @@ use Liip\ImagineBundle\Model\Binary;
 
 class FilterManager
 {
+    private const VIPS_QUALITY_OPTIONS = [
+        'jpeg_quality',
+        'png_quality',
+        'webp_quality',
+        'heif_quality',
+        'avif_quality',
+        'jxl_quality',
+    ];
+
     /**
      * @var FilterConfiguration
      */
@@ -144,6 +154,12 @@ class FilterManager
         $options = [
             'quality' => $config['quality'],
         ];
+
+        if ($this->imagine instanceof VipsImagine) {
+            foreach (self::VIPS_QUALITY_OPTIONS as $qualityOption) {
+                $options[$qualityOption] = $config[$qualityOption] ?? $config['quality'];
+            }
+        }
 
         if (isset($config['jpeg_quality'])) {
             $options['jpeg_quality'] = $config['jpeg_quality'];

--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -107,6 +107,7 @@ There are several configuration options available:
 * ``driver`` - one of the drivers: ``gd``, ``imagick``, ``gmagick``, ``vips``.
   Default value: ``gd``
   * If you want to use vips, you need to additionally require ``rokka/imagine-vips``
+  * With vips, ``quality`` is applied to each output format's quality option.
 * ``default_filter_set_settings`` - specify the default values that will be inherit for any set defined in
   ``filter_sets``. These values will be overridden if they are specified in the each set. In case of ``filters`` and
   ``post_processors``, the specified values will be merged with the default ones.

--- a/Tests/Imagine/Filter/FilterManagerTest.php
+++ b/Tests/Imagine/Filter/FilterManagerTest.php
@@ -11,6 +11,8 @@
 
 namespace Liip\ImagineBundle\Tests\Filter;
 
+use Imagine\Gd\Imagine as GdImagine;
+use Imagine\Vips\Imagine as VipsImagine;
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
 use Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface;
@@ -23,6 +25,9 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class FilterManagerTest extends AbstractTest
 {
+    private const VIPS_JPEG_QUALITY = 60;
+    private const VIPS_QUALITY = 80;
+
     public function testThrowsIfNoLoadersAddedForFilterOnApplyFilter(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -405,6 +410,47 @@ class FilterManagerTest extends AbstractTest
         $filterManager->addLoader('thumbnail', $loader);
 
         $this->assertInstanceOf(Binary::class, $filterManager->applyFilter($binary, 'thumbnail'));
+    }
+
+    public function testMapsQualityToVipsFormatOptionsOnApply(): void
+    {
+        if (!class_exists(VipsImagine::class)) {
+            class_alias(GdImagine::class, VipsImagine::class);
+        }
+
+        $binary = new Binary('aOriginalContent', 'image/png', 'png');
+        $image = $this->getImageInterfaceMock();
+        $image
+            ->expects($this->once())
+            ->method('get')
+            ->with('png', [
+                'quality' => self::VIPS_QUALITY,
+                'jpeg_quality' => self::VIPS_JPEG_QUALITY,
+                'png_quality' => self::VIPS_QUALITY,
+                'webp_quality' => self::VIPS_QUALITY,
+                'heif_quality' => self::VIPS_QUALITY,
+                'avif_quality' => self::VIPS_QUALITY,
+                'jxl_quality' => self::VIPS_QUALITY,
+            ])
+            ->willReturn('aFilteredContent');
+
+        $imagine = $this->createMock(VipsImagine::class);
+        $imagine
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn($image);
+
+        $filterManager = new FilterManager(
+            $this->createFilterConfigurationMock(),
+            $imagine,
+            $this->createMimeTypeGuesserInterfaceMock()
+        );
+
+        $this->assertInstanceOf(Binary::class, $filterManager->apply($binary, [
+            'quality' => self::VIPS_QUALITY,
+            'jpeg_quality' => self::VIPS_JPEG_QUALITY,
+            'post_processors' => [],
+        ]));
     }
 
     public function testAlters100QualityIfNotSetOnApplyFilter(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | Fix #1601
| License | MIT
| Doc | configuration.rst

Map the generic filter-set `quality` value to every format-specific quality option expected by the Vips driver. Existing explicit `jpeg_quality` values continue to take precedence.

## Test verification (RED → GREEN)

On the upstream `2.x` branch, the focused test failed because only the generic option reached the encoder:

```text
Expected: quality, jpeg_quality, png_quality, webp_quality, heif_quality, avif_quality, jxl_quality
Actual:   quality
FAILURES!
Tests: 1, Assertions: 0, Failures: 1.
```

With this change:

```text
OK (1 test, 3 assertions)
php-diff-coverage: PASS 3/3 changed executable lines covered
```

Full local CI also passed: container lint, 1,059 PHPUnit tests (23 existing skips), PHP CS Fixer, and PHPStan.
