### PR TITLE
Fix the documented range of the background filter transparency

### DIFF
--- a/Resources/doc/filters/general.rst
+++ b/Resources/doc/filters/general.rst
@@ -62,7 +62,9 @@ Background Options
     ``bottom``, and ``bottomright``.
 
 **transparency:** ``integer``
-    Sets the background alpha value. The value should be within a range of 0 (opaque) - 100 (fully transparent).
+    Sets the background alpha value, from ``0`` (fully transparent) to ``100`` (opaque).
+    The background is opaque when the option is omitted. Despite its name the value is an
+    opacity, because it is handed to Imagine as the alpha of the background color.
 
 
 .. _filter-grayscale:

--- a/Tests/Imagine/Filter/Loader/BackgroundFilterLoaderTest.php
+++ b/Tests/Imagine/Filter/Loader/BackgroundFilterLoaderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the `liip/LiipImagineBundle` project.
+ *
+ * (c) https://github.com/liip/LiipImagineBundle/graphs/contributors
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\ImagineBundle\Tests\Filter;
+
+use Imagine\Gd\Imagine;
+use Imagine\Image\Box;
+use Imagine\Image\Point;
+use Liip\ImagineBundle\Imagine\Filter\Loader\BackgroundFilterLoader;
+use Liip\ImagineBundle\Tests\AbstractTest;
+
+/**
+ * @covers \Liip\ImagineBundle\Imagine\Filter\Loader\BackgroundFilterLoader
+ */
+class BackgroundFilterLoaderTest extends AbstractTest
+{
+    /**
+     * The option is handed straight to the palette as the alpha of the background color, so it
+     * reads as an opacity: 100 keeps the background, 0 makes it disappear.
+     *
+     * @dataProvider provideTransparencyData
+     */
+    public function testTransparencyIsTheAlphaOfTheBackground(?int $transparency, int $expectedAlpha): void
+    {
+        $imagine = new Imagine();
+        $loader = new BackgroundFilterLoader($imagine);
+
+        $options = ['color' => '#ff0000', 'size' => [20, 20], 'position' => 'center'];
+
+        if (null !== $transparency) {
+            $options['transparency'] = $transparency;
+        }
+
+        $result = $loader->load($imagine->create(new Box(10, 10)), $options);
+
+        // a corner of the canvas, outside of the pasted image
+        $this->assertSame($expectedAlpha, $result->getColorAt(new Point(0, 0))->getAlpha());
+    }
+
+    /**
+     * @return iterable<string, array{int|null, int}>
+     */
+    public static function provideTransparencyData(): iterable
+    {
+        yield 'no transparency given' => [null, 100];
+        yield 'fully transparent' => [0, 0];
+        yield 'half way' => [50, 50];
+        yield 'opaque' => [100, 100];
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #1654
| License | MIT
| Doc | yes

@dbu you asked on #1654 whether the behaviour is the same across the Imagine drivers, since that decides between fixing the documentation and fixing the code. It is the same, so this fixes the documentation.

The reporter is right: `0` is the transparent end and `100` the opaque one, the opposite of what the page says. Omitting the option leaves the background opaque.

Measured on GD, running the filter and reading the alpha of a background pixel:

| `transparency` | resulting alpha |
| --- | --- |
| omitted | 100 (opaque) |
| 0 | 0 (fully transparent) |
| 50 | 50 |
| 100 | 100 (opaque) |

And the three drivers agree on the direction, since `BackgroundFilterLoader` hands the option straight to `palette()->color($color, $alpha)` and the semantics are Imagine's from there on:

* GD: `imagecolorallocatealpha(..., round(127 * (100 - $color->getAlpha()) / 100))`, and GD's own alpha runs from 0 (opaque) to 127, so an alpha of 100 comes out opaque.
* Imagick: `$pixel->setColorValue(\Imagick::COLOR_ALPHA, $color->getAlpha() / 100)`, where the ImageMagick alpha channel is 1.0 for opaque.
* Gmagick: throws `alpha transparency is not supported` for a value below 100 on a palette without alpha, so 100 is the opaque end there too.

So the value is an alpha, which reads as an opacity, despite the option being called `transparency`. I said as much on the page rather than only flipping the two words, since the name will keep surprising people.

The filter had no test at all, so the direction is pinned by one now. It uses the real GD driver, like `GrayscaleFilterLoaderTest` and the two `FloatToIntCast...` tests already do.

One thing I could not check and would rather not write into the documentation: `Gmagick\Imagine::create()` builds the canvas with `$pixel->getcolor(false)`, without the alpha component, and only then calls `setimagebackgroundcolor()` with the full pixel. I do not have the extension to tell whether a partially transparent background actually comes out of it. If it does not, that is worth a note on the page, and you or someone with gmagick would know in a second.
