### PR TITLE
Dispatch events on the cache storage lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ for a given releases. Unreleased, upcoming changes will be updated here periodic
 
 ## 2.18.0 (unreleased)
 
+- Dispatch pre/post store and pre/post remove events on the CacheManager, so applications can react to the cache storage lifecycle ([ousamabenyounes](https://github.com/liip/LiipImagineBundle/pull/1664))
 - Fix bug that we did not delete the webp variant when enabled, when deleting an image through the CacheManager ([ousamabenyounes](https://github.com/liip/LiipImagineBundle/pull/1661))
 - Drop support for PHP 8.0.
 

--- a/Events/CacheRemoveEvent.php
+++ b/Events/CacheRemoveEvent.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Events;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Dispatched before and after cached images are removed from their cache resolvers.
+ */
+class CacheRemoveEvent extends Event
+{
+    /**
+     * @var string[]
+     */
+    private $paths;
+
+    /**
+     * @var string[]
+     */
+    private $filters;
+
+    /**
+     * @param string[] $paths   the paths being removed, an empty list meaning every path of the given filters
+     * @param string[] $filters the filter names the removal applies to
+     */
+    public function __construct(array $paths, array $filters)
+    {
+        $this->paths = $paths;
+        $this->filters = $filters;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPaths(): array
+    {
+        return $this->paths;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFilters(): array
+    {
+        return $this->filters;
+    }
+}

--- a/Events/CacheStoreEvent.php
+++ b/Events/CacheStoreEvent.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Events;
+
+use Liip\ImagineBundle\Binary\BinaryInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Dispatched before and after a filtered image is handed over to its cache resolver.
+ */
+class CacheStoreEvent extends Event
+{
+    /**
+     * @var BinaryInterface
+     */
+    private $binary;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var string
+     */
+    private $filter;
+
+    /**
+     * @var string|null
+     */
+    private $resolver;
+
+    /**
+     * @param string      $path     the path the filtered image is stored under
+     * @param string      $filter   the name of the imagine filter in effect
+     * @param string|null $resolver the resolver name passed to the cache manager, null when the filter default is used
+     */
+    public function __construct(BinaryInterface $binary, string $path, string $filter, ?string $resolver = null)
+    {
+        $this->binary = $binary;
+        $this->path = $path;
+        $this->filter = $filter;
+        $this->resolver = $resolver;
+    }
+
+    public function getBinary(): BinaryInterface
+    {
+        return $this->binary;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getFilter(): string
+    {
+        return $this->filter;
+    }
+
+    public function getResolver(): ?string
+    {
+        return $this->resolver;
+    }
+}

--- a/Imagine/Cache/CacheManager.php
+++ b/Imagine/Cache/CacheManager.php
@@ -12,7 +12,9 @@
 namespace Liip\ImagineBundle\Imagine\Cache;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;
+use Liip\ImagineBundle\Events\CacheRemoveEvent;
 use Liip\ImagineBundle\Events\CacheResolveEvent;
+use Liip\ImagineBundle\Events\CacheStoreEvent;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Liip\ImagineBundle\ImagineEvents;
@@ -226,7 +228,11 @@ class CacheManager
      */
     public function store(BinaryInterface $binary, $path, $filter, $resolver = null): void
     {
+        $this->dispatchWithBC(new CacheStoreEvent($binary, $path, $filter, $resolver), ImagineEvents::PRE_STORE);
+
         $this->getResolver($filter, $resolver)->store($binary, $path, $filter);
+
+        $this->dispatchWithBC(new CacheStoreEvent($binary, $path, $filter, $resolver), ImagineEvents::POST_STORE);
     }
 
     /**
@@ -255,6 +261,8 @@ class CacheManager
             $paths = array_values(array_unique(array_merge($paths, $webpPaths)));
         }
 
+        $this->dispatchWithBC(new CacheRemoveEvent($paths, $filters), ImagineEvents::PRE_REMOVE);
+
         $mapping = new \SplObjectStorage();
         foreach ($filters as $filter) {
             $resolver = $this->getResolver($filter, null);
@@ -269,6 +277,8 @@ class CacheManager
         foreach ($mapping as $resolver) {
             $resolver->remove($paths, $mapping[$resolver]);
         }
+
+        $this->dispatchWithBC(new CacheRemoveEvent($paths, $filters), ImagineEvents::POST_REMOVE);
     }
 
     /**
@@ -304,7 +314,7 @@ class CacheManager
     /**
      * BC Layer for Symfony < 4.3
      */
-    private function dispatchWithBC(CacheResolveEvent $event, string $eventName): void
+    private function dispatchWithBC(object $event, string $eventName): void
     {
         if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
             $this->dispatcher->dispatch($event, $eventName);

--- a/ImagineEvents.php
+++ b/ImagineEvents.php
@@ -22,4 +22,24 @@ interface ImagineEvents
      * @Event("Liip\ImagineBundle\Events\CacheResolveEvent")
      */
     public const POST_RESOLVE = 'liip_imagine.post_resolve';
+
+    /**
+     * @Event("Liip\ImagineBundle\Events\CacheStoreEvent")
+     */
+    public const PRE_STORE = 'liip_imagine.pre_store';
+
+    /**
+     * @Event("Liip\ImagineBundle\Events\CacheStoreEvent")
+     */
+    public const POST_STORE = 'liip_imagine.post_store';
+
+    /**
+     * @Event("Liip\ImagineBundle\Events\CacheRemoveEvent")
+     */
+    public const PRE_REMOVE = 'liip_imagine.pre_remove';
+
+    /**
+     * @Event("Liip\ImagineBundle\Events\CacheRemoveEvent")
+     */
+    public const POST_REMOVE = 'liip_imagine.post_remove';
 }

--- a/Resources/doc/events.rst
+++ b/Resources/doc/events.rst
@@ -3,8 +3,11 @@
 Events
 ======
 
-Events availables in the bundle are ``PRE_RESOLVE`` and ``POST_RESOLVE``.
-Both receive a CacheResolveEvent as event.
+The bundle dispatches the following events around the cache lifecycle:
+
+* ``PRE_RESOLVE`` and ``POST_RESOLVE``, both receiving a CacheResolveEvent.
+* ``PRE_STORE`` and ``POST_STORE``, both receiving a CacheStoreEvent.
+* ``PRE_REMOVE`` and ``POST_REMOVE``, both receiving a CacheRemoveEvent.
 
 PRE_RESOLVE
 -----------
@@ -16,6 +19,34 @@ POST_RESOLVE
 ------------
 
 Called after url to the cached filtered image is generated.
+
+PRE_STORE
+---------
+
+Called before the filtered image is handed over to its cache resolver. The
+CacheStoreEvent gives access to the binary about to be stored, the path it is
+stored under, the filter name and the resolver name that was passed to the
+cache manager - the latter being ``null`` when the filter default is used.
+
+POST_STORE
+----------
+
+Called after the filtered image has been handed over to its cache resolver,
+for example to inspect the image that was just written.
+
+PRE_REMOVE
+----------
+
+Called before cached images are removed from their cache resolvers. The
+CacheRemoveEvent gives access to the paths and the filter names the removal
+applies to. An empty list of paths means every cached path of those filters is
+removed. With ``webp_generate`` enabled, the paths also contain the ``.webp``
+companion of every removed path.
+
+POST_REMOVE
+-----------
+
+Called after the cached images have been removed from their cache resolvers.
 
 Example: Signed URLs
 --------------------

--- a/Tests/Imagine/Cache/CacheManagerTest.php
+++ b/Tests/Imagine/Cache/CacheManagerTest.php
@@ -11,7 +11,9 @@
 
 namespace Liip\ImagineBundle\Tests\Imagine\Cache;
 
+use Liip\ImagineBundle\Events\CacheRemoveEvent;
 use Liip\ImagineBundle\Events\CacheResolveEvent;
+use Liip\ImagineBundle\Events\CacheStoreEvent;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Cache\Signer;
@@ -29,6 +31,14 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEvent
  */
 class CacheManagerTest extends AbstractTest
 {
+    /**
+     * Markers recorded by the resolver mocks so that the cache lifecycle tests
+     * can assert the events are dispatched around the resolver call.
+     */
+    private const RESOLVER_STORE_CALL = 'resolver.store';
+
+    private const RESOLVER_REMOVE_CALL = 'resolver.remove';
+
     public function testAddCacheManagerAwareResolver(): void
     {
         $cacheManager = new CacheManager(
@@ -748,6 +758,100 @@ class CacheManagerTest extends AbstractTest
 
         $cacheManager->addResolver('default', $this->createCacheResolverInterfaceMock());
         $cacheManager->resolve('cats.jpg', 'thumbnail');
+    }
+
+    public function testShouldDispatchCacheStoreEvents(): void
+    {
+        $binary = new Binary('aContent', 'image/jpeg', 'jpg');
+
+        $sequence = [];
+        $dispatched = [];
+        $dispatcher = $this->createEventDispatcherInterfaceMock();
+        $dispatcher
+            ->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback($this->getDispatcherCallbackWithBC($dispatcher, static function (CacheStoreEvent $event, string $eventName) use (&$sequence, &$dispatched): void {
+                $sequence[] = $eventName;
+                $dispatched[$eventName] = $event;
+            }));
+
+        $resolver = $this->createCacheResolverInterfaceMock();
+        $resolver
+            ->expects($this->once())
+            ->method('store')
+            ->with($binary, 'cats.jpg', 'thumbnail')
+            ->willReturnCallback(static function () use (&$sequence): void {
+                $sequence[] = self::RESOLVER_STORE_CALL;
+            });
+
+        $cacheManager = new CacheManager(
+            $this->createFilterConfigurationMock(),
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $dispatcher
+        );
+
+        $cacheManager->addResolver('the_resolver', $resolver);
+        $cacheManager->store($binary, 'cats.jpg', 'thumbnail', 'the_resolver');
+
+        $this->assertSame([ImagineEvents::PRE_STORE, self::RESOLVER_STORE_CALL, ImagineEvents::POST_STORE], $sequence);
+
+        foreach ($dispatched as $event) {
+            $this->assertSame($binary, $event->getBinary());
+            $this->assertSame('cats.jpg', $event->getPath());
+            $this->assertSame('thumbnail', $event->getFilter());
+            $this->assertSame('the_resolver', $event->getResolver());
+        }
+    }
+
+    public function testShouldDispatchCacheRemoveEvents(): void
+    {
+        $sequence = [];
+        $dispatched = [];
+        $dispatcher = $this->createEventDispatcherInterfaceMock();
+        $dispatcher
+            ->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback($this->getDispatcherCallbackWithBC($dispatcher, static function (CacheRemoveEvent $event, string $eventName) use (&$sequence, &$dispatched): void {
+                $sequence[] = $eventName;
+                $dispatched[$eventName] = $event;
+            }));
+
+        $config = $this->createFilterConfigurationMock();
+        $config
+            ->expects($this->atLeastOnce())
+            ->method('get')
+            ->willReturnCallback(static function ($filter) {
+                return [
+                    'cache' => $filter,
+                ];
+            });
+
+        $resolver = $this->createCacheResolverInterfaceMock();
+        $resolver
+            ->expects($this->once())
+            ->method('remove')
+            ->with(['cats.jpg'], ['thumbnail'])
+            ->willReturnCallback(static function () use (&$sequence): void {
+                $sequence[] = self::RESOLVER_REMOVE_CALL;
+            });
+
+        $cacheManager = new CacheManager(
+            $config,
+            $this->createRouterInterfaceMock(),
+            new Signer('secret'),
+            $dispatcher
+        );
+
+        $cacheManager->addResolver('thumbnail', $resolver);
+        $cacheManager->remove('cats.jpg', 'thumbnail');
+
+        $this->assertSame([ImagineEvents::PRE_REMOVE, self::RESOLVER_REMOVE_CALL, ImagineEvents::POST_REMOVE], $sequence);
+
+        foreach ($dispatched as $event) {
+            $this->assertSame(['cats.jpg'], $event->getPaths());
+            $this->assertSame(['thumbnail'], $event->getFilters());
+        }
     }
 
     public function testShouldAllowToPassChangedDataFromPreResolveEventToResolver(): void


### PR DESCRIPTION
Fixes #1280.

Adds `liip_imagine.pre_store` / `post_store` and `liip_imagine.pre_remove` / `post_remove` events so applications can react to the cache storage lifecycle without decorating `CacheManager`.

This follows the design agreed in the issue thread: pre **and** post events for both store and remove, and the legacy-compatible dispatch helper generalised to accept any event class instead of only `CacheResolveEvent`. PR #1127 attempted the store half in 2020 but was abandoned (the author's fork is gone), and it did not cover removal.

## What changed

- `Events/CacheStoreEvent` — carries the `BinaryInterface`, path, filter and resolver.
- `Events/CacheRemoveEvent` — carries the paths and filters being removed.
- `ImagineEvents` — four new constants with `@Event` annotations.
- `CacheManager::store()` / `::remove()` dispatch pre/post around the resolver call.
- `CacheManager::dispatchWithBC()` now accepts `object $event` instead of `CacheResolveEvent`.
- `Resources/doc/events.rst` documents the four events; CHANGELOG entry added.

No existing behaviour changes: without listeners the dispatch is a no-op, and the resolver call order is untouched.

## Test verification (RED → GREEN)

The two new tests assert the full ordering (`pre` → resolver call → `post`) and the event payload.

**RED — on `2.x` @ `3b62ee98`, with only the new test file applied** (event names inlined as string literals so the test exercises the behaviour rather than the not-yet-existing constants):

```
$ vendor/bin/simple-phpunit --no-coverage --filter "testShouldDispatchCache(Store|Remove)Events" Tests/Imagine/Cache/CacheManagerTest.php

1) ...CacheManagerTest::testShouldDispatchCacheStoreEvents
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
 Array &0 (
-    0 => 'liip_imagine.pre_store'
-    1 => 'resolver.store'
-    2 => 'liip_imagine.post_store'
+    0 => 'resolver.store'
 )

2) ...CacheManagerTest::testShouldDispatchCacheRemoveEvents
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
 Array &0 (
-    0 => 'liip_imagine.pre_remove'
-    1 => 'resolver.remove'
-    2 => 'liip_imagine.post_remove'
+    0 => 'resolver.remove'
 )

FAILURES!
Tests: 2, Assertions: 2, Failures: 2.
```

Only the resolver call happens today — no event is emitted.

**GREEN — same tests with this branch:**

```
$ vendor/bin/simple-phpunit --no-coverage --filter "testShouldDispatchCache(Store|Remove)Events" Tests/Imagine/Cache/CacheManagerTest.php

Testing Liip\ImagineBundle\Tests\Imagine\Cache\CacheManagerTest
..                                                                  2 / 2 (100%)

OK (2 tests, 19 assertions)
```

## Full local CI replay (PHP 8.2, gd/imagick/exif)

```
./Tests/Functional/app/bin/console lint:container
 [OK] The container was linted successfully: all services are injected with ...

vendor/bin/simple-phpunit -v --no-coverage
Tests: 1060, Assertions: 2648, Skipped: 23.      (2.x baseline: 1058 / 2629 / 23)

vendor/bin/phpstan analyze
 [OK] No errors

php-cs-fixer fix --dry-run --diff
Found 0 of 303 files that can be fixed
```
