### PR TITLE
Document how asset versioning works with the AssetMapper

### DIFF
--- a/Resources/doc/asset-versioning.rst
+++ b/Resources/doc/asset-versioning.rst
@@ -39,6 +39,9 @@ answers that the source image could not be found. Use the
 :doc:`asset mapper data loader <data-loader/asset_mapper>`, which maps the
 versioned public path back to its source file.
 
+Images that are not AssetMapper assets, such as uploads, are not versioned and
+keep being loaded by the ``filesystem`` loader from wherever they are stored.
+
 Cache Busting
 ~~~~~~~~~~~~~
 

--- a/Resources/doc/asset-versioning.rst
+++ b/Resources/doc/asset-versioning.rst
@@ -22,6 +22,23 @@ setting for ``framework.assets.json_manifest_path``. The manifest file is used
 to lookup the location of the actual file, and append the versioning string to
 the resulting image URL so that cache busting is used.
 
+Asset Mapper
+~~~~~~~~~~~~
+
+Symfony's `AssetMapper`_ puts the version in the file name rather than in a
+query string or in a manifest, so neither of the two integrations above applies
+to it.
+
+In production there is nothing to configure: ``asset-map:compile`` writes the
+versioned files into the public directory, where the ``filesystem`` data loader
+finds them like any other file.
+
+In development the versioned files do not exist on disk, because AssetMapper
+serves the assets from their source directory, so the ``filesystem`` loader
+answers that the source image could not be found. Use the
+:doc:`asset mapper data loader <data-loader/asset_mapper>`, which maps the
+versioned public path back to its source file.
+
 Cache Busting
 ~~~~~~~~~~~~~
 
@@ -59,3 +76,4 @@ configured Symfony to append an asset version, you now won't be able to use the
 ``asset`` Twig function with the ``imagine_filter``.
 
 .. _`asset version`: https://symfony.com/doc/current/reference/configuration/framework.html#reference-framework-assets-version
+.. _`AssetMapper`: https://symfony.com/doc/current/frontend/asset_mapper.html

--- a/Resources/doc/data-loader/asset_mapper.rst
+++ b/Resources/doc/data-loader/asset_mapper.rst
@@ -2,7 +2,7 @@
 .. _data-loaders-asset-mapper:
 
 Asset Mapper Loader (for dev)
-============================
+=============================
 
 The ``AssetMapper`` data loader allows for loading images using Symfony's AssetMapper component.
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Branch? | 2.x
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #1608
| License | MIT
| Doc | yes

@dbu you said on #1608 that you were glad if somebody sorted it out and proposed fixes or documentation updates. Checking first, the code half is already done: `AssetMapperLocator` landed in 2.17.0 with #1645. What is left is the documentation, and it is what produced the confusion in the first place.

The reporter went to *Asset Versioning* because it promises the bundle handles versioning. That page covers `framework.assets.version`, which puts the version in a query string, and `json_manifest_path`, which puts it in a manifest. AssetMapper puts it in the file name, so neither integration applies to it and the page reads as if nothing had to be done.

What actually happens, as `AssetMapperLocator`'s own docblock describes:

* in production, `asset-map:compile` writes the versioned files into the public directory, so the `filesystem` loader finds them like any other file. That is why running that command works around the problem, as @Schyzophrenic found in the thread;
* in development the versioned files do not exist on disk, since AssetMapper serves the assets from their source directory, which is where the `Source image for path could not be found` comes from, and what the `asset_mapper` data loader is for.

The page now says both, and links to the loader page.

While linking to it I noticed its title underline is one character shorter than the title, which makes Sphinx warn about it, so that is fixed here too.
