### PR TITLE
Dispatch filter lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ for a given releases. Unreleased, upcoming changes will be updated here periodic
 
 ## 2.18.0 (unreleased)
 
+- Dispatch filter lifecycle events for telemetry and debugging ([ousamabenyounes](https://github.com/liip/LiipImagineBundle/pull/1666))
 - Fall back to the `default_image` when a filter does not exist or the image can not be generated, unless the new `controller.debug` option is enabled ([Amoifr](https://github.com/liip/LiipImagineBundle/pull/1665))
 - Dispatch pre/post store and pre/post remove events on the CacheManager, so applications can react to the cache storage lifecycle ([ousamabenyounes](https://github.com/liip/LiipImagineBundle/pull/1664))
 - Fix bug that we did not delete the webp variant when enabled, when deleting an image through the CacheManager ([ousamabenyounes](https://github.com/liip/LiipImagineBundle/pull/1661))

--- a/Events/FilterEvent.php
+++ b/Events/FilterEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Events;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Dispatched before and after an image filter or post-processor runs.
+ */
+class FilterEvent extends Event
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct(string $name, array $options)
+    {
+        $this->name = $name;
+        $this->options = $options;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}

--- a/Imagine/Filter/FilterManager.php
+++ b/Imagine/Filter/FilterManager.php
@@ -16,9 +16,13 @@ use Imagine\Image\ImagineInterface;
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Binary\FileBinaryInterface;
 use Liip\ImagineBundle\Binary\MimeTypeGuesserInterface;
+use Liip\ImagineBundle\Events\FilterEvent;
 use Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface;
 use Liip\ImagineBundle\Imagine\Filter\PostProcessor\PostProcessorInterface;
+use Liip\ImagineBundle\ImagineEvents;
 use Liip\ImagineBundle\Model\Binary;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 class FilterManager
 {
@@ -47,11 +51,17 @@ class FilterManager
      */
     protected $postProcessors = [];
 
-    public function __construct(FilterConfiguration $filterConfig, ImagineInterface $imagine, MimeTypeGuesserInterface $mimeTypeGuesser)
+    /**
+     * @var EventDispatcherInterface|null
+     */
+    private $dispatcher;
+
+    public function __construct(FilterConfiguration $filterConfig, ImagineInterface $imagine, MimeTypeGuesserInterface $mimeTypeGuesser, ?EventDispatcherInterface $dispatcher = null)
     {
         $this->filterConfig = $filterConfig;
         $this->imagine = $imagine;
         $this->mimeTypeGuesser = $mimeTypeGuesser;
+        $this->dispatcher = $dispatcher;
     }
 
     /**
@@ -97,8 +107,14 @@ class FilterManager
         }
 
         foreach ($this->sanitizeFilters($config['filters'] ?? []) as $name => $options) {
+            $event = new FilterEvent($name, $options);
+            $this->dispatchWithBC($event, ImagineEvents::PRE_FILTER);
             $prior = $image;
-            $image = $this->loaders[$name]->load($image, $options);
+            try {
+                $image = $this->loaders[$name]->load($image, $options);
+            } finally {
+                $this->dispatchWithBC($event, ImagineEvents::POST_FILTER);
+            }
 
             if ($prior !== $image) {
                 $this->destroyImage($prior);
@@ -133,7 +149,13 @@ class FilterManager
     public function applyPostProcessors(BinaryInterface $binary, array $config): BinaryInterface
     {
         foreach ($this->sanitizePostProcessors($config['post_processors'] ?? []) as $name => $options) {
-            $binary = $this->postProcessors[$name]->process($binary, $options);
+            $event = new FilterEvent($name, $options);
+            $this->dispatchWithBC($event, ImagineEvents::PRE_POST_PROCESSOR);
+            try {
+                $binary = $this->postProcessors[$name]->process($binary, $options);
+            } finally {
+                $this->dispatchWithBC($event, ImagineEvents::POST_POST_PROCESSOR);
+            }
         }
 
         return $binary;
@@ -215,6 +237,22 @@ class FilterManager
     {
         if (method_exists($image, '__destruct')) {
             $image->__destruct();
+        }
+    }
+
+    /**
+     * BC Layer for Symfony < 4.3.
+     */
+    private function dispatchWithBC(object $event, string $eventName): void
+    {
+        if (null === $this->dispatcher) {
+            return;
+        }
+
+        if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
+            $this->dispatcher->dispatch($event, $eventName);
+        } else {
+            $this->dispatcher->dispatch($eventName, $event);
         }
     }
 }

--- a/ImagineEvents.php
+++ b/ImagineEvents.php
@@ -42,4 +42,24 @@ interface ImagineEvents
      * @Event("Liip\ImagineBundle\Events\CacheRemoveEvent")
      */
     public const POST_REMOVE = 'liip_imagine.post_remove';
+
+    /**
+     * @Event("Liip\ImagineBundle\Events\FilterEvent")
+     */
+    public const PRE_FILTER = 'liip_imagine.pre_filter';
+
+    /**
+     * @Event("Liip\ImagineBundle\Events\FilterEvent")
+     */
+    public const POST_FILTER = 'liip_imagine.post_filter';
+
+    /**
+     * @Event("Liip\ImagineBundle\Events\FilterEvent")
+     */
+    public const PRE_POST_PROCESSOR = 'liip_imagine.pre_post_processor';
+
+    /**
+     * @Event("Liip\ImagineBundle\Events\FilterEvent")
+     */
+    public const POST_POST_PROCESSOR = 'liip_imagine.post_post_processor';
 }

--- a/Resources/config/imagine.php
+++ b/Resources/config/imagine.php
@@ -217,6 +217,7 @@ return static function (ContainerConfigurator $container) {
             service('liip_imagine.filter.configuration'),
             service('liip_imagine'),
             service('liip_imagine.binary.mime_type_guesser'),
+            service('event_dispatcher'),
         ]);
 
     $services->alias(FilterManager::class, 'liip_imagine.filter.manager');

--- a/Resources/doc/events.rst
+++ b/Resources/doc/events.rst
@@ -8,6 +8,8 @@ The bundle dispatches the following events around the cache lifecycle:
 * ``PRE_RESOLVE`` and ``POST_RESOLVE``, both receiving a CacheResolveEvent.
 * ``PRE_STORE`` and ``POST_STORE``, both receiving a CacheStoreEvent.
 * ``PRE_REMOVE`` and ``POST_REMOVE``, both receiving a CacheRemoveEvent.
+* ``PRE_FILTER`` and ``POST_FILTER``, both receiving a FilterEvent.
+* ``PRE_POST_PROCESSOR`` and ``POST_POST_PROCESSOR``, both receiving a FilterEvent.
 
 PRE_RESOLVE
 -----------
@@ -47,6 +49,20 @@ POST_REMOVE
 -----------
 
 Called after the cached images have been removed from their cache resolvers.
+
+PRE_FILTER and POST_FILTER
+--------------------------
+
+Called immediately before and after each configured image filter runs. The
+FilterEvent exposes the filter name and its configured options. These events
+are informational and cannot change the filter operation.
+
+PRE_POST_PROCESSOR and POST_POST_PROCESSOR
+------------------------------------------
+
+Called immediately before and after each configured post-processor runs. The
+FilterEvent exposes the post-processor name and its configured options. These
+events are informational and cannot change the post-processing operation.
 
 Example: Signed URLs
 --------------------

--- a/Tests/Imagine/Filter/FilterManagerTest.php
+++ b/Tests/Imagine/Filter/FilterManagerTest.php
@@ -12,17 +12,26 @@
 namespace Liip\ImagineBundle\Tests\Filter;
 
 use Liip\ImagineBundle\Binary\BinaryInterface;
+use Liip\ImagineBundle\Events\FilterEvent;
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
 use Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface;
+use Liip\ImagineBundle\Imagine\Filter\PostProcessor\PostProcessorInterface;
 use Liip\ImagineBundle\Model\Binary;
 use Liip\ImagineBundle\Tests\AbstractTest;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * @covers \Liip\ImagineBundle\Imagine\Filter\FilterManager
+ * @covers \Liip\ImagineBundle\Events\FilterEvent
  */
 class FilterManagerTest extends AbstractTest
 {
+    private const EVENT_PRE_FILTER = 'liip_imagine.pre_filter';
+    private const EVENT_POST_FILTER = 'liip_imagine.post_filter';
+    private const EVENT_PRE_POST_PROCESSOR = 'liip_imagine.pre_post_processor';
+    private const EVENT_POST_POST_PROCESSOR = 'liip_imagine.post_post_processor';
+
     public function testThrowsIfNoLoadersAddedForFilterOnApplyFilter(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -1057,6 +1066,69 @@ class FilterManagerTest extends AbstractTest
         );
 
         $this->assertSame($binary, $filterManager->applyPostProcessors($binary, []));
+    }
+
+    public function testDispatchesEventsAroundFiltersAndPostProcessors(): void
+    {
+        $sequence = [];
+        $events = [];
+        $dispatcher = new EventDispatcher();
+        foreach ([self::EVENT_PRE_FILTER, self::EVENT_POST_FILTER, self::EVENT_PRE_POST_PROCESSOR, self::EVENT_POST_POST_PROCESSOR] as $eventName) {
+            $dispatcher->addListener($eventName, static function (FilterEvent $event) use (&$events, &$sequence, $eventName): void {
+                $sequence[] = $eventName;
+                $events[$eventName] = $event;
+            });
+        }
+
+        $image = $this->getImageInterfaceMock();
+        $loader = $this->createFilterLoaderInterfaceMock();
+        $loader
+            ->method('load')
+            ->willReturnCallback(static function () use (&$sequence, $image) {
+                $sequence[] = 'filter';
+
+                return $image;
+            });
+
+        $postProcessor = $this->createObjectMock(PostProcessorInterface::class);
+        $postProcessor
+            ->method('process')
+            ->willReturnCallback(static function (BinaryInterface $binary) use (&$sequence): BinaryInterface {
+                $sequence[] = 'post_processor';
+
+                return $binary;
+            });
+
+        $imagine = $this->createImagineInterfaceMock();
+        $imagine->method('load')->willReturn($image);
+        $image->method('get')->willReturn('filtered');
+
+        $filterManager = new FilterManager(
+            $this->createFilterConfigurationMock(),
+            $imagine,
+            $this->createMimeTypeGuesserInterfaceMock(),
+            $dispatcher
+        );
+        $filterManager->addLoader('thumbnail', $loader);
+        $filterManager->addPostProcessor('optimizer', $postProcessor);
+
+        $filterManager->apply(new Binary('original', 'image/jpeg', 'jpeg'), [
+            'filters' => ['thumbnail' => []],
+            'post_processors' => ['optimizer' => []],
+        ]);
+
+        $this->assertSame([
+            self::EVENT_PRE_FILTER,
+            'filter',
+            self::EVENT_POST_FILTER,
+            self::EVENT_PRE_POST_PROCESSOR,
+            'post_processor',
+            self::EVENT_POST_POST_PROCESSOR,
+        ], $sequence);
+        $this->assertSame('thumbnail', $events[self::EVENT_PRE_FILTER]->getName());
+        $this->assertSame([], $events[self::EVENT_PRE_FILTER]->getOptions());
+        $this->assertSame('optimizer', $events[self::EVENT_PRE_POST_PROCESSOR]->getName());
+        $this->assertSame([], $events[self::EVENT_PRE_POST_PROCESSOR]->getOptions());
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | Fix #1467
| License | MIT
| Doc | Resources/doc/events.rst

This adds side-effect-free lifecycle events around each image filter and post-processor. Event listeners receive the operation name and configured options, which lets telemetry integrations measure individual operations without changing filter behavior.

The event dispatcher remains optional for callers that instantiate `FilterManager` directly.

## Test verification (RED → GREEN)

The focused test was copied onto the unmodified `2.x` base and failed behaviorally because no lifecycle events were dispatched:

```text
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
-    0 => 'liip_imagine.pre_filter'
-    1 => 'filter'
-    2 => 'liip_imagine.post_filter'
-    3 => 'liip_imagine.pre_post_processor'
-    4 => 'post_processor'
-    5 => 'liip_imagine.post_post_processor'
+    0 => 'filter'
+    1 => 'post_processor'
```

With this change:

```text
OK (1 test, 5 assertions)
```

Full local validation suite on PHP 8.2 / Symfony 6.4:

```text
Container lint: OK
Tests: 1074, Assertions: 2693, Skipped: 23
PHP-CS-Fixer: 0 of 304 files can be fixed
PHPStan: No errors
```
